### PR TITLE
YD-233 Standard temp password in test config

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -41,7 +41,6 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:user".firstName == "Bob"
 		response.responseData._links."yona:user" == null
 		response.responseData._links.self.href.startsWith(richard.url)
-		response.responseData.userCreatedInviteURL
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -53,7 +52,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 
 		when:
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
@@ -74,7 +73,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 
 		when:
@@ -118,7 +117,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -146,7 +145,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -175,7 +174,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -207,7 +206,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -243,7 +242,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = "+$timestamp"
-		def inviteURL = sendBuddyRequestForBob(richard, mobileNumberBob).responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, inviteURL, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -304,7 +303,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def inviteURL = sendBuddyRequestForBob(richard, "+$timestamp").responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, "+$timestamp"))
 
 		when:
 		def response = appService.getResource(YonaServer.stripQueryString(inviteURL), [:], ["tempPassword": "hack", "includePrivateData": "true"])
@@ -322,7 +321,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def inviteURL = sendBuddyRequestForBob(richard, "+$timestamp").responseData.userCreatedInviteURL
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, "+$timestamp"))
 
 		when:
 		def response = appService.updateResource(YonaServer.stripQueryString(inviteURL), """{
@@ -399,5 +398,10 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 			"sendingStatus":"REQUESTED",
 			"receivingStatus":"REQUESTED"
 		}""", user.password)
+	}
+
+	String buildInviteUrl(def response)
+	{
+		response.responseData._embedded."yona:user"._links.self.href + "?tempPassword=abcd"
 	}
 }

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -57,6 +57,11 @@ paths:
           description: The device password
           required: false
           type: string
+        - name: tempPassword
+          in: query
+          description: The temporary password that was included in the invitation e-mail when a user invited a non-Yona user as buddy
+          required: false
+          type: string
         - name: includePrivateData
           in: query
           description: Pass true to fetch the private data of the user
@@ -81,6 +86,11 @@ paths:
           in: header
           description: The device password
           required: true
+          type: string
+        - name: tempPassword
+          in: query
+          description: The temporary password that was included in the invitation e-mail when a user invited a non-Yona user as buddy
+          required: false
           type: string
         - in: body
           name: body

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDTO.java
@@ -31,11 +31,6 @@ public class BuddyDTO
 	private Status receivingStatus;
 	private Set<GoalDTO> goals;
 
-	/*
-	 * Only intended for test purposes.
-	 */
-	private String userCreatedInviteURL;
-
 	public BuddyDTO(UUID id, UserDTO user, String message, String nickname, UUID userAnonymizedID, Status sendingStatus,
 			Status receivingStatus)
 	{
@@ -113,23 +108,6 @@ public class BuddyDTO
 	public UUID getUserAnonymizedID()
 	{
 		return userAnonymizedID;
-	}
-
-	/*
-	 * Only intended for test purposes.
-	 */
-	public void setUserCreatedInviteURL(String userCreatedInviteURL)
-	{
-		this.userCreatedInviteURL = userCreatedInviteURL;
-	}
-
-	/*
-	 * Only intended for test purposes.
-	 */
-	@JsonInclude(Include.NON_EMPTY)
-	public String getUserCreatedInviteURL()
-	{
-		return userCreatedInviteURL;
 	}
 
 	public void setGoals(Set<GoalDTO> goals)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
 
@@ -336,18 +336,19 @@ public class BuddyService
 	{
 		UserDTO buddyUser = buddy.getUser();
 
-		String tempPassword = userService.generatePassword();
+		String tempPassword = getTempPassword();
 		User buddyUserEntity = userService.addUserCreatedOnBuddyRequest(buddyUser, tempPassword);
 		BuddyDTO savedBuddy = handleBuddyRequestForExistingUser(requestingUser, buddy, buddyUserEntity);
 
 		String inviteURL = inviteURLGetter.apply(buddyUserEntity.getID(), tempPassword);
-		if (!properties.getEmail().isEnabled())
-		{
-			savedBuddy.setUserCreatedInviteURL(inviteURL);
-		}
 		sendInvitationMessage(requestingUser, buddyUserEntity, buddy, inviteURL);
 
 		return savedBuddy;
+	}
+
+	private String getTempPassword()
+	{
+		return (properties.getEmail().isEnabled()) ? userService.generatePassword() : "abcd";
 	}
 
 	private BuddyDTO handleBuddyRequestForExistingUser(UserDTO requestingUser, BuddyDTO buddy, User buddyUserEntity)


### PR DESCRIPTION
* Added the tempPassword query parameter to the Swagger spec for GET and PUT /users/{id}
* Removed property userCreatedInviteURL from BuddyDTO
* Now generates password abcd in case e-mail is disabled
* The test now composes the invitation URL from the self-link of the buddy user and the abcd password.