### PR TITLE
YD-148 Improve error reporting

### DIFF
--- a/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;
 
@@ -18,6 +18,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +32,7 @@ import nu.yona.server.goals.service.ActivityCategoryService;
 
 @Controller
 @ExposesResourceFor(ActivityCategoryResource.class)
-@RequestMapping(value = "/activityCategories")
+@RequestMapping(value = "/activityCategories", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class ActivityCategoryController
 {
 	@Autowired

--- a/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;
 
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ import nu.yona.server.analysis.service.AnalysisEngineService;
 import nu.yona.server.analysis.service.NetworkActivityDTO;
 
 @Controller
-@RequestMapping(value = "/analysisEngine")
+@RequestMapping(value = "/analysisEngine", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class AnalysisEngineController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
+++ b/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
@@ -6,6 +6,7 @@ package nu.yona.server.admin.rest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
-@RequestMapping(value = "/admin")
+@RequestMapping(value = "/admin", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class AdminController
 {
 

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityController.java
@@ -23,6 +23,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,7 +47,7 @@ import nu.yona.server.subscriptions.service.UserService;
  * Controller to retrieve activity data for a user.
  */
 @Controller
-@RequestMapping(value = "/users/{userID}/activity")
+@RequestMapping(value = "/users/{userID}/activity", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class ActivityController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/AppActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/AppActivityController.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -35,7 +36,7 @@ import nu.yona.server.subscriptions.service.UserService;
  * the application service once there is a network connection.
  */
 @Controller
-@RequestMapping(value = "/users/{userID}/appActivity")
+@RequestMapping(value = "/users/{userID}/appActivity", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class AppActivityController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -18,6 +18,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +32,7 @@ import nu.yona.server.goals.service.ActivityCategoryService;
 
 @Controller
 @ExposesResourceFor(ActivityCategoryResource.class)
-@RequestMapping(value = "/activityCategories")
+@RequestMapping(value = "/activityCategories", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class ActivityCategoryController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -21,6 +21,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,7 +42,7 @@ import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
 @ExposesResourceFor(GoalDTO.class)
-@RequestMapping(value = "/users/{userID}/goals")
+@RequestMapping(value = "/users/{userID}/goals", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class GoalController
 {
 	private static final String ACTIVITY_CATEGORY_REL = "activityCategory";

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -27,6 +27,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,7 +56,7 @@ import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
 @ExposesResourceFor(MessageDTO.class)
-@RequestMapping(value = "/users/{userID}/messages")
+@RequestMapping(value = "/users/{userID}/messages", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class MessageController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -24,6 +24,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,7 +52,7 @@ import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
 @ExposesResourceFor(BuddyResource.class)
-@RequestMapping(value = "/users/{requestingUserID}/buddies")
+@RequestMapping(value = "/users/{requestingUserID}/buddies", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class BuddyController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
@@ -15,6 +15,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,7 +41,7 @@ import nu.yona.server.subscriptions.service.UserServiceException;
 
 @Controller
 @ExposesResourceFor(NewDeviceRequestResource.class)
-@RequestMapping(value = "/newDeviceRequests")
+@RequestMapping(value = "/newDeviceRequests", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class NewDeviceRequestController
 {
 	private static final Logger logger = LoggerFactory.getLogger(NewDeviceRequestController.class);

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,7 +35,7 @@ import nu.yona.server.subscriptions.service.PinResetRequestService;
 import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
-@RequestMapping(value = "/users/{id}/pinResetRequest")
+@RequestMapping(value = "/users/{id}/pinResetRequest", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class PinResetRequestController
 {
 	@Autowired

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -28,6 +28,7 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -66,7 +67,7 @@ import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
 @ExposesResourceFor(UserResource.class)
-@RequestMapping(value = "/users")
+@RequestMapping(value = "/users", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class UserController
 {
 	private static final Logger logger = LoggerFactory.getLogger(UserController.class);

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -1,0 +1,63 @@
+package nu.yona.server.rest;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ErrorLoggingFilter implements Filter
+{
+	private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingFilter.class);
+
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+			throws IOException, ServletException
+	{
+		HttpServletRequest request = (HttpServletRequest) servletRequest;
+		HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+		chain.doFilter(request, response);
+
+		if (HttpStatus.Series.valueOf(response.getStatus()) == Series.SUCCESSFUL)
+		{
+			return;
+		}
+
+		String queryString = request.getQueryString();
+		if (queryString == null)
+		{
+			logger.warn("Status {} returned from {} on URL {}", response.getStatus(), request.getMethod(),
+					request.getRequestURI());
+		}
+		else
+		{
+			logger.warn("Status {} returned from {} on URL {} with query string {}", response.getStatus(), request.getMethod(),
+					request.getRequestURI(), queryString);
+		}
+	}
+
+	@Override
+	public void destroy()
+	{
+		// Nothing to do here
+	}
+
+	@Override
+	public void init(FilterConfig config) throws ServletException
+	{
+		// Nothing to do here
+	}
+}

--- a/core/src/main/resources/templates/error.vm
+++ b/core/src/main/resources/templates/error.vm
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Error</h1>
+
+<p>Request handling failed: ${status} ${error}</p>
+<p><b>Note:</b> the Yona services do not expose a web UI.</p>
+</body>
+</html>

--- a/core/src/main/resources/templates/error.vm
+++ b/core/src/main/resources/templates/error.vm
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+<head><title>Request handling failed</title></head>
 <body>
 
 <h1>Error</h1>


### PR DESCRIPTION
Several supportability improvements:
* Custom (basic) error page
* All HTTP errors are now logged as warnings
* It's now possible to do a GET on for instance /activitycategories/, to see whether the service is up.