### PR TITLE
YD-263 Cache goal DTOs inside UserAnonymizedDTO

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -44,6 +44,15 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	public String GAMBLING_ACT_CAT_URL = appService.composeActivityCategoryUrl("192d69f4-8d3e-499b-983c-36ca97340ba9")
 
 	@Shared
+	public String MULTIMEDIA_ACT_CAT_URL = appService.composeActivityCategoryUrl("eb7be352-b449-4d30-98fe-3be6ad555b43")
+
+	@Shared
+	public String COMMUNICATION_ACT_CAT_URL = appService.composeActivityCategoryUrl("90b9838f-1430-484b-94c1-e169318091cb")
+
+	@Shared
+	public String ADULT_CONTENT_ACT_CAT_URL = appService.composeActivityCategoryUrl("1f088f0b-9952-4ac7-bdc0-fd242238bc1d")
+
+	@Shared
 	public String SOCIAL_ACT_CAT_URL = appService.composeActivityCategoryUrl("27395d17-7022-4f71-9daf-f431ff4f11e8")
 
 	@Shared
@@ -122,7 +131,23 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	void addTimeZoneGoal(User user, activityCategoryURL, zones, relativeCreationDateTimeString)
 	{
 		ZonedDateTime creationTime = YonaServer.relativeDateTimeStringToZonedDateTime(relativeCreationDateTimeString)
+		addTimeZoneGoal(user, activityCategoryURL, zones, creationTime)
+	}
+
+	void addTimeZoneGoal(User user, activityCategoryURL, zones, ZonedDateTime creationTime = YonaServer.now)
+	{
 		appService.addGoal(appService.&assertResponseStatusCreated, user, TimeZoneGoal.createInstance(creationTime, activityCategoryURL, zones.toArray()))
+	}
+
+	void addBudgetGoal(User user, activityCategoryURL, int maxDurationMinutes, relativeCreationDateTimeString)
+	{
+		ZonedDateTime creationTime = YonaServer.relativeDateTimeStringToZonedDateTime(relativeCreationDateTimeString)
+		addBudgetGoal(user, activityCategoryURL, maxDurationMinutes, creationTime)
+	}
+
+	void addBudgetGoal(User user, activityCategoryURL, int maxDurationMinutes, ZonedDateTime creationTime = YonaServer.now)
+	{
+		appService.addGoal(appService.&assertResponseStatusCreated, user, BudgetGoal.createInstance(creationTime, activityCategoryURL, maxDurationMinutes))
 	}
 
 	void reportAppActivity(User user, def appName, def relativeStartDateTimeString, relativeEndDateTimeString)

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -71,10 +71,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def expectedValuesLastWeek = [
 			"Mon" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: false, minutesBeyondGoal: 20, spread: [13 : 15, 14 : 5]]]],
 			"Tue" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: false, minutesBeyondGoal: 25, spread: [35 : 15, 36 : 10]]]],
-			"Wed" : [
-				[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]],
-				[goalUrl:timeZoneGoalSocialUrl, data: [goalAccomplished: false, minutesBeyondGoal: 1, spread: [68 : 1]]]
-			],
+			"Wed" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]], [goalUrl:timeZoneGoalSocialUrl, data: [goalAccomplished: false, minutesBeyondGoal: 1, spread: [68 : 1]]]],
 			"Thu" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]], [goalUrl:timeZoneGoalSocialUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [48 : 1]]]],
 			"Fri" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]], [goalUrl:timeZoneGoalSocialUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
 			"Sat" : [[goalUrl:budgetGoalNewsUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]], [goalUrl:timeZoneGoalSocialUrl, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]]]
@@ -178,6 +175,24 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseDayOverviewsAfterActivity = appService.getDayActivityOverviews(richard)
 		assertDayOverviewForBudgetGoal(responseDayOverviewsAfterActivity, budgetGoalNewsUrl, expectedValuesAfterActivity, 0, currentShortDay)
 		assertDayDetail(richard, responseDayOverviewsAfterActivity, budgetGoalNewsUrl, expectedValuesAfterActivity, 0, currentShortDay)
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
+	def 'Add goals and fetch activities'()
+	{
+		given:
+		User richard = addRichard()
+		addTimeZoneGoal(richard, MULTIMEDIA_ACT_CAT_URL, ["11:00-12:00"])
+		assert appService.getDayActivityOverviews(richard).status == 200
+		assert appService.getWeekActivityOverviews(richard).status == 200
+
+		when:
+		addBudgetGoal(richard, COMMUNICATION_ACT_CAT_URL, 60)
+		then:
+		appService.getDayActivityOverviews(richard).status == 200
+		appService.getWeekActivityOverviews(richard).status == 200
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -72,7 +72,7 @@ public class GoalController
 			@PathVariable UUID userID, @PathVariable UUID goalID)
 	{
 		return CryptoSession.execute(password, () -> userService.canAccessPrivateData(userID),
-				() -> createResponse(userID, goalService.getGoal(userID, goalID), HttpStatus.OK));
+				() -> createResponse(userID, goalService.getGoalForUserID(userID, goalID), HttpStatus.OK));
 	}
 
 	@RequestMapping(value = "/", method = RequestMethod.POST)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -118,7 +118,7 @@ public class PinResetRequestController
 
 	public void addLinks(UserResource userResource)
 	{
-		ConfirmationCode confirmationCode = userService.getUserByID(userResource.getContent().getID())
+		ConfirmationCode confirmationCode = userService.getUserEntityByID(userResource.getContent().getID())
 				.getPinResetConfirmationCode();
 		if (confirmationCode == null || pinResetRequestService.isExpired(confirmationCode))
 		{

--- a/core/src/main/java/nu/yona/server/goals/service/BudgetGoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/BudgetGoalDTO.java
@@ -68,6 +68,12 @@ public class BudgetGoalDTO extends GoalDTO
 		((BudgetGoal) existingGoal).setMaxDurationMinutes(maxDurationMinutes);
 	}
 
+	@Override
+	public boolean isNoGoGoal()
+	{
+		return maxDurationMinutes == 0;
+	}
+
 	public int getMaxDurationMinutes()
 	{
 		return maxDurationMinutes;

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDTO.java
@@ -5,6 +5,7 @@
 package nu.yona.server.goals.service;
 
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -69,6 +70,15 @@ public abstract class GoalDTO extends PolymorphicDTO
 		return endTime.isPresent();
 	}
 
+	public boolean wasActiveAtInterval(ZonedDateTime dateAtStartOfInterval, ChronoUnit timeUnit)
+	{
+		if (!creationTime.isPresent())
+		{
+			return false;
+		}
+		return creationTime.get().isBefore(dateAtStartOfInterval.plus(1, timeUnit));
+	}
+
 	@JsonIgnore
 	public UUID getActivityCategoryID()
 	{
@@ -92,6 +102,9 @@ public abstract class GoalDTO extends PolymorphicDTO
 	public abstract boolean isGoalChanged(Goal existingGoal);
 
 	public abstract void updateGoalEntity(Goal existingGoal);
+
+	@JsonIgnore
+	public abstract boolean isNoGoGoal();
 
 	public static GoalDTO createInstance(Goal goal)
 	{

--- a/core/src/main/java/nu/yona/server/goals/service/GoalService.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalService.java
@@ -45,18 +45,35 @@ public class GoalService
 		return user.getPrivateData().getGoals();
 	}
 
-	public GoalDTO getGoal(UUID userID, UUID goalID)
+	public GoalDTO getGoalForUserID(UUID userID, UUID goalID)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		return GoalDTO.createInstance(getGoalEntity(userEntity, goalID));
+	}
+
+	public GoalDTO getGoalForUserAnonymizedID(UUID userAnonymizedID, UUID goalID)
+	{
+		return userAnonymizedService.getUserAnonymized(userAnonymizedID).getGoals().stream().filter(g -> g.getID().equals(goalID))
+				.findFirst().orElseThrow(() -> GoalServiceException.goalNotFoundById(userAnonymizedID, goalID));
+	}
+
+	public Goal getGoalEntityForUserAnonymizedID(UUID userAnonymizedID, UUID goalID)
+	{
+		UserAnonymized userAnonymizedEntity = userAnonymizedService.getUserAnonymizedEntity(userAnonymizedID);
+		return getGoalEntity(userAnonymizedEntity, goalID);
 	}
 
 	private Goal getGoalEntity(User userEntity, UUID goalID)
 	{
-		Optional<Goal> foundGoal = userEntity.getGoals().stream().filter(goal -> goal.getID().equals(goalID)).findFirst();
+		return getGoalEntity(userEntity.getAnonymized(), goalID);
+	}
+
+	private Goal getGoalEntity(UserAnonymized userAnonymized, UUID goalID)
+	{
+		Optional<Goal> foundGoal = userAnonymized.getGoals().stream().filter(goal -> goal.getID().equals(goalID)).findFirst();
 		if (!foundGoal.isPresent())
 		{
-			throw GoalServiceException.goalNotFoundById(userEntity.getID(), goalID);
+			throw GoalServiceException.goalNotFoundById(userAnonymized.getID(), goalID);
 		}
 		return foundGoal.get();
 	}
@@ -65,7 +82,7 @@ public class GoalService
 	public GoalDTO addGoal(UUID userID, GoalDTO goal, Optional<String> message)
 	{
 		goal.validate();
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		UserAnonymized userAnonymizedEntity = userEntity.getAnonymized();
 		Optional<Goal> conflictingExistingGoal = userAnonymizedEntity.getGoals().stream()
 				.filter(existingGoal -> existingGoal.getActivityCategory().getID().equals(goal.getActivityCategoryID()))
@@ -88,7 +105,7 @@ public class GoalService
 	@Transactional
 	public GoalDTO updateGoal(UUID userID, UUID goalID, GoalDTO newGoalDTO, Optional<String> message)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		Goal existingGoal = getGoalEntity(userEntity, goalID);
 
 		if (newGoalDTO.getCreationTime().isPresent())
@@ -164,7 +181,7 @@ public class GoalService
 	@Transactional
 	public void removeGoal(UUID userID, UUID goalID, Optional<String> message)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		UserAnonymized userAnonymizedEntity = userEntity.getAnonymized();
 		Optional<Goal> goalEntity = userAnonymizedEntity.getGoals().stream().filter(goal -> goal.getID().equals(goalID))
 				.findFirst();

--- a/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDTO.java
@@ -133,6 +133,12 @@ public class TimeZoneGoalDTO extends GoalDTO
 		((TimeZoneGoal) existingGoal).setZones(zones);
 	}
 
+	@Override
+	public boolean isNoGoGoal()
+	{
+		return false;
+	}
+
 	public List<String> getZones()
 	{
 		return zones;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import nu.yona.server.Translator;
 import nu.yona.server.email.EmailService;
 import nu.yona.server.exceptions.EmailException;
-import nu.yona.server.goals.service.GoalDTO;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
 import nu.yona.server.messaging.service.MessageService;
@@ -80,7 +79,7 @@ public class BuddyService
 		if (canIncludePrivateData(buddyEntity))
 		{
 			result.setGoals(userAnonymizedService.getUserAnonymized(buddyEntity.getUserAnonymizedID()).getGoals().stream()
-					.map(g -> GoalDTO.createInstance(g)).collect(Collectors.toSet()));
+					.collect(Collectors.toSet()));
 		}
 		return result;
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
@@ -36,7 +36,7 @@ public class PinResetRequestService
 	@Transactional
 	public void requestPinReset(UUID userID)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		logger.info("User with mobile number '{}' and ID '{}' requested a pin reset confirmation code",
 				userEntity.getMobileNumber(), userID);
 		ConfirmationCode confirmationCode = createConfirmationCode(Moment.DELAYED);
@@ -50,7 +50,7 @@ public class PinResetRequestService
 	@Transactional
 	public void verifyPinResetConfirmationCode(UUID userID, String userProvidedConfirmationCode)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		logger.info("User with mobile number '{}' and ID '{}' requested to verity the pin reset confirmation code",
 				userEntity.getMobileNumber(), userID);
 		ConfirmationCode confirmationCode = userEntity.getPinResetConfirmationCode();
@@ -76,7 +76,7 @@ public class PinResetRequestService
 	@Transactional
 	public void resendPinResetConfirmationCode(UUID userID)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		logger.info("User with mobile number '{}' and ID '{}' requested to resend the pin reset confirmation code",
 				userEntity.getMobileNumber(), userEntity.getID());
 		ConfirmationCode confirmationCode = createConfirmationCode(Moment.IMMEDIATELY);
@@ -87,7 +87,7 @@ public class PinResetRequestService
 	@Transactional
 	public void clearPinResetRequest(UUID userID)
 	{
-		User userEntity = userService.getUserByID(userID);
+		User userEntity = userService.getUserEntityByID(userID);
 		logger.info("User with mobile number '{}' and ID '{}' requested to clear the pin reset confirmation code",
 				userEntity.getMobileNumber(), userEntity.getID());
 		setConfirmationCode(userEntity, null);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDTO.java
@@ -36,7 +36,7 @@ public class UserAnonymizedDTO
 
 	public static UserAnonymizedDTO createInstance(UserAnonymized entity)
 	{
-		return new UserAnonymizedDTO(entity.getID(), getGetGoalsIncludingHistoryItems(entity),
+		return new UserAnonymizedDTO(entity.getID(), getGoalsIncludingHistoryItems(entity),
 				MessageDestinationDTO.createInstance(entity.getAnonymousDestination()), entity.getBuddiesAnonymized().stream()
 						.map(buddyAnonymized -> buddyAnonymized.getID()).collect(Collectors.toSet()));
 	}
@@ -86,7 +86,7 @@ public class UserAnonymizedDTO
 		return goal;
 	}
 
-	static Set<GoalDTO> getGetGoalsIncludingHistoryItems(UserAnonymized userAnonymizedEntity)
+	static Set<GoalDTO> getGoalsIncludingHistoryItems(UserAnonymized userAnonymizedEntity)
 	{
 		Set<Goal> activeGoals = userAnonymizedEntity.getGoals();
 		Set<Goal> historyItems = getGoalHistoryItems(activeGoals);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDTO.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import nu.yona.server.goals.entities.Goal;
+import nu.yona.server.goals.service.GoalDTO;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
@@ -20,11 +21,11 @@ import nu.yona.server.subscriptions.entities.UserAnonymized;
 public class UserAnonymizedDTO
 {
 	private UUID id;
-	private Set<Goal> goals;
+	private Set<GoalDTO> goals;
 	private MessageDestinationDTO anonymousMessageDestination;
 	private Set<UUID> buddyAnonymizedIDs;
 
-	public UserAnonymizedDTO(UUID id, Set<Goal> goals, MessageDestinationDTO anonymousMessageDestination,
+	public UserAnonymizedDTO(UUID id, Set<GoalDTO> goals, MessageDestinationDTO anonymousMessageDestination,
 			Set<UUID> buddyAnonymizedIDs)
 	{
 		this.id = id;
@@ -35,7 +36,7 @@ public class UserAnonymizedDTO
 
 	public static UserAnonymizedDTO createInstance(UserAnonymized entity)
 	{
-		return new UserAnonymizedDTO(entity.getID(), entity.getGoals(),
+		return new UserAnonymizedDTO(entity.getID(), getGetGoalsIncludingHistoryItems(entity),
 				MessageDestinationDTO.createInstance(entity.getAnonymousDestination()), entity.getBuddiesAnonymized().stream()
 						.map(buddyAnonymized -> buddyAnonymized.getID()).collect(Collectors.toSet()));
 	}
@@ -45,7 +46,7 @@ public class UserAnonymizedDTO
 		return id;
 	}
 
-	public Set<Goal> getGoals()
+	public Set<GoalDTO> getGoals()
 	{
 		return goals;
 	}
@@ -76,18 +77,35 @@ public class UserAnonymizedDTO
 
 	public Optional<ZonedDateTime> getOldestGoalCreationTime()
 	{
-		return getGoals().stream().map(goal -> getOldestVersionOfGoal(goal).getCreationTime()).min(ZonedDateTime::compareTo);
+		return getGoals().stream().map(goal -> getOldestVersionOfGoal(goal).getCreationTime()).filter(Optional::isPresent)
+				.map(Optional::get).min(ZonedDateTime::compareTo);
 	}
 
-	private Goal getOldestVersionOfGoal(Goal goal)
+	private GoalDTO getOldestVersionOfGoal(GoalDTO goal)
 	{
-		if (!goal.getPreviousVersionOfThisGoal().isPresent())
-		{
-			// no earlier version
-			return goal;
-		}
+		return goal;
+	}
 
-		// recursive on previous version
-		return getOldestVersionOfGoal(goal.getPreviousVersionOfThisGoal().get());
+	static Set<GoalDTO> getGetGoalsIncludingHistoryItems(UserAnonymized userAnonymizedEntity)
+	{
+		Set<Goal> activeGoals = userAnonymizedEntity.getGoals();
+		Set<Goal> historyItems = getGoalHistoryItems(activeGoals);
+		Set<Goal> allGoals = new HashSet<>(activeGoals);
+		allGoals.addAll(historyItems);
+		return allGoals.stream().map(g -> GoalDTO.createInstance(g)).collect(Collectors.toSet());
+	}
+
+	private static Set<Goal> getGoalHistoryItems(Set<Goal> activeGoals)
+	{
+		Set<Goal> historyItems = new HashSet<>();
+		activeGoals.stream().forEach(g -> {
+			Optional<Goal> historyItem = g.getPreviousVersionOfThisGoal();
+			while (historyItem.isPresent())
+			{
+				historyItems.add(historyItem.get());
+				historyItem = historyItem.get().getPreviousVersionOfThisGoal();
+			}
+		});
+		return historyItems;
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDTO.java
@@ -4,8 +4,6 @@
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
 
-import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -19,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import nu.yona.server.exceptions.MobileNumberConfirmationException;
-import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.service.GoalDTO;
 import nu.yona.server.subscriptions.entities.User;
 
@@ -177,31 +174,9 @@ public class UserDTO
 		return new UserDTO(userEntity.getID(), userEntity.getFirstName(), userEntity.getLastName(), userEntity.getNickname(),
 				userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(), userEntity.getNamedMessageSource().getID(),
 				userEntity.getNamedMessageDestination().getID(), userEntity.getAnonymousMessageSource().getID(),
-				userEntity.getAnonymousMessageSource().getDestination().getID(), getGetGoalsIncludingHistoryItems(userEntity),
-				getBuddyIDs(userEntity), userEntity.getUserAnonymizedID(), VPNProfileDTO.createInstance(userEntity));
-	}
-
-	private static Set<GoalDTO> getGetGoalsIncludingHistoryItems(User userEntity)
-	{
-		Set<Goal> activeGoals = userEntity.getGoals();
-		Set<Goal> historyItems = getGoalHistoryItems(activeGoals);
-		Set<Goal> allGoals = new HashSet<>(activeGoals);
-		allGoals.addAll(historyItems);
-		return allGoals.stream().map(g -> GoalDTO.createInstance(g)).collect(Collectors.toSet());
-	}
-
-	private static Set<Goal> getGoalHistoryItems(Set<Goal> activeGoals)
-	{
-		Set<Goal> historyItems = new HashSet<>();
-		activeGoals.stream().forEach(g -> {
-			Optional<Goal> historyItem = g.getPreviousVersionOfThisGoal();
-			while (historyItem.isPresent())
-			{
-				historyItems.add(historyItem.get());
-				historyItem = historyItem.get().getPreviousVersionOfThisGoal();
-			}
-		});
-		return historyItems;
+				userEntity.getAnonymousMessageSource().getDestination().getID(),
+				UserAnonymizedDTO.getGetGoalsIncludingHistoryItems(userEntity.getAnonymized()), getBuddyIDs(userEntity),
+				userEntity.getUserAnonymizedID(), VPNProfileDTO.createInstance(userEntity));
 	}
 
 	private static Set<UUID> getBuddyIDs(User userEntity)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDTO.java
@@ -175,7 +175,7 @@ public class UserDTO
 				userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(), userEntity.getNamedMessageSource().getID(),
 				userEntity.getNamedMessageDestination().getID(), userEntity.getAnonymousMessageSource().getID(),
 				userEntity.getAnonymousMessageSource().getDestination().getID(),
-				UserAnonymizedDTO.getGetGoalsIncludingHistoryItems(userEntity.getAnonymized()), getBuddyIDs(userEntity),
+				UserAnonymizedDTO.getGoalsIncludingHistoryItems(userEntity.getAnonymized()), getBuddyIDs(userEntity),
 				userEntity.getUserAnonymizedID(), VPNProfileDTO.createInstance(userEntity));
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -76,19 +76,19 @@ public class UserService
 	@Transactional
 	public boolean canAccessPrivateData(UUID id)
 	{
-		return getUserByID(id).canAccessPrivateData();
+		return getUserEntityByID(id).canAccessPrivateData();
 	}
 
 	@Transactional
 	public UserDTO getPublicUser(UUID id)
 	{
-		return UserDTO.createInstance(getUserByID(id));
+		return UserDTO.createInstance(getUserEntityByID(id));
 	}
 
 	@Transactional
 	public UserDTO getPrivateUser(UUID id)
 	{
-		User user = getUserByID(id);
+		User user = getUserEntityByID(id);
 		handleBuddyUsersRemovedWhileOffline(user);
 		return UserDTO.createInstanceWithPrivateData(user);
 	}
@@ -224,7 +224,7 @@ public class UserService
 	@Transactional
 	public UserDTO confirmMobileNumber(UUID userID, String userProvidedConfirmationCode)
 	{
-		User userEntity = getUserByID(userID);
+		User userEntity = getUserEntityByID(userID);
 		ConfirmationCode confirmationCode = userEntity.getMobileNumberConfirmationCode();
 
 		verifyConfirmationCode(userEntity, confirmationCode, userProvidedConfirmationCode,
@@ -250,7 +250,7 @@ public class UserService
 	@Transactional
 	public Object resendMobileNumberConfirmationCode(UUID userID)
 	{
-		User userEntity = getUserByID(userID);
+		User userEntity = getUserEntityByID(userID);
 		logger.info("User with mobile number '{}' and ID '{}' requests to resend the mobile number confirmation code",
 				userEntity.getMobileNumber(), userEntity.getID());
 		ConfirmationCode confirmationCode = createConfirmationCode();
@@ -275,7 +275,7 @@ public class UserService
 
 		logger.info("User with mobile number '{}' and ID '{}' created on buddy request", buddyUser.getMobileNumber(),
 				buddyUser.getID());
-		return getUserByID(savedUserID);
+		return getUserEntityByID(savedUserID);
 	}
 
 	private User addUserCreatedOnBuddyRequestInSubTransaction(UserDTO buddyUserResource)
@@ -294,7 +294,7 @@ public class UserService
 	@Transactional
 	public UserDTO updateUser(UUID id, UserDTO user)
 	{
-		User originalUserEntity = getUserByID(id);
+		User originalUserEntity = getUserEntityByID(id);
 		validateUpdateRequest(user, originalUserEntity);
 
 		boolean isMobileNumberDifferent = isMobileNumberDifferent(user, originalUserEntity);
@@ -337,7 +337,7 @@ public class UserService
 	@Transactional
 	public UserDTO updateUserCreatedOnBuddyRequest(UUID id, String tempPassword, UserDTO userResource)
 	{
-		User originalUserEntity = getUserByID(id);
+		User originalUserEntity = getUserEntityByID(id);
 		if (!originalUserEntity.isCreatedOnBuddyRequest())
 		{
 			// security check: should not be able to replace the password on an existing user
@@ -375,7 +375,7 @@ public class UserService
 	@Transactional
 	public void deleteUser(UUID id, Optional<String> message)
 	{
-		User userEntity = getUserByID(id);
+		User userEntity = getUserEntityByID(id);
 
 		userEntity.getBuddies().forEach(buddyEntity -> buddyService.removeBuddyInfoForBuddy(userEntity, buddyEntity, message,
 				DropBuddyReason.USER_ACCOUNT_DELETED));
@@ -409,7 +409,7 @@ public class UserService
 			throw InvalidDataException.emptyBuddyId();
 		}
 
-		User userEntity = getUserByID(user.getID());
+		User userEntity = getUserEntityByID(user.getID());
 		userEntity.assertMobileNumberConfirmed();
 
 		Buddy buddyEntity = Buddy.getRepository().findOne(buddy.getID());
@@ -448,7 +448,7 @@ public class UserService
 	 * @param id the ID of the user
 	 * @return The user entity (never null)
 	 */
-	public User getUserByID(UUID id)
+	public User getUserEntityByID(UUID id)
 	{
 		if (id == null)
 		{
@@ -478,7 +478,7 @@ public class UserService
 	 */
 	public User getValidatedUserbyID(UUID id)
 	{
-		User retVal = getUserByID(id);
+		User retVal = getUserEntityByID(id);
 		retVal.assertMobileNumberConfirmed();
 
 		return retVal;

--- a/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTests.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTests.java
@@ -45,6 +45,7 @@ import nu.yona.server.goals.entities.ActivityCategory;
 import nu.yona.server.goals.entities.BudgetGoal;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.entities.TimeZoneGoal;
+import nu.yona.server.goals.service.GoalService;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.properties.AnalysisServiceProperties;
 import nu.yona.server.properties.YonaProperties;
@@ -60,6 +61,8 @@ public class ActivityServiceTests
 
 	@Mock
 	private UserService mockUserService;
+	@Mock
+	private GoalService mockGoalService;
 	@Mock
 	private YonaProperties mockYonaProperties;
 	@Mock
@@ -123,6 +126,13 @@ public class ActivityServiceTests
 		// Stub the UserAnonymizedService to return our user.
 		when(mockUserAnonymizedService.getUserAnonymized(userAnonID)).thenReturn(userAnon);
 		when(mockUserAnonymizedService.getUserAnonymizedEntity(userAnonID)).thenReturn(userAnonEntity);
+
+		// Stub the GoalService to return our goals.
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, gamblingGoal.getID())).thenReturn(gamblingGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, newsGoal.getID())).thenReturn(newsGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, gamingGoal.getID())).thenReturn(gamingGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, socialGoal.getID())).thenReturn(socialGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, shoppingGoal.getID())).thenReturn(shoppingGoal);
 	}
 
 	private Map<Locale, String> usString(String string)

--- a/core/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTests.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTests.java
@@ -55,6 +55,7 @@ import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.entities.TimeZoneGoal;
 import nu.yona.server.goals.service.ActivityCategoryDTO;
 import nu.yona.server.goals.service.ActivityCategoryService;
+import nu.yona.server.goals.service.GoalService;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
 import nu.yona.server.messaging.service.MessageService;
@@ -73,6 +74,8 @@ public class AnalysisEngineServiceTests
 	private ActivityCategoryService mockActivityCategoryService;
 	@Mock
 	private UserAnonymizedService mockUserAnonymizedService;
+	@Mock
+	private GoalService mockGoalService;
 	@Mock
 	private MessageService mockMessageService;
 	@Mock
@@ -160,6 +163,13 @@ public class AnalysisEngineServiceTests
 		// Stub the UserAnonymizedService to return our user.
 		when(mockUserAnonymizedService.getUserAnonymized(userAnonID)).thenReturn(userAnon);
 		when(mockUserAnonymizedService.getUserAnonymizedEntity(userAnonID)).thenReturn(userAnonEntity);
+
+		// Stub the GoalService to return our goals.
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, gamblingGoal.getID())).thenReturn(gamblingGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, newsGoal.getID())).thenReturn(newsGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, gamingGoal.getID())).thenReturn(gamingGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, socialGoal.getID())).thenReturn(socialGoal);
+		when(mockGoalService.getGoalEntityForUserAnonymizedID(userAnonID, shoppingGoal.getID())).thenReturn(shoppingGoal);
 	}
 
 	private Map<Locale, String> usString(String string)


### PR DESCRIPTION
instead of goal entities

Along with this, the following is done:
* Add a test that failed before the fix (failed to lazily initialize a collection)
* Renamed GoalService.getGoal into getGoalForUserID and added getGoalForUserAnonymizedID
* Renamed UserService.getUserByID into getUserEntityByID, in alignment with other get...Entity methods
* Extended GoalService with operations to deal with user anonymized