### PR TITLE
YD-274 Remove activities along with goals

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
@@ -36,5 +36,9 @@ public interface DayActivityRepository extends CrudRepository<DayActivity, UUID>
 	@Query("delete from DayActivity a where a.userAnonymized.id = :userAnonymizedID")
 	void deleteAllForUser(@Param("userAnonymizedID") UUID userAnonymizedID);
 
+	@Modifying
+	@Query("delete from DayActivity a where a.goal.id = :goalID")
+	void deleteAllForGoal(@Param("goalID") UUID goalID);
+
 	Set<DayActivity> findByGoal(Goal goal);
 }

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivityRepository.java
@@ -37,5 +37,9 @@ public interface WeekActivityRepository extends CrudRepository<WeekActivity, UUI
 	@Query("delete from WeekActivity a where a.userAnonymized.id = :userAnonymizedID")
 	void deleteAllForUser(@Param("userAnonymizedID") UUID userAnonymizedID);
 
+	@Modifying
+	@Query("delete from WeekActivity a where a.goal.id = :goalID")
+	void deleteAllForGoal(@Param("goalID") UUID goalID);
+
 	Set<WeekActivity> findByGoal(Goal goal);
 }


### PR DESCRIPTION
The test is very basic and needs to be extended, but it proves the basics: the related activity entries are removed.