### PR TITLE
YD-244 Delete user with activities fails

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -65,7 +65,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		cleanup:
 		appService.deleteUser(richard)
-		appService.deleteUser(bob)
+		// Cannot delete Bob, as he did not set up a Yona password yet.
 	}
 
 	def 'Bob adjusts data and submits; app saves with the device password'()

--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -30,6 +31,10 @@ public interface DayActivityRepository extends CrudRepository<DayActivity, UUID>
 	@Query("select a from DayActivity a where a.userAnonymized.id = :userAnonymizedID and a.date >= :dateFrom and a.date <= :dateUntil order by a.startTime desc")
 	Set<DayActivity> findAll(@Param("userAnonymizedID") UUID userAnonymizedID, @Param("dateFrom") LocalDate dateFrom,
 			@Param("dateUntil") LocalDate dateUntil);
+
+	@Modifying
+	@Query("delete from DayActivity a where a.userAnonymized.id = :userAnonymizedID")
+	void deleteAllForUser(@Param("userAnonymizedID") UUID userAnonymizedID);
 
 	Set<DayActivity> findByGoal(Goal goal);
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
@@ -39,7 +39,7 @@ public class MessageDestination extends EntityWithID
 	@Transient
 	private PublicKey publicKey;
 
-	@OneToMany(cascade = CascadeType.ALL)
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Message> messages;
 
 	// Default constructor is required for JPA

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import nu.yona.server.analysis.entities.DayActivity;
 import nu.yona.server.analysis.entities.WeekActivity;
 import nu.yona.server.crypto.CryptoSession;
 import nu.yona.server.crypto.CryptoUtil;
@@ -380,6 +381,7 @@ public class UserService
 				DropBuddyReason.USER_ACCOUNT_DELETED));
 
 		WeekActivity.getRepository().deleteAllForUser(userEntity.getUserAnonymizedID());
+		DayActivity.getRepository().deleteAllForUser(userEntity.getUserAnonymizedID());
 
 		UUID vpnLoginID = userEntity.getVPNLoginID();
 		UUID userAnonymizedID = userEntity.getUserAnonymizedID();

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -89,6 +89,8 @@ class AppService extends Service
 			return null
 		}
 		def response = yonaServer.deleteResourceWithPassword(user.editURL, user.password, ["message":message])
+		// assert response.status == 200 Enable this after fixing YD-261
+		return response
 	}
 
 	def deleteUser(userEditURL, password, message = "")


### PR DESCRIPTION
* Cascading delete does not work when deleting through a JQL statement, so day activities are to be deleted explicitly.
* We removed the messages from the destination, but orphan removal was off, so the messages continued to exist, thus prohibiting removal of the goal linked to a goal change message.

There is still one more such issue, see YD-261.