### PR TITLE
YD-243 YD-197 Send messages on user overwrite

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -377,10 +377,117 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richard)
 	}
 
+	def 'Overwrite user created on buddy request'()
+	{
+		given:
+		def richard = addRichard()
+		def mobileNumberBob = "+$timestamp"
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+
+		when:
+		def response = appService.requestOverwriteUser(mobileNumberBob)
+
+		then:
+		response.status == 200
+
+		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "B o b", "Bob Changed",
+				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
+		bob
+		bob.firstName == "Bob Changed"
+		bob.lastName == "Dunn Changed"
+		bob.nickname == "BD Changed"
+		bob.mobileNumber == mobileNumberBob
+		bob.goals.size() == 1 //mandatory goal
+		bob.goals[0].activityCategoryUrl == GAMBLING_ACT_CAT_URL
+
+		def buddiesRichard = appService.getBuddies(richard)
+		buddiesRichard.size() == 0
+
+		def buddiesBob = appService.getBuddies(bob)
+		buddiesBob.size() == 0
+
+		def getMessagesResponse = appService.getMessages(richard)
+		getMessagesResponse.status == 200
+		getMessagesResponse.responseData._embedded
+		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
+
+		def buddyConnectResponseMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
+		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
+		buddyConnectResponseMessage.message == "User account was deleted"
+		buddyConnectResponseMessage.nickname == "Bob Dunn"
+		buddyConnectResponseMessage._links.self.href.startsWith(richard.messagesUrl)
+		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
+
+		def getResponse = appService.getMessages(richard)
+		def disconnectMessage = getResponse.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]
+		def processURL = disconnectMessage?._links?."yona:process"?.href
+		processURL
+		def processDisconnectResponse = appService.postMessageActionWithPassword(processURL, [:], richard.password)
+		processDisconnectResponse.status == 200
+
+		User richardAfterBobOverwrite = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, richard.url, true, richard.password)
+		richardAfterBobOverwrite.buddies.size() == 0
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
+	}
+
+	def 'Overwrite user created on buddy request and connect again'()
+	{
+		given:
+		def richard = addRichard()
+		def mobileNumberBob = "+$timestamp"
+		def inviteURL = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		appService.requestOverwriteUser(mobileNumberBob)
+		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "B o b", "Bob Changed",
+				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
+
+		when:
+		appService.makeBuddies(richard, bob)
+		analysisService.postToAnalysisEngine(richard, ["news/media"], "http://www.refdag.nl")
+
+		then:
+
+		def buddiesRichard = appService.getBuddies(richard)
+		buddiesRichard.size() == 1
+		buddiesRichard[0].user.firstName == "Bob Changed"
+
+		def buddiesBob = appService.getBuddies(bob)
+		buddiesBob.size() == 1
+		buddiesBob[0].user.firstName == "Richard"
+
+		def getMessagesRichardResponse = appService.getMessages(richard)
+		getMessagesRichardResponse.status == 200
+		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
+		richardGoalConflictMessages.size() == 1
+		richardGoalConflictMessages[0].nickname == "<self>"
+		richardGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
+		richardGoalConflictMessages[0].url == "http://www.refdag.nl"
+
+		def getMessagesBobResponse = appService.getMessages(bob)
+		getMessagesBobResponse.status == 200
+		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
+		bobGoalConflictMessages.size() == 1
+		bobGoalConflictMessages[0].nickname == richard.nickname
+		bobGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
+		bobGoalConflictMessages[0].url == null
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
+	}
+
 	def assertUserCreationFailedBecauseOfDuplicate(response)
 	{
 		response.status == 400
 		response.responseData.code == "error.user.exists.created.on.buddy.request"
+	}
+
+	def assertUserOverwriteResponseDetails(def response)
+	{
+		appService.assertResponseStatusCreated(response)
+		appService.assertUserWithPrivateData(response.responseData)
 	}
 
 	def sendBuddyRequestForBob(User user, String mobileNumber)

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -418,12 +418,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		buddyConnectResponseMessage._links.self.href.startsWith(richard.messagesUrl)
 		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
 
-		def getResponse = appService.getMessages(richard)
-		def disconnectMessage = getResponse.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]
-		def processURL = disconnectMessage?._links?."yona:process"?.href
-		processURL
-		def processDisconnectResponse = appService.postMessageActionWithPassword(processURL, [:], richard.password)
-		processDisconnectResponse.status == 200
+		def processURL = buddyConnectResponseMessage._links."yona:process".href
+		def processBuddyConnectResponse = appService.postMessageActionWithPassword(processURL, [:], richard.password)
+		processBuddyConnectResponse.status == 200
 
 		User richardAfterBobOverwrite = appService.getUser(appService.&assertUserGetResponseDetailsPublicDataAndVpnProfile, richard.url, true, richard.password)
 		richardAfterBobOverwrite.buddies.size() == 0

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -236,7 +236,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 	}
 
 
-	def 'Goal conflict for Bob after Richard overwrote his account is not reported to Richard'()
+	def 'Overwrite Richard while being a buddy of Bob and verify Richard does not receive Bob\'s goal conflicts anymore'()
 	{
 		given:
 		def richardAndBob = addRichardAndBobAsBuddies()

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -36,7 +36,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		newRichard
 	}
 
-	def 'Remove Richard and verify that Bob receives a remove buddy message'()
+	def 'Remove Richard while being a buddy of Bob and verify that Bob receives a buddy disconnect message'()
 	{
 		given:
 		def richardAndBob = addRichardAndBobAsBuddies()
@@ -51,17 +51,22 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def buddies = appService.getBuddies(bob)
-		buddies.size() == 1
-		!buddies[0].goals
+		buddies.size() == 0
+
 		def getMessagesResponse = appService.getMessages(bob)
 		getMessagesResponse.status == 200
 		getMessagesResponse.responseData._embedded
+		getMessagesResponse.responseData._embedded."yona:messages".size() == 2
+
 		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}
-		buddyDisconnectMessages[0].reason == "USER_ACCOUNT_DELETED"
-		buddyDisconnectMessages[0].message == message
-		buddyDisconnectMessages[0].nickname == richard.nickname
-		buddyDisconnectMessages[0]._links.self.href.startsWith(bob.messagesUrl)
-		buddyDisconnectMessages[0]._links."yona:process".href.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href)
+		buddyDisconnectMessages.size() == 1
+		def disconnectMessage = buddyDisconnectMessages[0]
+		disconnectMessage.reason == "USER_ACCOUNT_DELETED"
+		disconnectMessage.message == message
+		disconnectMessage.nickname == richard.nickname
+		disconnectMessage._links.self.href.startsWith(bob.messagesUrl)
+		disconnectMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href)
+
 		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessages.size == 1
 		goalConflictMessages[0].nickname == "<self>"
@@ -69,43 +74,49 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		goalConflictMessages[0].url =~ /poker/
 		getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}.size() == 0
 
-		cleanup:
-		appService.deleteUser(bob)
-	}
-
-	def 'Remove Richard and verify that buddy data is removed after Bob processed the remove buddy message'()
-	{
-		given:
-		def richardAndBob = addRichardAndBobAsBuddies()
-		def richard = richardAndBob.richard
-		def bob = richardAndBob.bob
-		analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com")
-		analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl")
-		def message = "Goodbye friends! I deinstalled the Internet"
-		appService.deleteUser(richard, message)
-		def getResponse = appService.getMessages(bob)
-		def disconnectMessage = getResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]
-		def processURL = disconnectMessage._links."yona:process".href
-
-		when:
-		def response = appService.postMessageActionWithPassword(processURL, [:], bob.password)
-
-		then:
+		def response = appService.postMessageActionWithPassword(buddyDisconnectMessages[0]._links."yona:process".href, [:], bob.password)
 		response.status == 200
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == disconnectMessage._links.self.href
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
+		cleanup:
+		appService.deleteUser(bob)
+	}
+
+	def 'Remove Richard with pending buddy request from Bob and verify that Bob receives a reject message'()
+	{
+		given:
+		def richard = addRichard()
+		def bob = addBob()
+		appService.sendBuddyConnectRequest(bob, richard)
+
+		when:
+		def message = "Goodbye friends! I deinstalled the Internet"
+		appService.deleteUser(richard, message)
+
+		then:
 		def buddies = appService.getBuddies(bob)
 		buddies.size() == 0
+
 		def getMessagesResponse = appService.getMessages(bob)
 		getMessagesResponse.status == 200
 		getMessagesResponse.responseData._embedded
-		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
-		goalConflictMessages.size == 1
-		goalConflictMessages[0].nickname == "<self>"
-		goalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
-		goalConflictMessages[0].url =~ /poker/
+		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
+
+		def buddyConnectResponseMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
+		buddyConnectResponseMessages.size() == 1
+		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
+		buddyConnectResponseMessage.message == "User account was deleted"
+		buddyConnectResponseMessage.nickname == "$richard.firstName $richard.lastName"
+		buddyConnectResponseMessage._links.self.href.startsWith(bob.messagesUrl)
+		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
+
+		def response = appService.postMessageActionWithPassword(buddyConnectResponseMessages[0]._links."yona:process".href, [:], bob.password)
+		response.status == 200
+		response.responseData._embedded."yona:affectedMessages".size() == 1
+		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyConnectResponseMessage._links.self.href
+		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
 		cleanup:
 		appService.deleteUser(bob)

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -192,10 +192,9 @@ public class MessageController
 
 		private void addRelatedMessageLink(MessageDTO message, MessageDTO messageResource)
 		{
-			if (message.getRelatedAnonymousMessageID() != null)
+			if (message.getRelatedMessageID() != null)
 			{
-				messageResource
-						.add(getAnonymousMessageLinkBuilder(userID, message.getRelatedAnonymousMessageID()).withRel("related"));
+				messageResource.add(getAnonymousMessageLinkBuilder(userID, message.getRelatedMessageID()).withRel("related"));
 			}
 		}
 

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1213,6 +1213,7 @@ definitions:
     properties:
       code:
         type: string
+        example: 1234
     required:
       - code
   PostPutGoal:

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1437,8 +1437,8 @@ definitions:
         properties:
           "yona:user":
               $ref: "#/definitions/UserWithOnlyPublicData"
-    required:
-      - _embedded
+        required:
+          - "yona:user"
   BuddyConnectRequestMessage:
     allOf:
       - $ref: '#/definitions/BuddyMessageWithEmbeddedUser'

--- a/core/src/main/java/nu/yona/server/goals/entities/GoalChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/GoalChangeMessage.java
@@ -30,10 +30,10 @@ public class GoalChangeMessage extends BuddyMessage
 		super();
 	}
 
-	protected GoalChangeMessage(UUID id, UUID userAnonymizedID, UUID userID, String nickname, Goal changedGoal, Change change,
+	protected GoalChangeMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, String senderNickname, Goal changedGoal, Change change,
 			String message)
 	{
-		super(id, userAnonymizedID, userID, nickname, message);
+		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message);
 
 		this.changedGoal = changedGoal;
 		this.change = change;
@@ -49,9 +49,9 @@ public class GoalChangeMessage extends BuddyMessage
 		return change;
 	}
 
-	public static GoalChangeMessage createInstance(UUID userAnonymizedID, UUID userID, String nickname, Goal changedGoal,
+	public static GoalChangeMessage createInstance(UUID senderUserID, UUID senderUserAnonymizedID, String senderNickname, Goal changedGoal,
 			Change change, String message)
 	{
-		return new GoalChangeMessage(UUID.randomUUID(), userAnonymizedID, userID, nickname, changedGoal, change, message);
+		return new GoalChangeMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID, senderNickname, changedGoal, change, message);
 	}
 }

--- a/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
@@ -77,7 +77,7 @@ public class GoalChangeMessageDTO extends BuddyMessageLinkedUserDTO
 	public static GoalChangeMessageDTO createInstance(UserDTO actingUser, GoalChangeMessage messageEntity)
 	{
 		return new GoalChangeMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getNickname(),
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(),
 				GoalDTO.createInstance(messageEntity.getChangedGoal()), messageEntity.getChange(), messageEntity.getMessage());
 	}
 

--- a/core/src/main/java/nu/yona/server/goals/service/GoalService.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalService.java
@@ -169,7 +169,7 @@ public class GoalService
 			Optional<String> message)
 	{
 		messageService.broadcastMessageToBuddies(UserAnonymizedDTO.createInstance(userEntity.getAnonymized()),
-				() -> GoalChangeMessage.createInstance(userEntity.getUserAnonymizedID(), userEntity.getID(),
+				() -> GoalChangeMessage.createInstance(userEntity.getID(), userEntity.getUserAnonymizedID(),
 						userEntity.getNickname(), changedGoal, change, message.orElse(null)));
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/DisclosureRequestMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/DisclosureRequestMessage.java
@@ -28,10 +28,10 @@ public class DisclosureRequestMessage extends BuddyMessage
 
 	}
 
-	private DisclosureRequestMessage(UUID id, UUID requestingUserID, UUID requestingUserAnonymizedID,
-			UUID targetGoalConflictMessageID, String nickname, String message)
+	private DisclosureRequestMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID,
+			UUID targetGoalConflictMessageID, String senderUserNickname, String message)
 	{
-		super(id, requestingUserAnonymizedID, requestingUserID, nickname, message);
+		super(id, senderUserID, senderUserAnonymizedID, senderUserNickname, message);
 		this.targetGoalConflictMessageID = targetGoalConflictMessageID;
 		this.status = Status.DISCLOSURE_REQUESTED;
 	}
@@ -68,10 +68,10 @@ public class DisclosureRequestMessage extends BuddyMessage
 		super.decrypt(decryptor);
 	}
 
-	public static Message createInstance(UUID requestingUserID, UUID requestingUserAnonymizedID, String requestingUserNickname,
+	public static Message createInstance(UUID senderUserID, UUID senderUserAnonymizedID, String senderUserNickname,
 			String message, GoalConflictMessage targetGoalConflictMessage)
 	{
-		return new DisclosureRequestMessage(UUID.randomUUID(), requestingUserID, requestingUserAnonymizedID,
-				targetGoalConflictMessage.getID(), requestingUserNickname, message);
+		return new DisclosureRequestMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID,
+				targetGoalConflictMessage.getID(), senderUserNickname, message);
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/DisclosureResponseMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/DisclosureResponseMessage.java
@@ -28,10 +28,10 @@ public class DisclosureResponseMessage extends BuddyMessage
 
 	}
 
-	private DisclosureResponseMessage(UUID id, UUID respondingUserID, UUID relatedUserAnonymizedID,
-			UUID targetGoalConflictMessageID, Status status, String nickname, String message)
+	private DisclosureResponseMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID,
+			UUID targetGoalConflictMessageID, Status status, String senderNickname, String message)
 	{
-		super(id, relatedUserAnonymizedID, respondingUserID, nickname, message);
+		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message);
 		this.targetGoalConflictMessageID = targetGoalConflictMessageID;
 		this.status = status;
 	}
@@ -58,10 +58,10 @@ public class DisclosureResponseMessage extends BuddyMessage
 		super.decrypt(decryptor);
 	}
 
-	public static DisclosureResponseMessage createInstance(UUID respondingUserID, UUID relatedUserAnonymizedID,
-			UUID targetGoalConflictMessageID, Status status, String nickname, String message)
+	public static DisclosureResponseMessage createInstance(UUID senderUserID, UUID senderUserAnonymizedID,
+			UUID targetGoalConflictMessageID, Status status, String senderNickname, String message)
 	{
-		return new DisclosureResponseMessage(UUID.randomUUID(), respondingUserID, relatedUserAnonymizedID,
-				targetGoalConflictMessageID, status, nickname, message);
+		return new DisclosureResponseMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID,
+				targetGoalConflictMessageID, status, senderNickname, message);
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/Message.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/Message.java
@@ -14,7 +14,6 @@ import nu.yona.server.crypto.Decryptor;
 import nu.yona.server.crypto.Encryptor;
 import nu.yona.server.entities.EntityWithID;
 import nu.yona.server.entities.RepositoryProvider;
-import nu.yona.server.messaging.service.MessageServiceException;
 
 @Entity
 @Table(name = "MESSAGES")
@@ -33,15 +32,12 @@ public abstract class Message extends EntityWithID
 	 * This is the only constructor, to ensure that subclasses don't accidentally omit the ID.
 	 * 
 	 * @param id The ID of the entity
+	 * @param relatedUserAnonymizedID The ID of the related anonymized user. This is either the sender of this message or the one
+	 *            for which this message is sent (e.g in case of a goal conflict message).
 	 */
 	protected Message(UUID id, UUID relatedUserAnonymizedID)
 	{
 		super(id);
-
-		if (id != null && relatedUserAnonymizedID == null)
-		{
-			throw MessageServiceException.anonymizedUserIdMustBeSet();
-		}
 
 		this.relatedUserAnonymizedID = relatedUserAnonymizedID;
 		this.creationTime = ZonedDateTime.now();
@@ -62,6 +58,13 @@ public abstract class Message extends EntityWithID
 		return creationTime;
 	}
 
+	/**
+	 * The ID of the related anonymized user. This is either the sender of this message or the one for which this message is sent
+	 * (e.g in case of a goal conflict message).
+	 * 
+	 * @return The ID of the related anonymized user. Might be null if that user was already deleted at the time this message was
+	 *         sent on behalf of that user.
+	 */
 	public UUID getRelatedUserAnonymizedID()
 	{
 		return relatedUserAnonymizedID;

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
@@ -74,7 +74,7 @@ public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 	{
 		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
 		return new DisclosureRequestMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getNickname(), messageEntity.getMessage(),
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(), messageEntity.getMessage(),
 				messageEntity.getStatus(), targetGoalConflictMessage.getOriginGoalConflictMessageID());
 	}
 

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
@@ -64,7 +64,7 @@ public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 	{
 		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
 		return new DisclosureResponseMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getStatus(), messageEntity.getNickname(),
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getStatus(), messageEntity.getSenderNickname(),
 				messageEntity.getMessage(), targetGoalConflictMessage.getID());
 	}
 

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -34,7 +34,7 @@ public abstract class MessageDTO extends PolymorphicDTO
 {
 	private final UUID id;
 	private final ZonedDateTime creationTime;
-	private final UUID relatedAnonymousMessageID;
+	private final UUID relatedMessageID;
 
 	protected MessageDTO(UUID id, ZonedDateTime creationTime)
 	{
@@ -45,7 +45,7 @@ public abstract class MessageDTO extends PolymorphicDTO
 	{
 		this.id = id;
 		this.creationTime = creationTime;
-		this.relatedAnonymousMessageID = relatedMessageID;
+		this.relatedMessageID = relatedMessageID;
 	}
 
 	@JsonIgnore
@@ -61,9 +61,9 @@ public abstract class MessageDTO extends PolymorphicDTO
 	}
 
 	@JsonIgnore
-	public UUID getRelatedAnonymousMessageID()
+	public UUID getRelatedMessageID()
 	{
-		return relatedAnonymousMessageID;
+		return relatedMessageID;
 	}
 
 	@JsonIgnore

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageServiceException.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageServiceException.java
@@ -1,9 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
 
@@ -32,10 +29,5 @@ public class MessageServiceException extends YonaException
 	public static MessageServiceException actionNotSupported(String action)
 	{
 		return new MessageServiceException("error.message.action.not.supported", action);
-	}
-
-	public static MessageServiceException anonymizedUserIdMustBeSet()
-	{
-		return new MessageServiceException("error.message.anonymized.user.id.must.be.set");
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
@@ -80,13 +80,11 @@ public class BuddyAnonymized extends EntityWithID
 
 	public UUID getUserAnonymizedID()
 	{
-		// notice these are the same
 		return userAnonymizedID;
 	}
 
 	public void setUserAnonymizedID(UUID userAnonymizedID)
 	{
-		// notice these are the same
 		this.userAnonymizedID = userAnonymizedID;
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
@@ -26,9 +26,9 @@ public abstract class BuddyConnectMessage extends BuddyMessage
 		super();
 	}
 
-	protected BuddyConnectMessage(UUID id, UUID userAnonymizedID, UUID userID, String nickname, String message, UUID buddyID)
+	protected BuddyConnectMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, String senderNickname, String message, UUID buddyID)
 	{
-		super(id, userAnonymizedID, userID, nickname, message);
+		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message);
 		this.buddyID = buddyID;
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
@@ -25,12 +25,12 @@ public class BuddyConnectRequestMessage extends BuddyConnectMessage
 		super();
 	}
 
-	private BuddyConnectRequestMessage(UUID id, UUID userID, UUID userAnonymizedID, String nickname, String message, UUID buddyID,
+	private BuddyConnectRequestMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, String senderNickname, String message, UUID buddyID,
 			boolean isRequestingSending, boolean isRequestingReceiving)
 	{
-		super(id, userAnonymizedID, userID, nickname, message, buddyID);
+		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message, buddyID);
 
-		if (userID == null)
+		if (senderUserID == null)
 		{
 			throw BuddyServiceException.requestingUserCannotBeNull();
 		}
@@ -60,10 +60,10 @@ public class BuddyConnectRequestMessage extends BuddyConnectMessage
 		return this.status;
 	}
 
-	public static BuddyConnectRequestMessage createInstance(UUID requestingUserID, UUID requestingUserUserAnonymizedID,
-			String nickname, String message, UUID buddyID, boolean isRequestingSending, boolean isRequestingReceiving)
+	public static BuddyConnectRequestMessage createInstance(UUID senderUserID, UUID senderUserAnonymizedID,
+			String senderNickname, String message, UUID buddyID, boolean isRequestingSending, boolean isRequestingReceiving)
 	{
-		return new BuddyConnectRequestMessage(UUID.randomUUID(), requestingUserID, requestingUserUserAnonymizedID, nickname,
+		return new BuddyConnectRequestMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID, senderNickname,
 				message, buddyID, isRequestingSending, isRequestingReceiving);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectResponseMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectResponseMessage.java
@@ -20,10 +20,10 @@ public class BuddyConnectResponseMessage extends BuddyConnectMessage
 		super();
 	}
 
-	private BuddyConnectResponseMessage(UUID id, UUID userID, UUID userAnonymizedID, String nickname, String message,
+	private BuddyConnectResponseMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, String senderNickname, String message,
 			UUID buddyID, BuddyAnonymized.Status status)
 	{
-		super(id, userAnonymizedID, userID, nickname, message, buddyID);
+		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message, buddyID);
 		this.status = status;
 	}
 
@@ -42,10 +42,10 @@ public class BuddyConnectResponseMessage extends BuddyConnectMessage
 		this.isProcessed = true;
 	}
 
-	public static BuddyConnectResponseMessage createInstance(UUID respondingUserID, UUID respondingUserAnonymizedID,
-			String nickname, String message, UUID buddyID, BuddyAnonymized.Status status)
+	public static BuddyConnectResponseMessage createInstance(UUID senderUserID, UUID senderUserAnonymizedID,
+			String senderNickname, String message, UUID buddyID, BuddyAnonymized.Status status)
 	{
-		return new BuddyConnectResponseMessage(UUID.randomUUID(), respondingUserID, respondingUserAnonymizedID, nickname, message,
+		return new BuddyConnectResponseMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID, senderNickname, message,
 				buddyID, status);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
@@ -20,9 +20,9 @@ public class BuddyDisconnectMessage extends BuddyMessage
 	private boolean isProcessed;
 	private DropBuddyReason reason;
 
-	public BuddyDisconnectMessage(UUID id, UUID userID, UUID loginID, String nickname, String message, DropBuddyReason reason)
+	public BuddyDisconnectMessage(UUID id, UUID senderUserID, UUID senderAnonymizedUserID, String senderNickname, String message, DropBuddyReason reason)
 	{
-		super(id, loginID, userID, nickname, message);
+		super(id, senderUserID, senderAnonymizedUserID, senderNickname, message);
 		this.reason = reason;
 	}
 
@@ -30,12 +30,6 @@ public class BuddyDisconnectMessage extends BuddyMessage
 	public BuddyDisconnectMessage()
 	{
 		super();
-	}
-
-	public static BuddyDisconnectMessage createInstance(UUID userID, UUID loginID, String nickname, String message,
-			DropBuddyReason reason)
-	{
-		return new BuddyDisconnectMessage(UUID.randomUUID(), userID, loginID, nickname, message, reason);
 	}
 
 	public DropBuddyReason getReason()
@@ -51,5 +45,11 @@ public class BuddyDisconnectMessage extends BuddyMessage
 	public void setProcessed()
 	{
 		this.isProcessed = true;
+	}
+
+	public static BuddyDisconnectMessage createInstance(UUID senderUserID, UUID senderAnonymizedUserID, String senderNickname, String message,
+			DropBuddyReason reason)
+	{
+		return new BuddyDisconnectMessage(UUID.randomUUID(), senderUserID, senderAnonymizedUserID, senderNickname, message, reason);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -304,8 +304,8 @@ public class User extends EntityWithID
 		this.pinResetConfirmationCode = pinResetConfirmationCode;
 	}
 
-	public Set<Buddy> getBuddiesOfRemovedUsers()
+	public Set<Buddy> getBuddiesRelatedToRemovedUsers()
 	{
-		return userPrivate.getBuddiesOfRemovedUsers();
+		return userPrivate.getBuddiesRelatedToRemovedUsers();
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -303,4 +303,9 @@ public class User extends EntityWithID
 	{
 		this.pinResetConfirmationCode = pinResetConfirmationCode;
 	}
+
+	public Set<Buddy> getBuddiesOfRemovedUsers()
+	{
+		return userPrivate.getBuddiesOfRemovedUsers();
+	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -161,5 +162,10 @@ public class UserPrivate extends EntityWithID
 	public UUID getUserAnonymizedID()
 	{
 		return userAnonymizedID;
+	}
+
+	public Set<Buddy> getBuddiesOfRemovedUsers()
+	{
+		return buddies.stream().filter(b -> b.getUser() == null).collect(Collectors.toSet());
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -164,7 +164,7 @@ public class UserPrivate extends EntityWithID
 		return userAnonymizedID;
 	}
 
-	public Set<Buddy> getBuddiesOfRemovedUsers()
+	public Set<Buddy> getBuddiesRelatedToRemovedUsers()
 	{
 		return buddies.stream().filter(b -> b.getUser() == null).collect(Collectors.toSet());
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
@@ -22,15 +22,12 @@ import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.service.BuddyMessageEmbeddedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
-import nu.yona.server.messaging.service.MessageDestinationDTO;
-import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.messaging.service.MessageService.DTOManager;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
 import nu.yona.server.messaging.service.MessageServiceException;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.BuddyConnectRequestMessage;
-import nu.yona.server.subscriptions.entities.BuddyConnectResponseMessage;
 
 @JsonRootName("buddyConnectRequestMessage")
 public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
@@ -90,8 +87,8 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 	public static BuddyConnectRequestMessageDTO createInstance(UserDTO actingUser, BuddyConnectRequestMessage messageEntity)
 	{
 		return new BuddyConnectRequestMessageDTO(messageEntity, messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getRelatedUserAnonymizedID(),
-				messageEntity.getNickname(), messageEntity.getMessage(), messageEntity.getStatus());
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getRelatedUserAnonymizedID(),
+				messageEntity.getSenderNickname(), messageEntity.getMessage(), messageEntity.getStatus());
 	}
 
 	@Component
@@ -104,12 +101,6 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 
 		@Autowired
 		private BuddyService buddyService;
-
-		@Autowired
-		private UserAnonymizedService userAnonymizedService;
-
-		@Autowired
-		private MessageService messageService;
 
 		@PostConstruct
 		private void init()
@@ -143,8 +134,12 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 		private MessageActionDTO handleAction_Accept(UserDTO actingUser, BuddyConnectRequestMessage connectRequestMessageEntity,
 				MessageActionDTO payload)
 		{
-			buddyService.addBuddyToAcceptingUser(actingUser, connectRequestMessageEntity.getUser().getID(),
-					connectRequestMessageEntity.getNickname(), connectRequestMessageEntity.getRelatedUserAnonymizedID(),
+			if (connectRequestMessageEntity.getSenderUser() == null)
+			{
+				throw UserServiceException.notFoundByID(connectRequestMessageEntity.getSenderUserID());
+			}
+			buddyService.addBuddyToAcceptingUser(actingUser, connectRequestMessageEntity.getSenderUser().getID(),
+					connectRequestMessageEntity.getSenderNickname(), connectRequestMessageEntity.getRelatedUserAnonymizedID(),
 					connectRequestMessageEntity.requestingSending(), connectRequestMessageEntity.requestingReceiving());
 
 			connectRequestMessageEntity = updateMessageStatusAsAccepted(connectRequestMessageEntity);
@@ -153,8 +148,9 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 
 			logger.info(
 					"User with mobile number '{}' and ID '{}' accepted buddy connect request from user with mobile number '{}' and ID '{}'",
-					actingUser.getMobileNumber(), actingUser.getID(), connectRequestMessageEntity.getUser().getMobileNumber(),
-					connectRequestMessageEntity.getUser().getID());
+					actingUser.getMobileNumber(), actingUser.getID(),
+					connectRequestMessageEntity.getSenderUser().getMobileNumber(),
+					connectRequestMessageEntity.getSenderUser().getID());
 
 			return MessageActionDTO
 					.createInstanceActionDone(theDTOFactory.createInstance(actingUser, connectRequestMessageEntity));
@@ -167,10 +163,13 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 
 			sendResponseMessageToRequestingUser(actingUser, connectRequestMessageEntity, payload.getProperty("message"));
 
+			String mobileNumber = (connectRequestMessageEntity.getSenderUser() == null) ? "already deleted"
+					: connectRequestMessageEntity.getSenderUser().getMobileNumber();
+			String id = (connectRequestMessageEntity.getSenderUser() == null) ? "already deleted"
+					: connectRequestMessageEntity.getSenderUser().getID().toString();
 			logger.info(
 					"User with mobile number '{}' and ID '{}' rejected buddy connect request from user with mobile number '{}' and ID '{}'",
-					actingUser.getMobileNumber(), actingUser.getID(), connectRequestMessageEntity.getUser().getMobileNumber(),
-					connectRequestMessageEntity.getUser().getID());
+					actingUser.getMobileNumber(), actingUser.getID(), mobileNumber, id);
 
 			return MessageActionDTO
 					.createInstanceActionDone(theDTOFactory.createInstance(actingUser, connectRequestMessageEntity));
@@ -191,14 +190,10 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 		private void sendResponseMessageToRequestingUser(UserDTO respondingUser,
 				BuddyConnectRequestMessage connectRequestMessageEntity, String responseMessage)
 		{
-			MessageDestinationDTO messageDestination = userAnonymizedService
-					.getUserAnonymized(connectRequestMessageEntity.getRelatedUserAnonymizedID()).getAnonymousDestination();
-			assert messageDestination != null;
-			messageService.sendMessage(
-					BuddyConnectResponseMessage.createInstance(respondingUser.getID(),
-							respondingUser.getPrivateData().getUserAnonymizedID(), respondingUser.getPrivateData().getNickname(),
-							responseMessage, connectRequestMessageEntity.getBuddyID(), connectRequestMessageEntity.getStatus()),
-					messageDestination);
+			buddyService.sendBuddyConnectResponseMessage(respondingUser.getID(),
+					respondingUser.getPrivateData().getUserAnonymizedID(), respondingUser.getPrivateData().getNickname(),
+					connectRequestMessageEntity.getRelatedUserAnonymizedID(), connectRequestMessageEntity.getBuddyID(),
+					connectRequestMessageEntity.getStatus(), responseMessage);
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
@@ -81,8 +81,8 @@ public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 	public static BuddyConnectResponseMessageDTO createInstance(UserDTO actingUser, BuddyConnectResponseMessage messageEntity)
 	{
 		return new BuddyConnectResponseMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getNickname(), messageEntity.getMessage(),
-				messageEntity.getStatus(), messageEntity.isProcessed());
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(),
+				messageEntity.getMessage(), messageEntity.getStatus(), messageEntity.isProcessed());
 	}
 
 	@Component
@@ -134,15 +134,19 @@ public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 			else
 			{
 				buddyService.setBuddyAcceptedWithSecretUserInfo(connectResponseMessageEntity.getBuddyID(),
-						connectResponseMessageEntity.getRelatedUserAnonymizedID(), connectResponseMessageEntity.getNickname());
+						connectResponseMessageEntity.getRelatedUserAnonymizedID(),
+						connectResponseMessageEntity.getSenderNickname());
 			}
 
 			connectResponseMessageEntity = updateMessageStatusAsProcessed(connectResponseMessageEntity);
 
+			String mobileNumber = (connectResponseMessageEntity.getSenderUser() == null) ? "already deleted"
+					: connectResponseMessageEntity.getSenderUser().getMobileNumber();
+			String id = (connectResponseMessageEntity.getSenderUser() == null) ? "already deleted"
+					: connectResponseMessageEntity.getSenderUser().getID().toString();
 			logger.info(
 					"User with mobile number '{}' and ID '{}' processed buddy connect response from user with mobile number '{}' and ID '{}'",
-					actingUser.getMobileNumber(), actingUser.getID(), connectResponseMessageEntity.getUser().getMobileNumber(),
-					connectResponseMessageEntity.getUser().getID());
+					actingUser.getMobileNumber(), actingUser.getID(), mobileNumber, id);
 
 			return MessageActionDTO
 					.createInstanceActionDone(theDTOFactory.createInstance(actingUser, connectResponseMessageEntity));

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDTO.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import nu.yona.server.Translator;
 import nu.yona.server.goals.service.GoalDTO;
 import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
@@ -71,9 +72,15 @@ public class BuddyDTO
 		return user;
 	}
 
-	Buddy createBuddyEntity()
+	Buddy createBuddyEntity(Translator translator)
 	{
-		return Buddy.createInstance(user.getID(), user.getPrivateData().getNickname(), getSendingStatus(), getReceivingStatus());
+		return Buddy.createInstance(user.getID(), determineTempNickname(translator), getSendingStatus(), getReceivingStatus());
+	}
+
+	private String determineTempNickname(Translator translator)
+	{
+		// Used to till the user accepted the request and shared their nickname
+		return translator.getLocalizedMessage("message.temp.nickname", user.getFirstName(), user.getLastName());
 	}
 
 	public static BuddyDTO createInstance(Buddy buddyEntity)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDTO.java
@@ -79,8 +79,8 @@ public class BuddyDisconnectMessageDTO extends BuddyMessageEmbeddedUserDTO
 	public static BuddyDisconnectMessageDTO createInstance(UserDTO actingUser, BuddyDisconnectMessage messageEntity)
 	{
 		return new BuddyDisconnectMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getUser()), messageEntity.getRelatedUserAnonymizedID(),
-				messageEntity.getNickname(), messageEntity.getMessage(), messageEntity.getReason(), messageEntity.isProcessed());
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getRelatedUserAnonymizedID(),
+				messageEntity.getSenderNickname(), messageEntity.getMessage(), messageEntity.getReason(), messageEntity.isProcessed());
 	}
 
 	@Component
@@ -120,7 +120,7 @@ public class BuddyDisconnectMessageDTO extends BuddyMessageEmbeddedUserDTO
 		private MessageActionDTO handleAction_Process(UserDTO actingUser, BuddyDisconnectMessage messageEntity,
 				MessageActionDTO requestPayload)
 		{
-			buddyService.removeBuddyAfterBuddyRemovedConnection(actingUser.getID(), messageEntity.getUserID());
+			buddyService.removeBuddyAfterBuddyRemovedConnection(actingUser.getID(), messageEntity.getSenderUserID());
 
 			messageEntity = updateMessageStatusAsProcessed(messageEntity);
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyServiceException.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyServiceException.java
@@ -20,11 +20,6 @@ public class BuddyServiceException extends YonaException
 		super(t, messageId, parameters);
 	}
 
-	public static BuddyServiceException userCannotBeNull()
-	{
-		return new BuddyServiceException("error.buddy.user.cannot.be.null");
-	}
-
 	public static BuddyServiceException messageEntityCannotBeNull()
 	{
 		return new BuddyServiceException("error.buddy.message.entity.cannot.be.null");

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -510,7 +510,7 @@ public class UserService
 
 	private void handleBuddyUsersRemovedWhileOffline(User user)
 	{
-		Set<Buddy> buddiesOfRemovedUsers = user.getBuddiesOfRemovedUsers();
+		Set<Buddy> buddiesOfRemovedUsers = user.getBuddiesRelatedToRemovedUsers();
 		buddiesOfRemovedUsers.stream().forEach(b -> buddyService.removeBuddyInfoForRemovedUser(user, b));
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -85,13 +86,17 @@ public class UserService
 	@Transactional
 	public UserDTO getPrivateUser(UUID id)
 	{
-		return UserDTO.createInstanceWithPrivateData(getUserByID(id));
+		User user = getUserByID(id);
+		handleBuddyUsersRemovedWhileOffline(user);
+		return UserDTO.createInstanceWithPrivateData(user);
 	}
 
 	@Transactional
 	public UserDTO getPrivateValidatedUser(UUID id)
 	{
-		return UserDTO.createInstanceWithPrivateData(getValidatedUserbyID(id));
+		User validatedUser = getValidatedUserbyID(id);
+		handleBuddyUsersRemovedWhileOffline(validatedUser);
+		return UserDTO.createInstanceWithPrivateData(validatedUser);
 	}
 
 	@Transactional
@@ -501,6 +506,12 @@ public class UserService
 			registerFailedAttempt(userEntity, confirmationCode);
 			throw invalidConfirmationCodeExceptionSupplier.apply(remainingAttempts - 1);
 		}
+	}
+
+	private void handleBuddyUsersRemovedWhileOffline(User user)
+	{
+		Set<Buddy> buddiesOfRemovedUsers = user.getBuddiesOfRemovedUsers();
+		buddiesOfRemovedUsers.stream().forEach(b -> buddyService.removeBuddyInfoForRemovedUser(user, b));
 	}
 
 	public void registerFailedAttempt(User userEntity, ConfirmationCode confirmationCode)

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -8,6 +8,8 @@
 message.user.account.deleted=User account was deleted
 message.user.removed.buddy=User removed you as a buddy
 
+message.temp.nickname={0} {1}
+
 error.invalid.request=Invalid request
 
 error.user.firstname=The first name of the user must be set
@@ -49,7 +51,6 @@ error.encoding.public.key=Error encoding the public key
 error.decoding.public.key=Error decoding the public key
 
 error.buddy.not.found=Buddy with ID ''{0}'' not found
-error.buddy.user.cannot.be.null=User cannot be null
 error.buddy.requesting.user.cannot.be.null=Requesting user cannot be null
 error.buddy.message.entity.cannot.be.null=Message entity cannot be null
 error.buddy.useranonymizedid.cannot.be.null=Anonymized user ID cannot be null 
@@ -80,7 +81,6 @@ error.device.request.invalid.password=Invalid temporary password to use new devi
 error.message.not.found=Message with ID ''{0}'' not found
 error.message.no.dto.manager.registered=No DTO manager registered for class ''{0}''
 error.message.action.not.supported=Action ''{0}'' not supported
-error.message.anonymized.user.id.must.be.set=Anonymized user ID must be set
 
 error.loading.activitycategories.from.file=Error loading activity categories from file
 error.activitycategory.not.found=Activity category with ID ''{0}'' not found

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -8,6 +8,7 @@
 message.user.account.deleted=User account was deleted
 message.user.removed.buddy=User removed you as a buddy
 
+# Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}
 
 error.invalid.request=Invalid request

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -8,6 +8,8 @@
 message.user.account.deleted=Gebruikersaccount verwijderd
 message.user.removed.buddy=De gebruiker heeft je 'ontvriend'
 
+message.temp.nickname={0} {1}
+
 error.invalid.request=Fout request
 
 error.user.firstname=De voornaam van de gebruiker moet worden ingevuld
@@ -49,7 +51,6 @@ error.encoding.public.key=Fout bij het coderen van de public key
 error.decoding.public.key=Fout bij het decoderen van de public key
 
 error.buddy.not.found=Vriend met ID ''{0}'' niet gevonden
-error.buddy.user.cannot.be.null=Gebruiker mag niet null zijn
 error.buddy.requesting.user.cannot.be.null=Aanvragende gebruiker mag niet null zijn
 error.buddy.message.entity.cannot.be.null=Message entity mag niet null zijn
 error.buddy.useranonymizedid.cannot.be.null=VPN login ID mag niet null zijn 
@@ -80,7 +81,6 @@ error.device.request.invalid.password=Het tijdelijke wachtwoord voor het ''new d
 error.message.not.found=Bericht met ID ''{0}'' niet gevonden
 error.message.no.dto.manager.registered=Geen DTO manager ''{0}'' geregistreerd
 error.message.action.not.supported=Actie ''{0}'' wordt niet ondersteund
-error.message.anonymized.user.id.must.be.set=Het VPN login ID mag niet leeg zijn
 
 error.loading.activitycategories.from.file=Fout bij het laden van de activiteitencategorien van disk
 error.activitycategory.not.found=Activiteitencategorie met ID ''{0}'' niet gevonden

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -8,6 +8,7 @@
 message.user.account.deleted=Gebruikersaccount verwijderd
 message.user.removed.buddy=De gebruiker heeft je 'ontvriend'
 
+# Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}
 
 error.invalid.request=Fout request


### PR DESCRIPTION
* Behavior change: remove user and overwrite user now seem immediately applicable to buddies
* Buddies are now informed about account overwrite. In case of a pending buddy request, a reject is received. In case of an existing buddy relationship, a disconnect is received.
* Added test: Overwrite user created on buddy request
* Updated OverwriteUserTest for the changed behavior, including:
  * Updated "Overwrite the existing user" to become "Overwrite Richard while being a buddy of Bob"
  * Added "Overwrite Richard with pending buddy invitation to Bob"
  * Added "Overwrite Richard with pending buddy invitation from Bob"
  * Removed "Bob removes overwritten user Richard as buddy" as the buddy is now immediately removed
  * Added "Goal conflict for Bob after Richard overwrote his account is not reported to Richard"
* Updated RemoveUserTest for the changed behavior, including:
  * Updated "Remove Richard and verify that Bob receives a remove buddy message" to become "Remove Richard while being a buddy of Bob and verify that Bob receives a buddy disconnect message"
  * Removed "Remove Richard and verify that buddy data is removed after Bob processed the remove buddy message", as that's not relevant now that removal is immediately active
  * Added "Remove Richard with pending buddy request from Bob and verify that Bob receives a reject message"
* Several name corrections:
  * login ID --> userAnonymizedID
  * relatedAnonymousMessageID --> relatedMessageID
  * All messages now talk about sender... where applicable and use a consistent parameter sequence
* Updated the Swagger spec to indicate that the embedded user in BuddyMessageWithEmbeddedUser is optional.
* It's now possible to have a BuddyMessage without a sender user
* It's now possible to have a getRelatedUserAnonymizedID without an anonymized user ID
* BuddyService.removeBuddy now really removes the buddy object (earlier it only removed it from the user but left it in the database).