### PR TITLE
YD-196 Messages now include a link when possible

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -48,6 +48,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 201
 		response.responseData._embedded."yona:user".firstName == "Bob"
+		response.responseData._links."yona:user" == null
 		response.responseData._links.self.href.startsWith(richard.url)
 
 		def richardWithBuddy = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, richard.url, true, richard.password)
@@ -83,6 +84,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertEquals(buddyConnectRequestMessages[0].creationTime, new Date())
 		buddyConnectRequestMessages[0].status == "REQUESTED"
 		buddyConnectRequestMessages[0]._embedded."yona:user".firstName == "Richard"
+		buddyConnectRequestMessages[0]._links."yona:user" == null
 		buddyConnectRequestMessages[0]._links.self.href.startsWith(bob.messagesUrl)
 		buddyConnectRequestMessages[0]._links."yona:accept".href.startsWith(buddyConnectRequestMessages[0]._links.self.href)
 
@@ -148,6 +150,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		response.status == 200
 		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
 		buddyConnectResponseMessages[0]._links?."yona:user"?.href == bob.url
+		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
 		buddyConnectResponseMessages[0].nickname == bob.nickname
 		assertEquals(buddyConnectResponseMessages[0].creationTime, new Date())
 		buddyConnectResponseMessages[0].status == "ACCEPTED"
@@ -353,6 +356,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		buddyDisconnectMessages[0].reason == "USER_REMOVED_BUDDY"
 		buddyDisconnectMessages[0].nickname == "${richard.nickname}"
 		buddyDisconnectMessages[0]._embedded?."yona:user"?.firstName == "Richard"
+		buddyDisconnectMessages[0]._links."yona:user" == null
 		assertEquals(buddyDisconnectMessages[0].creationTime, new Date())
 		buddyDisconnectMessages[0].message == message
 		buddyDisconnectMessages[0]._links.self.href.startsWith(bob.messagesUrl)

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -82,7 +82,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		buddyConnectRequestMessages[0].nickname == richard.nickname
 		assertEquals(buddyConnectRequestMessages[0].creationTime, new Date())
 		buddyConnectRequestMessages[0].status == "REQUESTED"
-		buddyConnectRequestMessages[0].user.firstName == "Richard"
+		buddyConnectRequestMessages[0]._embedded."yona:user".firstName == "Richard"
 		buddyConnectRequestMessages[0]._links.self.href.startsWith(bob.messagesUrl)
 		buddyConnectRequestMessages[0]._links."yona:accept".href.startsWith(buddyConnectRequestMessages[0]._links.self.href)
 
@@ -147,7 +147,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 200
 		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
-		buddyConnectResponseMessages[0].user.firstName == "Bob"
+		buddyConnectResponseMessages[0]._links?."yona:user"?.href == bob.url
 		buddyConnectResponseMessages[0].nickname == bob.nickname
 		assertEquals(buddyConnectResponseMessages[0].creationTime, new Date())
 		buddyConnectResponseMessages[0].status == "ACCEPTED"
@@ -352,6 +352,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		buddyDisconnectMessages.size() == 1
 		buddyDisconnectMessages[0].reason == "USER_REMOVED_BUDDY"
 		buddyDisconnectMessages[0].nickname == "${richard.nickname}"
+		buddyDisconnectMessages[0]._embedded?."yona:user"?.firstName == "Richard"
 		assertEquals(buddyDisconnectMessages[0].creationTime, new Date())
 		buddyDisconnectMessages[0].message == message
 		buddyDisconnectMessages[0]._links.self.href.startsWith(bob.messagesUrl)

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -39,6 +39,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 201
 		response.responseData._embedded."yona:user".firstName == "Bob"
+		response.responseData._links."yona:user" == null
 		response.responseData._links.self.href.startsWith(richard.url)
 		response.responseData.userCreatedInviteURL
 

--- a/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
@@ -73,12 +73,10 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0].status == "DISCLOSURE_REQUESTED"
 		disclosureRequestMessages[0].message == requestMessageText
 		assertEquals(disclosureRequestMessages[0].creationTime, new Date())
-		disclosureRequestMessages[0].targetGoalConflictMessage.activityCategoryName == "gambling"
-		assertEquals(disclosureRequestMessages[0].targetGoalConflictMessage.creationTime, new Date())
-		disclosureRequestMessages[0].user.firstName == "Bob"
-		disclosureRequestMessages[0]._links.related.href == getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links.self.href
-		disclosureRequestMessages[0]._links."yona:accept".href
-		disclosureRequestMessages[0]._links."yona:reject".href
+		disclosureRequestMessages[0]._links?."yona:user"?.href== bob.url
+		disclosureRequestMessages[0]._links?.related?.href == getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links.self.href
+		disclosureRequestMessages[0]._links."yona:accept"?.href
+		disclosureRequestMessages[0]._links."yona:reject"?.href
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -130,7 +128,8 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage.message == responseMessageText
 		disclosureResponseMessage.nickname == richard.nickname
 		assertEquals(disclosureResponseMessage.creationTime, new Date())
-		disclosureResponseMessage.user.firstName == "Richard"
+		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
+		disclosureResponseMessage._links?."yona:user"?.href == richard.url
 
 		//check delete
 		disclosureResponseMessage._links.edit
@@ -188,7 +187,8 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage.status == "DISCLOSURE_REJECTED"
 		disclosureResponseMessage.message == responseMessageText
 		disclosureResponseMessage.nickname == richard.nickname
-		disclosureResponseMessage.user.firstName == "Richard"
+		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
+		disclosureResponseMessage._links?."yona:user"?.href == richard.url
 
 		//check delete
 		disclosureResponseMessage._links.edit

--- a/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
@@ -130,6 +130,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		assertEquals(disclosureResponseMessage.creationTime, new Date())
 		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
 		disclosureResponseMessage._links?."yona:user"?.href == richard.url
+		disclosureResponseMessage._embedded?."yona:user" == null
 
 		//check delete
 		disclosureResponseMessage._links.edit
@@ -189,6 +190,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage.nickname == richard.nickname
 		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
 		disclosureResponseMessage._links?."yona:user"?.href == richard.url
+		disclosureResponseMessage._embedded?."yona:user" == null
 
 		//check delete
 		disclosureResponseMessage._links.edit

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -75,7 +75,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages.size() == 1
 		goalChangeMessages[0].change == 'GOAL_ADDED'
 		goalChangeMessages[0].changedGoal.activityCategoryName == 'social'
-		goalChangeMessages[0].user.firstName == 'Richard'
+		goalChangeMessages[0]._links?."yona:user"?.href == richard.url
 		goalChangeMessages[0].nickname == 'RQ'
 		assertEquals(goalChangeMessages[0].creationTime, new Date())
 		goalChangeMessages[0].message == "Going to monitor my social time!"
@@ -104,7 +104,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages.size() == 2
 		goalChangeMessages[0].change == 'GOAL_DELETED'
 		goalChangeMessages[0].changedGoal.activityCategoryName == 'social'
-		goalChangeMessages[0].user.firstName == 'Richard'
+		goalChangeMessages[0]._links?."yona:user"?.href == richard.url
 		goalChangeMessages[0].nickname == 'RQ'
 		assertEquals(goalChangeMessages[0].creationTime, new Date())
 		goalChangeMessages[0].message == "Don't want to monitor my social time anymore"

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -76,6 +76,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[0].change == 'GOAL_ADDED'
 		goalChangeMessages[0].changedGoal.activityCategoryName == 'social'
 		goalChangeMessages[0]._links?."yona:user"?.href == richard.url
+		goalChangeMessages[0]._embedded?."yona:user" == null
 		goalChangeMessages[0].nickname == 'RQ'
 		assertEquals(goalChangeMessages[0].creationTime, new Date())
 		goalChangeMessages[0].message == "Going to monitor my social time!"
@@ -105,6 +106,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[0].change == 'GOAL_DELETED'
 		goalChangeMessages[0].changedGoal.activityCategoryName == 'social'
 		goalChangeMessages[0]._links?."yona:user"?.href == richard.url
+		goalChangeMessages[0]._embedded?."yona:user" == null
 		goalChangeMessages[0].nickname == 'RQ'
 		assertEquals(goalChangeMessages[0].creationTime, new Date())
 		goalChangeMessages[0].message == "Don't want to monitor my social time anymore"

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -316,6 +316,11 @@ public class UserController
 		return linkBuilder.withSelfRel();
 	}
 
+	public static Link getUserLink(String rel, UUID userID)
+	{
+		return linkTo(methodOn(UserController.class).getPublicUser(Optional.empty(), userID)).withRel(rel);
+	}
+
 	static class UserResource extends Resource<UserDTO>
 	{
 		private final CurieProvider curieProvider;
@@ -354,7 +359,7 @@ public class UserController
 		}
 	}
 
-	static class UserResourceAssembler extends ResourceAssemblerSupport<UserDTO, UserResource>
+	public static class UserResourceAssembler extends ResourceAssemblerSupport<UserDTO, UserResource>
 	{
 		private final boolean includePrivateData;
 		private CurieProvider curieProvider;

--- a/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import nu.yona.server.goals.entities.GoalChangeMessage;
 import nu.yona.server.goals.entities.GoalChangeMessage.Change;
 import nu.yona.server.messaging.entities.Message;
-import nu.yona.server.messaging.service.BuddyMessageDTO;
+import nu.yona.server.messaging.service.BuddyMessageLinkedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.DTOManager;
@@ -24,7 +24,7 @@ import nu.yona.server.messaging.service.MessageServiceException;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("goalChangeMessage")
-public class GoalChangeMessageDTO extends BuddyMessageDTO
+public class GoalChangeMessageDTO extends BuddyMessageLinkedUserDTO
 {
 	private GoalDTO changedGoal;
 	private Change change;

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageDTO.java
@@ -7,6 +7,7 @@ package nu.yona.server.messaging.service;
 import java.util.Date;
 import java.util.UUID;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.subscriptions.service.UserDTO;
@@ -26,15 +27,15 @@ public abstract class BuddyMessageDTO extends MessageDTO
 		this.message = message;
 	}
 
-	protected BuddyMessageDTO(UUID id, Date creationTime, UUID relatedAnonymousMessageID, UserDTO user, String nickname,
-			String message)
+	protected BuddyMessageDTO(UUID id, Date creationTime, UUID relatedMessageID, UserDTO user, String nickname, String message)
 	{
-		super(id, creationTime, relatedAnonymousMessageID);
+		super(id, creationTime, relatedMessageID);
 		this.user = user;
 		this.nickname = nickname;
 		this.message = message;
 	}
 
+	@JsonIgnore
 	public UserDTO getUser()
 	{
 		return user;

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDTO.java
@@ -1,0 +1,40 @@
+package nu.yona.server.messaging.service;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import nu.yona.server.subscriptions.service.UserDTO;
+
+public abstract class BuddyMessageEmbeddedUserDTO extends BuddyMessageDTO
+{
+	private Map<String, Object> embeddedResources = Collections.emptyMap();
+
+	protected BuddyMessageEmbeddedUserDTO(UUID id, Date creationTime, UserDTO user, String nickname, String message)
+	{
+		super(id, creationTime, user, nickname, message);
+	}
+
+	protected BuddyMessageEmbeddedUserDTO(UUID id, Date creationTime, UUID targetGoalConflictMessageOriginID, UserDTO user,
+			String nickname, String message)
+	{
+		super(id, creationTime, user, nickname, message);
+	}
+
+	@JsonProperty("_embedded")
+	@JsonInclude(Include.NON_EMPTY)
+	public Map<String, Object> getEmbeddedResources()
+	{
+		return embeddedResources;
+	}
+
+	public void setEmbeddedUser(String rel, Object userResource)
+	{
+		embeddedResources = Collections.singletonMap(rel, userResource);
+	}
+}

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageLinkedUserDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageLinkedUserDTO.java
@@ -1,0 +1,21 @@
+package nu.yona.server.messaging.service;
+
+import java.util.Date;
+import java.util.UUID;
+
+import nu.yona.server.subscriptions.service.UserDTO;
+
+public abstract class BuddyMessageLinkedUserDTO extends BuddyMessageDTO
+{
+
+	protected BuddyMessageLinkedUserDTO(UUID id, Date creationTime, UserDTO user, String nickname, String message)
+	{
+		super(id, creationTime, user, nickname, message);
+	}
+
+	protected BuddyMessageLinkedUserDTO(UUID id, Date creationTime, UUID relatedMessageID, UserDTO user, String nickname,
+			String message)
+	{
+		super(id, creationTime, relatedMessageID, user, nickname, message);
+	}
+}

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.analysis.entities.GoalConflictMessage;
 import nu.yona.server.analysis.entities.GoalConflictMessage.Status;
-import nu.yona.server.analysis.service.GoalConflictMessageDTO;
 import nu.yona.server.messaging.entities.DisclosureRequestMessage;
 import nu.yona.server.messaging.entities.DisclosureResponseMessage;
 import nu.yona.server.messaging.entities.Message;
@@ -28,21 +27,18 @@ import nu.yona.server.subscriptions.service.UserAnonymizedService;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("disclosureRequestMessage")
-public class DisclosureRequestMessageDTO extends BuddyMessageDTO
+public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 {
 	private static final String ACCEPT = "accept";
 	private static final String REJECT = "reject";
 
 	private Status status;
 
-	private GoalConflictMessageDTO targetGoalConflictMessage;
-
 	private DisclosureRequestMessageDTO(UUID id, Date creationTime, UserDTO user, String nickname, String message, Status status,
-			UUID targetGoalConflictMessageOriginID, GoalConflictMessageDTO targetGoalConflictMessage)
+			UUID targetGoalConflictMessageID)
 	{
-		super(id, creationTime, targetGoalConflictMessageOriginID, user, nickname, message);
+		super(id, creationTime, targetGoalConflictMessageID, user, nickname, message);
 		this.status = status;
-		this.targetGoalConflictMessage = targetGoalConflictMessage;
 	}
 
 	@Override
@@ -63,11 +59,6 @@ public class DisclosureRequestMessageDTO extends BuddyMessageDTO
 		return possibleActions;
 	}
 
-	public GoalConflictMessageDTO getTargetGoalConflictMessage()
-	{
-		return targetGoalConflictMessage;
-	}
-
 	public Status getStatus()
 	{
 		return status;
@@ -84,8 +75,7 @@ public class DisclosureRequestMessageDTO extends BuddyMessageDTO
 		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
 		return new DisclosureRequestMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
 				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getNickname(), messageEntity.getMessage(),
-				messageEntity.getStatus(), targetGoalConflictMessage.getOriginGoalConflictMessageID(),
-				GoalConflictMessageDTO.createInstance(targetGoalConflictMessage, null));
+				messageEntity.getStatus(), targetGoalConflictMessage.getOriginGoalConflictMessageID());
 	}
 
 	@Component
@@ -156,7 +146,8 @@ public class DisclosureRequestMessageDTO extends BuddyMessageDTO
 					.createInstanceActionDone(theDTOFactory.createInstance(actingUser, disclosureRequestMessageEntity));
 		}
 
-		private DisclosureRequestMessage updateMessageStatus(DisclosureRequestMessage disclosureRequestMessageEntity, Status status)
+		private DisclosureRequestMessage updateMessageStatus(DisclosureRequestMessage disclosureRequestMessageEntity,
+				Status status)
 		{
 			disclosureRequestMessageEntity.setStatus(status);
 			return Message.getRepository().save(disclosureRequestMessageEntity);

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import nu.yona.server.analysis.entities.GoalConflictMessage;
 import nu.yona.server.analysis.entities.GoalConflictMessage.Status;
 import nu.yona.server.messaging.entities.DisclosureResponseMessage;
 import nu.yona.server.messaging.entities.Message;
@@ -24,13 +25,14 @@ import nu.yona.server.messaging.service.MessageService.TheDTOManager;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("disclosureResponseMessage")
-public class DisclosureResponseMessageDTO extends BuddyMessageDTO
+public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 {
 	private Status status;
 
-	private DisclosureResponseMessageDTO(UUID id, Date creationTime, UserDTO user, Status status, String nickname, String message)
+	private DisclosureResponseMessageDTO(UUID id, Date creationTime, UserDTO user, Status status, String nickname, String message,
+			UUID targetGoalConflictMessageID)
 	{
-		super(id, creationTime, user, nickname, message);
+		super(id, creationTime, targetGoalConflictMessageID, user, nickname, message);
 		this.status = status;
 	}
 
@@ -60,9 +62,10 @@ public class DisclosureResponseMessageDTO extends BuddyMessageDTO
 
 	public static DisclosureResponseMessageDTO createInstance(UserDTO actingUser, DisclosureResponseMessage messageEntity)
 	{
+		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
 		return new DisclosureResponseMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
 				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getStatus(), messageEntity.getNickname(),
-				messageEntity.getMessage());
+				messageEntity.getMessage(), targetGoalConflictMessage.getID());
 	}
 
 	@Component

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -39,11 +39,11 @@ public abstract class MessageDTO extends PolymorphicDTO
 		this(id, creationTime, null);
 	}
 
-	protected MessageDTO(UUID id, Date creationTime, UUID relatedAnonymousMessageID)
+	protected MessageDTO(UUID id, Date creationTime, UUID relatedMessageID)
 	{
 		this.id = id;
 		this.creationTime = creationTime;
-		this.relatedAnonymousMessageID = relatedAnonymousMessageID;
+		this.relatedAnonymousMessageID = relatedMessageID;
 	}
 
 	@JsonIgnore

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.messaging.entities.Message;
-import nu.yona.server.messaging.service.BuddyMessageDTO;
+import nu.yona.server.messaging.service.BuddyMessageEmbeddedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
@@ -33,7 +33,7 @@ import nu.yona.server.subscriptions.entities.BuddyConnectRequestMessage;
 import nu.yona.server.subscriptions.entities.BuddyConnectResponseMessage;
 
 @JsonRootName("buddyConnectRequestMessage")
-public class BuddyConnectRequestMessageDTO extends BuddyMessageDTO
+public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 {
 	private static final String ACCEPT = "accept";
 	private static final String REJECT = "reject";

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.messaging.entities.Message;
-import nu.yona.server.messaging.service.BuddyMessageDTO;
+import nu.yona.server.messaging.service.BuddyMessageLinkedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.DTOManager;
@@ -30,7 +30,7 @@ import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.BuddyConnectResponseMessage;
 
 @JsonRootName("buddyConnectResponseMessage")
-public class BuddyConnectResponseMessageDTO extends BuddyMessageDTO
+public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 {
 	private static final String PROCESS = "process";
 	private Status status;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDTO.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.messaging.entities.Message;
-import nu.yona.server.messaging.service.BuddyMessageDTO;
+import nu.yona.server.messaging.service.BuddyMessageEmbeddedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.DTOManager;
@@ -24,7 +24,7 @@ import nu.yona.server.subscriptions.entities.BuddyDisconnectMessage;
 import nu.yona.server.subscriptions.service.BuddyService.DropBuddyReason;
 
 @JsonRootName("buddyDisconnectMessage")
-public class BuddyDisconnectMessageDTO extends BuddyMessageDTO
+public class BuddyDisconnectMessageDTO extends BuddyMessageEmbeddedUserDTO
 {
 	private static final String PROCESS = "process";
 	private DropBuddyReason reason;


### PR DESCRIPTION
Till now, messages included an embedded User. This implies unnecessary overhead, has the user is available already as part of the buddy data.

The following messages now use a link to the user:

- BuddyConnectRequestMessage
- DisclosureRequestMessage
- DisclosureResponseMessage
- GoalChangeMessage

The following messages embed the user, as the user data might not be available in the buddy data (but now inside _embedded):

- BuddyConnectRequestMessage
- BuddyDisconnectMessage

Additional changes:

- The DisclosureRequestMessage does not embed the target anymore. There is a link, that's sufficient.
- The DisclosureResponseMessage now includes a "related" link for the target message