### PR TITLE
YD-247 inconsistencies in swagger spec

### DIFF
--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -79,6 +79,18 @@ public class PinResetRequestController
 		return new ResponseEntity<Void>(HttpStatus.OK);
 	}
 
+	@RequestMapping(value = "/resend", method = RequestMethod.POST)
+	@ResponseBody
+	public ResponseEntity<Void> resendPinResetConfirmationCode(
+			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID id)
+	{
+		CryptoSession.execute(password, () -> userService.canAccessPrivateData(id), () -> {
+			pinResetRequestService.resendPinResetConfirmationCode(id);
+			return null;
+		});
+		return new ResponseEntity<Void>(HttpStatus.OK);
+	}
+
 	@RequestMapping(value = "/clear", method = RequestMethod.POST)
 	@ResponseBody
 	public ResponseEntity<Void> clearPinResetRequest(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
@@ -114,8 +126,9 @@ public class PinResetRequestController
 		}
 		else if (confirmationCode.getConfirmationCode() != null)
 		{
-			addClearPinResetLink(userResource);
 			addVerifyPinResetLink(userResource);
+			addResendPinResetConfirmationCodeLink(userResource);
+			addClearPinResetLink(userResource);
 		}
 	}
 
@@ -131,6 +144,13 @@ public class PinResetRequestController
 		PinResetRequestController methodOn = methodOn(PinResetRequestController.class);
 		ResponseEntity<Void> method = methodOn.verifyPinResetConfirmationCode(null, userResource.getContent().getID(), null);
 		addLink(userResource, method, "yona:verifyPinReset");
+	}
+
+	private void addResendPinResetConfirmationCodeLink(UserResource userResource)
+	{
+		PinResetRequestController methodOn = methodOn(PinResetRequestController.class);
+		ResponseEntity<Void> method = methodOn.resendPinResetConfirmationCode(null, userResource.getContent().getID());
+		addLink(userResource, method, "yona:resendPinResetConfirmationCode");
 	}
 
 	private void addClearPinResetLink(UserResource userResource)

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -783,6 +783,30 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/ConfirmationError'
+  '/users/{userID}/pinResetRequest/resend':
+    post:
+      summary: Request resend of a pin reset confirmation code
+      description: Post an empty request to get a new pin reset confirmation code texted to the user
+      parameters:
+        - name: userID
+          in: path
+          description: The ID of the user
+          required: true
+          type: string
+        - name: Yona-Password
+          in: header
+          description: The device password
+          required: true
+          type: string
+      tags:
+        - Pin reset
+      responses:
+        '200':
+          description: The request is successfully handled
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
   '/users/{userID}/pinResetRequest/clear':
     post:
       summary: Clear pin reset confirmation code
@@ -1156,6 +1180,38 @@ definitions:
               href:
                 type: string
                 description: This link allows requesting a resend of the mobile number confirmation code.
+          "yona:requestPinReset":
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+                description: This link allows requesting a pin reset confirmation code.
+          "yona:verifyPinReset":
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+                description: This link allows verifying the pin reset confirmation code.
+          "yona:resendPinResetConfirmationCode":
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+                description: This link allows requesting a resend of a new pin reset confirmation code.
+          "yona:clearPinReset":
+            type: object
+            required:
+              - href
+            properties:
+              href:
+                type: string
+                description: This link allows clearing the pin reset confirmation code.
           "yona:messages":
             type: object
             required:

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -41,9 +41,9 @@ paths:
           description: Unexpected error.
           schema:
             $ref: '#/definitions/ConfirmationError'
-  '/users/{id}':
+  '/users/{userID}':
     parameters:
-      - name: id
+      - name: userID
         in: path
         description: The ID of the user
         required: true
@@ -102,9 +102,9 @@ paths:
         - User
       responses:
         '200':
-          description: The requested user
+          description: The updated user
           schema:
-            $ref: '#/definitions/PostPutUser'
+            $ref: '#/definitions/UserWithPrivateData'
         default:
           description: Unexpected error
           schema:
@@ -118,6 +118,11 @@ paths:
           description: The device password
           required: true
           type: string
+        - name: message
+          in: query
+          description: A message of the user to their buddies, explaining why they unsubscribe from Yona
+          required: false
+          type: string
       tags:
         - User
       responses:
@@ -127,9 +132,9 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/users/{id}/confirmMobileNumber':
+  '/users/{userID}/confirmMobileNumber':
     parameters:
-      - name: id
+      - name: userID
         in: path
         description: The ID of the user
         required: true
@@ -160,9 +165,9 @@ paths:
           description: Confirmation failed
           schema:
             $ref: '#/definitions/ConfirmationError'
-  '/users/{id}/resendMobileNumberConfirmationCode':
+  '/users/{userID}/resendMobileNumberConfirmationCode':
     parameters:
-      - name: id
+      - name: userID
         in: path
         description: The ID of the user
         required: true
@@ -238,14 +243,14 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/users/{userID}/goals/{id}':
+  '/users/{userID}/goals/{goalID}':
     parameters:
       - name: userID
         in: path
         description: The ID of the user
         required: true
         type: string
-      - name: id
+      - name: goalID
         in: path
         description: The ID of the goal
         required: true
@@ -367,14 +372,14 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/users/{userID}/buddies/{id}':
+  '/users/{userID}/buddies/{buddyID}':
     parameters:
       - name: userID
         in: path
         description: The ID of the user
         required: true
         type: string
-      - name: id
+      - name: buddyID
         in: path
         description: The ID of the buddy
         required: true
@@ -643,14 +648,14 @@ paths:
           description: Messages of this user.
           schema:
             $ref: '#/definitions/PagedMessages'
-  '/users/{userID}/messages/{id}':
+  '/users/{userID}/messages/{messageID}':
     parameters:
       - name: userID
         in: path
         description: The ID of the user
         required: true
         type: string
-      - name: id
+      - name: messageID
         in: path
         description: The ID of the message
         required: true
@@ -678,7 +683,7 @@ paths:
       responses:
         '200':
           description: Messages of this user.
-  '/users/{userID}/messages/{id}/{messageAction}':
+  '/users/{userID}/messages/{messageID}/{messageAction}':
     post:
       summary: Act on a message
       description: Perform the Process action on the message with the given ID
@@ -688,7 +693,7 @@ paths:
           description: The ID of the user
           required: true
           type: string
-        - name: id
+        - name: messageID
           in: path
           description: The ID of the message
           required: true
@@ -923,12 +928,12 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/activityCategories/{id}':
+  '/activityCategories/{activityCategoryID}':
     get:
       summary: Get an activity category
       description: Fetches the activity category identified by the given ID
       parameters:
-        - name: id
+        - name: activityCategoryID
           in: path
           description: The ID of the activity category
           required: true

--- a/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
@@ -22,6 +22,11 @@ public class PinResetRequestService
 {
 	private static final Logger logger = LoggerFactory.getLogger(PinResetRequestService.class);
 
+	private enum Moment
+	{
+		IMMEDIATELY, DELAYED
+	}
+
 	@Autowired
 	private UserService userService;
 
@@ -32,9 +37,9 @@ public class PinResetRequestService
 	public void requestPinReset(UUID userID)
 	{
 		User userEntity = userService.getUserByID(userID);
-		logger.info("Received pin reset request for user with mobile number '{}' and ID '{}'", userEntity.getMobileNumber(),
-				userID);
-		ConfirmationCode confirmationCode = createConfirmationCode();
+		logger.info("User with mobile number '{}' and ID '{}' requested a pin reset confirmation code",
+				userEntity.getMobileNumber(), userID);
+		ConfirmationCode confirmationCode = createConfirmationCode(Moment.DELAYED);
 		setConfirmationCode(userEntity, confirmationCode);
 		if (confirmationCode.getConfirmationCode() != null)
 		{
@@ -46,7 +51,7 @@ public class PinResetRequestService
 	public void verifyPinResetConfirmationCode(UUID userID, String userProvidedConfirmationCode)
 	{
 		User userEntity = userService.getUserByID(userID);
-		logger.info("Received pin reset verification request for user with mobile number '{}' and ID '{}'",
+		logger.info("User with mobile number '{}' and ID '{}' requested to verity the pin reset confirmation code",
 				userEntity.getMobileNumber(), userID);
 		ConfirmationCode confirmationCode = userEntity.getPinResetConfirmationCode();
 		if ((confirmationCode == null) || isExpired(confirmationCode))
@@ -69,24 +74,36 @@ public class PinResetRequestService
 	}
 
 	@Transactional
+	public void resendPinResetConfirmationCode(UUID userID)
+	{
+		User userEntity = userService.getUserByID(userID);
+		logger.info("User with mobile number '{}' and ID '{}' requested to resend the pin reset confirmation code",
+				userEntity.getMobileNumber(), userEntity.getID());
+		ConfirmationCode confirmationCode = createConfirmationCode(Moment.IMMEDIATELY);
+		setConfirmationCode(userEntity, confirmationCode);
+		sendConfirmationCodeTextMessage(userEntity, confirmationCode);
+	}
+
+	@Transactional
 	public void clearPinResetRequest(UUID userID)
 	{
 		User userEntity = userService.getUserByID(userID);
-		logger.info("Received pin reset clearance request for user with mobile number '{}' and ID '{}'",
-				userEntity.getMobileNumber(), userID);
+		logger.info("User with mobile number '{}' and ID '{}' requested to clear the pin reset confirmation code",
+				userEntity.getMobileNumber(), userEntity.getID());
 		setConfirmationCode(userEntity, null);
 	}
 
 	public void sendConfirmationCodeTextMessage(User userEntity, ConfirmationCode confirmationCode)
 	{
 		userService.sendConfirmationCodeTextMessage(userEntity.getMobileNumber(), confirmationCode,
-				SmsService.TemplateName_AddUserNumberConfirmation);
+				SmsService.TemplateName_PinResetRequestConfirmation);
 	}
 
-	private ConfirmationCode createConfirmationCode()
+	private ConfirmationCode createConfirmationCode(Moment moment)
 	{
-		String confirmationCode = yonaProperties.getSecurity().getPinResetRequestConfirmationCodeDelay().equals(Duration.ZERO)
-				? userService.generateConfirmationCode() : null;
+		String confirmationCode = (moment == Moment.IMMEDIATELY)
+				|| yonaProperties.getSecurity().getPinResetRequestConfirmationCodeDelay().equals(Duration.ZERO)
+						? userService.generateConfirmationCode() : null;
 		return ConfirmationCode.createInstance(confirmationCode);
 	}
 

--- a/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
@@ -32,6 +32,7 @@ class User
 	final String appActivityUrl
 	final String pinResetRequestUrl
 	final String verifyPinResetUrl
+	final String resendPinResetConfirmationCodeUrl
 	final String clearPinResetUrl
 	final String password
 
@@ -76,6 +77,7 @@ class User
 		this.appActivityUrl = json._links?."yona:appActivity"?.href
 		this.pinResetRequestUrl = json._links?."yona:requestPinReset"?.href
 		this.verifyPinResetUrl = json._links?."yona:verifyPinReset"?.href
+		this.resendPinResetConfirmationCodeUrl = json._links?."yona:resendPinResetConfirmationCode"?.href
 		this.clearPinResetUrl = json._links?."yona:clearPinReset"?.href
 	}
 


### PR DESCRIPTION
- PUT on /users/{id} actually returns a UserWithPrivateData, not a PostPutUser as currently in the spec.
- DELETE on /users/{id} takes a message query parameter
- We are not consistent in the way we specify IDs. E.g. we use /users/{id}} and /users/{userID}/messages/.
