### PR TITLE
YD-159 Add creationTime to goal DTO

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -83,7 +83,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	def assertEquals(dateTimeString, Date comparisonDateTime, int epsilonSeconds = 10)
 	{
 		// Example date string: 2016-02-23T21:28:58.556+0000
-		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+0000/
+		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+\d{4}/
 		Date dateTime = YonaServer.parseIsoDateString(dateTimeString)
 		int epsilonMilliseconds = epsilonSeconds * 1000
 

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -51,10 +51,12 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		gamblingGoals.size() == 1
 		gamblingGoals[0]."@type" == "BudgetGoal"
 		!gamblingGoals[0]._links.edit //mandatory goal
+		gamblingGoals[0].creationTime =~ /\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{3}\+\d{2}\:\d{2}/
 		def newsGoals = filterGoals(response, NEWS_ACT_CAT_URL)
 		newsGoals.size() == 1
 		newsGoals[0]."@type" == "BudgetGoal"
 		newsGoals[0]._links.edit.href
+		newsGoals[0].creationTime =~ /\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{3}\+\d{2}\:\d{2}/
 	}
 
 	def 'Add budget goal'()

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -10,6 +10,8 @@ import groovy.json.*
 import nu.yona.server.test.BudgetGoal
 import nu.yona.server.test.Goal
 import nu.yona.server.test.TimeZoneGoal
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 
 class EditGoalsTest extends AbstractAppServiceIntegrationTest
 {
@@ -42,6 +44,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
+		def creationTime = new Date()
 		when:
 		def response = appService.getGoals(richard)
 		then:
@@ -51,12 +54,12 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		gamblingGoals.size() == 1
 		gamblingGoals[0]."@type" == "BudgetGoal"
 		!gamblingGoals[0]._links.edit //mandatory goal
-		gamblingGoals[0].creationTime =~ /\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{3}\+\d{2}\:\d{2}/
+		assertEquals(gamblingGoals[0].creationTime, creationTime)
 		def newsGoals = filterGoals(response, NEWS_ACT_CAT_URL)
 		newsGoals.size() == 1
 		newsGoals[0]."@type" == "BudgetGoal"
 		newsGoals[0]._links.edit.href
-		newsGoals[0].creationTime =~ /\d{4}\-\d{2}\-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{3}\+\d{2}\:\d{2}/
+		assertEquals(newsGoals[0].creationTime, creationTime)
 	}
 
 	def 'Add budget goal'()

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1201,9 +1201,15 @@ definitions:
           - $ref: '#/definitions/SelfLink'
           - $ref: '#/definitions/EditLink'
           - $ref: '#/definitions/ActivityCategoryLink'
+      creationTime:
+        type: string
+        format: dateTime
+        description: The creation time of this goal
+        example: 2016-04-26T20:08:55.365+02:00
     required:
       - "@type"
       - _links
+      - creationTime
   VPNProfile:
     type: object
     description: VPN profile. Private data.

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1205,7 +1205,7 @@ definitions:
         type: string
         format: dateTime
         description: The creation time of this goal
-        example: 2016-04-26T20:08:55.365+02:00
+        example: 2016-04-26T20:08:55.365+0200
     required:
       - "@type"
       - _links

--- a/core/src/main/java/nu/yona/server/goals/service/BudgetGoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/BudgetGoalDTO.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.goals.service;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,9 +28,9 @@ public class BudgetGoalDTO extends GoalDTO
 		this.maxDurationMinutes = maxDurationMinutes;
 	}
 
-	public BudgetGoalDTO(UUID id, UUID activityCategoryID, int maxDurationMinutes, boolean mandatory)
+	public BudgetGoalDTO(UUID id, UUID activityCategoryID, int maxDurationMinutes, ZonedDateTime creationTime, boolean mandatory)
 	{
-		super(id, activityCategoryID, mandatory);
+		super(id, activityCategoryID, creationTime, mandatory);
 
 		this.maxDurationMinutes = maxDurationMinutes;
 	}
@@ -54,7 +55,7 @@ public class BudgetGoalDTO extends GoalDTO
 	public static BudgetGoalDTO createInstance(BudgetGoal entity)
 	{
 		return new BudgetGoalDTO(entity.getID(), entity.getActivityCategory().getID(), entity.getMaxDurationMinutes(),
-				entity.isMandatory());
+				entity.getCreationTime(), entity.isMandatory());
 	}
 
 	public BudgetGoal createGoalEntity()

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.goals.service;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import org.apache.commons.lang.NotImplementedException;
@@ -25,24 +26,31 @@ public abstract class GoalDTO extends PolymorphicDTO
 {
 	private final UUID id;
 	private UUID activityCategoryID;
+	private final ZonedDateTime creationTime;
 	private final boolean mandatory;
 
-	protected GoalDTO(UUID id, UUID activityCategoryID, boolean mandatory)
+	protected GoalDTO(UUID id, UUID activityCategoryID, ZonedDateTime creationTime, boolean mandatory)
 	{
 		this.id = id;
 		this.setActivityCategoryID(activityCategoryID);
+		this.creationTime = creationTime;
 		this.mandatory = mandatory;
 	}
 
 	public GoalDTO(String activityCategoryUrl)
 	{
-		this(null, null, false /* ignored */);
+		this(null, null, null /* ignored */, false /* ignored */);
 	}
 
 	@JsonIgnore
 	public UUID getID()
 	{
 		return id;
+	}
+
+	public ZonedDateTime getCreationTime()
+	{
+		return creationTime;
 	}
 
 	@JsonIgnore

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang.NotImplementedException;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -48,6 +49,7 @@ public abstract class GoalDTO extends PolymorphicDTO
 		return id;
 	}
 
+	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ")
 	public ZonedDateTime getCreationTime()
 	{
 		return creationTime;

--- a/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDTO.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.goals.service;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -27,9 +28,9 @@ public class TimeZoneGoalDTO extends GoalDTO
 		this.zones = zones;
 	}
 
-	private TimeZoneGoalDTO(UUID id, UUID activityCategoryID, String[] zones)
+	private TimeZoneGoalDTO(UUID id, UUID activityCategoryID, String[] zones, ZonedDateTime creationTime)
 	{
-		super(id, activityCategoryID, false);
+		super(id, activityCategoryID, creationTime, false);
 
 		this.zones = zones;
 	}
@@ -53,7 +54,8 @@ public class TimeZoneGoalDTO extends GoalDTO
 
 	static TimeZoneGoalDTO createInstance(TimeZoneGoal entity)
 	{
-		return new TimeZoneGoalDTO(entity.getID(), entity.getActivityCategory().getID(), entity.getZones());
+		return new TimeZoneGoalDTO(entity.getID(), entity.getActivityCategory().getID(), entity.getZones(),
+				entity.getCreationTime());
 	}
 
 	public TimeZoneGoal createGoalEntity()


### PR DESCRIPTION
The property was already added earlier for inactivity support.
One question: Should we also refactor Message.creationTime to ZonedDateTime? That would be more consistent. Or the other way around, expose a Date here?