### PR TITLE
YD-249 Remove user failed

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -118,6 +118,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyConnectResponseMessage._links.self.href
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
+		// Test whether Richard can be removed after he again established a buddy relationship with Bob
 		def newRichard = addRichard()
 		appService.makeBuddies(newRichard, bob)
 		appService.deleteUser(newRichard, "Sorry, going again").status == 200

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -118,6 +118,10 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyConnectResponseMessage._links.self.href
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
+		def newRichard = addRichard()
+		appService.makeBuddies(newRichard, bob)
+		appService.deleteUser(newRichard, "Sorry, going again").status == 200
+
 		cleanup:
 		appService.deleteUser(bob)
 	}

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
 
@@ -87,6 +87,6 @@ public class MessageDestination extends EntityWithID
 
 	public void removeMessagesFromUser(UUID sentByUserAnonymizedID)
 	{
-		messages.removeIf(message -> message.getRelatedUserAnonymizedID().equals(sentByUserAnonymizedID));
+		messages.removeIf(message -> sentByUserAnonymizedID.equals(message.getRelatedUserAnonymizedID()));
 	}
 }

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -208,7 +208,7 @@ class AppService extends Service
 		response.status >= 200 && response.status < 300
 	}
 
-	def makeBuddies(requestingUser, respondingUser)
+	void makeBuddies(requestingUser, respondingUser)
 	{
 		sendBuddyConnectRequest(requestingUser, respondingUser)
 		def acceptURL = fetchBuddyConnectRequestMessage(respondingUser).acceptURL


### PR DESCRIPTION
* Extended the test to reproduce the scenario
* Changed the order of the equals operation in MessageDestination.removeMessagesFromUser