### PR TITLE
YD-309 Now ignores activities occuring before the goal creation time

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -162,10 +162,10 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def bob = richardAndBob.bob
 		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		ZonedDateTime testStartTime = YonaServer.now
-		ZonedDateTime startTime = testStartTime.minusHuors(1)
-		ZonedDateTime endTime = testStartTime
-		ZonedDateTime startTime1 = endTime.minusSeconds(10)
-		ZonedDateTime endTime1 = endTime
+		ZonedDateTime startTime = testStartTime.minusHours(1)
+		ZonedDateTime endTime = testStartTime.minusSeconds(10)
+		ZonedDateTime startTime1 = endTime
+		ZonedDateTime endTime1 = testStartTime
 
 		when:
 		def response = appService.postAppActivityToAnalysisEngine(richard,

--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -12,7 +12,6 @@ import java.time.Duration
 import java.time.ZonedDateTime
 
 import nu.yona.server.test.AppActivity
-import spock.lang.IgnoreRest
 
 class AppActivityTest extends AbstractAppServiceIntegrationTest
 {

--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -46,9 +46,10 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		ZonedDateTime testStartTime = YonaServer.now
-		ZonedDateTime startTime = testStartTime
-		ZonedDateTime endTime = testStartTime.plusHours(1)
+		ZonedDateTime startTime = testStartTime.minusHours(1)
+		ZonedDateTime endTime = testStartTime
 
 		when:
 		def response = appService.postAppActivityToAnalysisEngine(richard, AppActivity.singleActivity("Poker App", startTime, endTime))
@@ -85,10 +86,11 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		Duration offset = Duration.ofMinutes(45) // Off by 45 minutes
 		ZonedDateTime testStartTime = YonaServer.now
-		ZonedDateTime startTime = testStartTime
-		ZonedDateTime endTime = testStartTime.plusHours(1)
+		ZonedDateTime startTime = testStartTime.minusHours(1)
+		ZonedDateTime endTime = testStartTime
 
 		when:
 		def testStartTimeWrong = testStartTime.plus(offset)
@@ -128,11 +130,12 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		ZonedDateTime testStartTime = YonaServer.now
-		ZonedDateTime startTime = testStartTime
-		ZonedDateTime endTime = testStartTime.plusHours(1)
-		ZonedDateTime startTime1 = testStartTime
-		ZonedDateTime endTime1 = testStartTime.plusSeconds(10)
+		ZonedDateTime startTime = testStartTime.minusHours(1)
+		ZonedDateTime endTime = testStartTime
+		ZonedDateTime startTime1 = testStartTime.minusSeconds(10)
+		ZonedDateTime endTime1 = testStartTime
 
 		when:
 		appService.postAppActivityToAnalysisEngine(richard, AppActivity.singleActivity("Poker App", startTime, endTime))
@@ -157,11 +160,12 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		ZonedDateTime testStartTime = YonaServer.now
-		ZonedDateTime startTime = testStartTime
-		ZonedDateTime endTime = testStartTime.plusHours(1)
-		ZonedDateTime startTime1 = endTime
-		ZonedDateTime endTime1 = endTime.plusSeconds(10)
+		ZonedDateTime startTime = testStartTime.minusHuors(1)
+		ZonedDateTime endTime = testStartTime
+		ZonedDateTime startTime1 = endTime.minusSeconds(10)
+		ZonedDateTime endTime1 = endTime
 
 		when:
 		def response = appService.postAppActivityToAnalysisEngine(richard,

--- a/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -67,12 +67,7 @@ public class AnalysisEngineService
 	private Duration determineDeviceTimeOffset(AppActivityDTO appActivities)
 	{
 		Duration offset = Duration.between(ZonedDateTime.now(), appActivities.getDeviceDateTime());
-		return (offset.abs().compareTo(Duration.ofSeconds(10)) > 0) ? offset : Duration.ZERO; // Ignore
-																								// if
-																								// less
-																								// than
-																								// 10
-																								// seconds
+		return (offset.abs().compareTo(Duration.ofSeconds(10)) > 0) ? offset : Duration.ZERO; // Ignore if less than 10 seconds
 	}
 
 	private ActivityPayload createActivityPayload(Duration deviceTimeOffset, AppActivityDTO.Activity appActivity,
@@ -134,8 +129,7 @@ public class AnalysisEngineService
 		{
 			if (isBeyondSkipWindowAfterLastRegisteredActivity(payload, lastRegisteredActivity))
 			{
-				// Update message only if it is within five seconds to avoid
-				// unnecessary cache flushes.
+				// Update message only if it is within five seconds to avoid unnecessary cache flushes.
 				updateActivityEndTime(payload, userAnonymized, matchingGoal, dayActivity, lastRegisteredActivity);
 			}
 		}

--- a/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -33,7 +33,8 @@ import nu.yona.server.subscriptions.service.UserAnonymizedDTO;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
 
 @Service
-public class AnalysisEngineService {
+public class AnalysisEngineService
+{
 	private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
 	@Autowired
 	private YonaProperties yonaProperties;
@@ -50,10 +51,12 @@ public class AnalysisEngineService {
 	@Autowired(required = false)
 	private DayActivityRepository dayActivityRepository;
 
-	public void analyze(UUID userAnonymizedID, AppActivityDTO appActivities) {
+	public void analyze(UUID userAnonymizedID, AppActivityDTO appActivities)
+	{
 		UserAnonymizedDTO userAnonymized = userAnonymizedService.getUserAnonymized(userAnonymizedID);
 		Duration deviceTimeOffset = determineDeviceTimeOffset(appActivities);
-		for (AppActivityDTO.Activity appActivity : appActivities.getActivities()) {
+		for (AppActivityDTO.Activity appActivity : appActivities.getActivities())
+		{
 			Set<ActivityCategoryDTO> matchingActivityCategories = activityCategoryService
 					.getMatchingCategoriesForApp(appActivity.getApplication());
 			analyze(createActivityPayload(deviceTimeOffset, appActivity, userAnonymized), userAnonymized,
@@ -61,7 +64,8 @@ public class AnalysisEngineService {
 		}
 	}
 
-	private Duration determineDeviceTimeOffset(AppActivityDTO appActivities) {
+	private Duration determineDeviceTimeOffset(AppActivityDTO appActivities)
+	{
 		Duration offset = Duration.between(ZonedDateTime.now(), appActivities.getDeviceDateTime());
 		return (offset.abs().compareTo(Duration.ofSeconds(10)) > 0) ? offset : Duration.ZERO; // Ignore
 																								// if
@@ -72,36 +76,41 @@ public class AnalysisEngineService {
 	}
 
 	private ActivityPayload createActivityPayload(Duration deviceTimeOffset, AppActivityDTO.Activity appActivity,
-			UserAnonymizedDTO userAnonymized) {
+			UserAnonymizedDTO userAnonymized)
+	{
 		ZonedDateTime correctedStartTime = correctTime(deviceTimeOffset, appActivity.getStartTime());
 		ZonedDateTime correctedEndTime = correctTime(deviceTimeOffset, appActivity.getEndTime());
-		return ActivityPayload.createInstance(userAnonymized, correctedStartTime, correctedEndTime,
-				appActivity.getApplication());
+		return ActivityPayload.createInstance(userAnonymized, correctedStartTime, correctedEndTime, appActivity.getApplication());
 	}
 
-	private ZonedDateTime correctTime(Duration deviceTimeOffset, ZonedDateTime time) {
+	private ZonedDateTime correctTime(Duration deviceTimeOffset, ZonedDateTime time)
+	{
 		return time.minus(deviceTimeOffset);
 	}
 
-	public void analyze(NetworkActivityDTO networkActivity) {
+	public void analyze(NetworkActivityDTO networkActivity)
+	{
 		UserAnonymizedDTO userAnonymized = userAnonymizedService.getUserAnonymized(networkActivity.getVPNLoginID());
 		Set<ActivityCategoryDTO> matchingActivityCategories = activityCategoryService
 				.getMatchingCategoriesForSmoothwallCategories(networkActivity.getCategories());
-		analyze(ActivityPayload.createInstance(userAnonymized, networkActivity), userAnonymized,
-				matchingActivityCategories);
+		analyze(ActivityPayload.createInstance(userAnonymized, networkActivity), userAnonymized, matchingActivityCategories);
 	}
 
 	private void analyze(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Set<ActivityCategoryDTO> matchingActivityCategories) {
+			Set<ActivityCategoryDTO> matchingActivityCategories)
+	{
 		Set<GoalDTO> matchingGoalsOfUser = determineMatchingGoalsForUser(userAnonymized, matchingActivityCategories,
 				payload.startTime);
-		for (GoalDTO matchingGoalOfUser : matchingGoalsOfUser) {
+		for (GoalDTO matchingGoalOfUser : matchingGoalsOfUser)
+		{
 			addOrUpdateActivity(payload, userAnonymized, matchingGoalOfUser);
 		}
 	}
 
-	private void addOrUpdateActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal) {
-		if (isCrossDayActivity(payload, userAnonymized)) {
+	private void addOrUpdateActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal)
+	{
+		if (isCrossDayActivity(payload, userAnonymized))
+		{
 			// assumption: activity never crosses 2 days
 			ActivityPayload truncatedPayload = ActivityPayload.copyTillEndTime(payload,
 					getEndOfDay(payload.startTime, userAnonymized));
@@ -110,143 +119,174 @@ public class AnalysisEngineService {
 
 			addOrUpdateDayTruncatedActivity(truncatedPayload, userAnonymized, matchingGoal);
 			addOrUpdateDayTruncatedActivity(nextDayPayload, userAnonymized, matchingGoal);
-		} else {
+		}
+		else
+		{
 			addOrUpdateDayTruncatedActivity(payload, userAnonymized, matchingGoal);
 		}
 	}
 
-	private void addOrUpdateDayTruncatedActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			GoalDTO matchingGoal) {
+	private void addOrUpdateDayTruncatedActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal)
+	{
 		DayActivityCacheResult dayActivity = getRegisteredDayActivity(payload, userAnonymized, matchingGoal);
 		Activity lastRegisteredActivity = dayActivity.content == null ? null : dayActivity.content.getLastActivity();
-		if (canCombineWithLastRegisteredActivity(payload, lastRegisteredActivity)) {
-			if (isBeyondSkipWindowAfterLastRegisteredActivity(payload, lastRegisteredActivity)) {
+		if (canCombineWithLastRegisteredActivity(payload, lastRegisteredActivity))
+		{
+			if (isBeyondSkipWindowAfterLastRegisteredActivity(payload, lastRegisteredActivity))
+			{
 				// Update message only if it is within five seconds to avoid
 				// unnecessary cache flushes.
 				updateActivityEndTime(payload, userAnonymized, matchingGoal, dayActivity, lastRegisteredActivity);
 			}
-		} else {
+		}
+		else
+		{
 			addActivity(payload, userAnonymized, matchingGoal, dayActivity);
 		}
 	}
 
-	private boolean isBeyondSkipWindowAfterLastRegisteredActivity(ActivityPayload payload,
-			Activity lastRegisteredActivity) {
+	private boolean isBeyondSkipWindowAfterLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
+	{
 		return Duration.between(lastRegisteredActivity.getEndTime(), payload.endTime)
 				.compareTo(yonaProperties.getAnalysisService().getUpdateSkipWindow()) >= 0;
 	}
 
-	private boolean canCombineWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity) {
-		if (lastRegisteredActivity == null) {
+	private boolean canCombineWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
+	{
+		if (lastRegisteredActivity == null)
+		{
 			return false;
 		}
 
-		if (precedesLastRegisteredActivity(payload, lastRegisteredActivity)) {
+		if (precedesLastRegisteredActivity(payload, lastRegisteredActivity))
+		{
 			// This can happen with app activity.
 			// Do not try to combine, add separately.
 			return false;
 		}
 
-		if (isBeyondCombineIntervalWithLastRegisteredActivity(payload, lastRegisteredActivity)) {
+		if (isBeyondCombineIntervalWithLastRegisteredActivity(payload, lastRegisteredActivity))
+		{
 			return false;
 		}
 
 		return true;
 	}
 
-	private boolean precedesLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity) {
+	private boolean precedesLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
+	{
 		return payload.startTime.isBefore(lastRegisteredActivity.getStartTime());
 	}
 
-	private boolean isBeyondCombineIntervalWithLastRegisteredActivity(ActivityPayload payload,
-			Activity lastRegisteredActivity) {
+	private boolean isBeyondCombineIntervalWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
+	{
 		ZonedDateTime intervalEndTime = lastRegisteredActivity.getEndTime()
 				.plus(yonaProperties.getAnalysisService().getConflictInterval());
 		return payload.startTime.isAfter(intervalEndTime);
 	}
 
 	private DayActivityCacheResult getRegisteredDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			GoalDTO matchingGoal) {
+			GoalDTO matchingGoal)
+	{
 		DayActivity lastRegisteredDayActivity = cacheService.fetchLastDayActivityForUser(userAnonymized.getID(),
 				matchingGoal.getID());
-		if (lastRegisteredDayActivity == null) {
+		if (lastRegisteredDayActivity == null)
+		{
 			return DayActivityCacheResult.none();
-		} else if (isOnPrecedingDay(payload, lastRegisteredDayActivity)) {
+		}
+		else if (isOnPrecedingDay(payload, lastRegisteredDayActivity))
+		{
 			// Fetch from the database because it is no longer in the cache
 			return DayActivityCacheResult.preceding(dayActivityRepository.findOne(userAnonymized.getID(),
 					getStartOfDay(payload.startTime, userAnonymized).toLocalDate(), matchingGoal.getID()));
-		} else if (isOnFollowingDay(payload, lastRegisteredDayActivity)) {
+		}
+		else if (isOnFollowingDay(payload, lastRegisteredDayActivity))
+		{
 			return DayActivityCacheResult.following();
-		} else {
+		}
+		else
+		{
 			return DayActivityCacheResult.fromCache(lastRegisteredDayActivity);
 		}
 	}
 
-	private boolean isOnFollowingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity) {
+	private boolean isOnFollowingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity)
+	{
 		return payload.startTime.isAfter(lastRegisteredDayActivity.getEndTime());
 	}
 
-	private boolean isOnPrecedingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity) {
+	private boolean isOnPrecedingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity)
+	{
 		return payload.startTime.isBefore(lastRegisteredDayActivity.getStartTime());
 	}
 
-	private boolean isCrossDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized) {
-		return getStartOfDay(payload.startTime, userAnonymized)
-				.isBefore(getStartOfDay(payload.endTime, userAnonymized));
+	private boolean isCrossDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized)
+	{
+		return getStartOfDay(payload.startTime, userAnonymized).isBefore(getStartOfDay(payload.endTime, userAnonymized));
 	}
 
 	private void addActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal,
-			DayActivityCacheResult dayActivityCacheResult) {
-		Goal matchingGoalEntity = goalService.getGoalEntityForUserAnonymizedID(userAnonymized.getID(),
-				matchingGoal.getID());
+			DayActivityCacheResult dayActivityCacheResult)
+	{
+		Goal matchingGoalEntity = goalService.getGoalEntityForUserAnonymizedID(userAnonymized.getID(), matchingGoal.getID());
 		DayActivity updatedDayActivity = createNewActivity(dayActivityCacheResult.content, payload, userAnonymized,
 				matchingGoalEntity);
 		dayActivityRepository.save(updatedDayActivity);
-		if (dayActivityCacheResult.shouldUpdateCache()) {
+		if (dayActivityCacheResult.shouldUpdateCache())
+		{
 			cacheService.updateLastDayActivityForUser(updatedDayActivity);
 		}
 
-		if (matchingGoal.isNoGoGoal()) {
+		if (matchingGoal.isNoGoGoal())
+		{
 			sendConflictMessageToAllDestinationsOfUser(payload, userAnonymized, updatedDayActivity.getLastActivity(),
 					matchingGoalEntity);
 		}
 	}
 
 	private void updateActivityEndTime(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal,
-			DayActivityCacheResult dayActivity, Activity activity) {
+			DayActivityCacheResult dayActivity, Activity activity)
+	{
 		assert userAnonymized.getID().equals(dayActivity.content.getUserAnonymized().getID());
 		assert matchingGoal.getID().equals(dayActivity.content.getGoal().getID());
 
 		activity.setEndTime(payload.endTime);
 		dayActivityRepository.save(dayActivity.content);
-		if (dayActivity.shouldUpdateCache()) {
+		if (dayActivity.shouldUpdateCache())
+		{
 			cacheService.updateLastDayActivityForUser(dayActivity.content);
 		}
 	}
 
-	private ZonedDateTime getStartOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
+	private ZonedDateTime getStartOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
+	{
 		return time.withZoneSameInstant(ZoneId.of(userAnonymized.getTimeZoneId())).truncatedTo(ChronoUnit.DAYS);
 	}
 
-	private ZonedDateTime getEndOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
+	private ZonedDateTime getEndOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
+	{
 		return getStartOfDay(time, userAnonymized).plusHours(23).plusMinutes(59).plusSeconds(59);
 	}
 
-	private ZonedDateTime getStartOfWeek(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
+	private ZonedDateTime getStartOfWeek(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
+	{
 		ZonedDateTime startOfDay = getStartOfDay(time, userAnonymized);
-		switch (startOfDay.getDayOfWeek()) {
-		case SUNDAY:
-			// take as the first day of week
-			return startOfDay;
-		default:
-			// MONDAY=1, etc.
-			return startOfDay.minusDays(startOfDay.getDayOfWeek().getValue());
+		switch (startOfDay.getDayOfWeek())
+		{
+			case SUNDAY:
+				// take as the first day of week
+				return startOfDay;
+			default:
+				// MONDAY=1, etc.
+				return startOfDay.minusDays(startOfDay.getDayOfWeek().getValue());
 		}
 	}
 
-	private DayActivity createNewActivity(DayActivity dayActivity, ActivityPayload payload,
-			UserAnonymizedDTO userAnonymized, Goal matchingGoal) {
-		if (dayActivity == null) {
+	private DayActivity createNewActivity(DayActivity dayActivity, ActivityPayload payload, UserAnonymizedDTO userAnonymized,
+			Goal matchingGoal)
+	{
+		if (dayActivity == null)
+		{
 			dayActivity = createNewDayActivity(payload, userAnonymized, matchingGoal);
 		}
 
@@ -256,16 +296,18 @@ public class AnalysisEngineService {
 		return dayActivity;
 	}
 
-	private ZonedDateTime ensureMinimumDurationOneMinute(ActivityPayload payload) {
+	private ZonedDateTime ensureMinimumDurationOneMinute(ActivityPayload payload)
+	{
 		Duration duration = Duration.between(payload.startTime, payload.endTime);
-		if (duration.compareTo(ONE_MINUTE) < 0) {
+		if (duration.compareTo(ONE_MINUTE) < 0)
+		{
 			return payload.endTime.plus(ONE_MINUTE);
 		}
 		return payload.endTime;
 	}
 
-	private DayActivity createNewDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Goal matchingGoal) {
+	private DayActivity createNewDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, Goal matchingGoal)
+	{
 		UserAnonymized userAnonymizedEntity = userAnonymizedService.getUserAnonymizedEntity(userAnonymized.getID());
 
 		DayActivity dayActivity = DayActivity.createInstance(userAnonymizedEntity, matchingGoal,
@@ -274,7 +316,8 @@ public class AnalysisEngineService {
 		ZonedDateTime startOfWeek = getStartOfWeek(payload.startTime, userAnonymized);
 		WeekActivity weekActivity = cacheService.fetchWeekActivityForUser(userAnonymized.getID(), matchingGoal.getID(),
 				startOfWeek.toLocalDate());
-		if (weekActivity == null) {
+		if (weekActivity == null)
+		{
 			weekActivity = WeekActivity.createInstance(userAnonymizedEntity, matchingGoal, startOfWeek);
 		}
 		dayActivityRepository.save(dayActivity);
@@ -283,15 +326,17 @@ public class AnalysisEngineService {
 		return dayActivity;
 	}
 
-	public Set<String> getRelevantSmoothwallCategories() {
-		return activityCategoryService.getAllActivityCategories().stream()
-				.flatMap(g -> g.getSmoothwallCategories().stream()).collect(Collectors.toSet());
+	public Set<String> getRelevantSmoothwallCategories()
+	{
+		return activityCategoryService.getAllActivityCategories().stream().flatMap(g -> g.getSmoothwallCategories().stream())
+				.collect(Collectors.toSet());
 	}
 
 	private void sendConflictMessageToAllDestinationsOfUser(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Activity activity, Goal matchingGoal) {
-		GoalConflictMessage selfGoalConflictMessage = GoalConflictMessage.createInstance(userAnonymized.getID(),
-				activity, matchingGoal, payload.url);
+			Activity activity, Goal matchingGoal)
+	{
+		GoalConflictMessage selfGoalConflictMessage = GoalConflictMessage.createInstance(userAnonymized.getID(), activity,
+				matchingGoal, payload.url);
 		messageService.sendMessage(selfGoalConflictMessage, userAnonymized.getAnonymousDestination());
 
 		messageService.broadcastMessageToBuddies(userAnonymized,
@@ -299,7 +344,8 @@ public class AnalysisEngineService {
 	}
 
 	private Set<GoalDTO> determineMatchingGoalsForUser(UserAnonymizedDTO userAnonymized,
-			Set<ActivityCategoryDTO> matchingActivityCategories, ZonedDateTime activityStartTime) {
+			Set<ActivityCategoryDTO> matchingActivityCategories, ZonedDateTime activityStartTime)
+	{
 		Set<UUID> matchingActivityCategoryIDs = matchingActivityCategories.stream().map(ac -> ac.getID())
 				.collect(Collectors.toSet());
 		Set<GoalDTO> goalsOfUser = userAnonymized.getGoals();
@@ -309,70 +355,84 @@ public class AnalysisEngineService {
 		return matchingGoalsOfUser;
 	}
 
-	private enum DayActivityCacheResultStatus {
+	private enum DayActivityCacheResultStatus
+	{
 		CACHE_EMPTY, FROM_CACHE, FOLLOWING_LAST_CACHED, PRECEDING_LAST_CACHED
 	}
 
-	private static class DayActivityCacheResult {
+	private static class DayActivityCacheResult
+	{
 		public final DayActivityCacheResultStatus status;
 		public DayActivity content;
 
-		public DayActivityCacheResult(DayActivity content, DayActivityCacheResultStatus status) {
+		public DayActivityCacheResult(DayActivity content, DayActivityCacheResultStatus status)
+		{
 			this.status = status;
 			this.content = content;
 		}
 
-		public boolean shouldUpdateCache() {
+		public boolean shouldUpdateCache()
+		{
 			return this.status != DayActivityCacheResultStatus.PRECEDING_LAST_CACHED;
 		}
 
-		public static DayActivityCacheResult none() {
+		public static DayActivityCacheResult none()
+		{
 			return new DayActivityCacheResult(null, DayActivityCacheResultStatus.CACHE_EMPTY);
 		}
 
-		public static DayActivityCacheResult fromCache(DayActivity lastRegisteredDayActivity) {
+		public static DayActivityCacheResult fromCache(DayActivity lastRegisteredDayActivity)
+		{
 			return new DayActivityCacheResult(lastRegisteredDayActivity, DayActivityCacheResultStatus.FROM_CACHE);
 		}
 
-		public static DayActivityCacheResult following() {
+		public static DayActivityCacheResult following()
+		{
 			return new DayActivityCacheResult(null, DayActivityCacheResultStatus.FROM_CACHE);
 		}
 
-		public static DayActivityCacheResult preceding(DayActivity resultFromDatabase) {
+		public static DayActivityCacheResult preceding(DayActivity resultFromDatabase)
+		{
 			return new DayActivityCacheResult(resultFromDatabase, DayActivityCacheResultStatus.PRECEDING_LAST_CACHED);
 		}
 	}
 
-	private static class ActivityPayload {
+	private static class ActivityPayload
+	{
 		public final Optional<String> url;
 		public final ZonedDateTime startTime;
 		public final ZonedDateTime endTime;
 		public final Optional<String> application;
 
 		private ActivityPayload(Optional<String> url, ZonedDateTime startTime, ZonedDateTime endTime,
-				Optional<String> application) {
+				Optional<String> application)
+		{
 			this.url = url;
 			this.startTime = startTime;
 			this.endTime = endTime;
 			this.application = application;
 		}
 
-		static ActivityPayload copyTillEndTime(ActivityPayload payload, ZonedDateTime endTime) {
+		static ActivityPayload copyTillEndTime(ActivityPayload payload, ZonedDateTime endTime)
+		{
 			return new ActivityPayload(payload.url, payload.startTime, endTime, payload.application);
 		}
 
-		static ActivityPayload copyFromStartTime(ActivityPayload payload, ZonedDateTime startTime) {
+		static ActivityPayload copyFromStartTime(ActivityPayload payload, ZonedDateTime startTime)
+		{
 			return new ActivityPayload(payload.url, startTime, payload.endTime, payload.application);
 		}
 
-		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, NetworkActivityDTO networkActivity) {
+		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, NetworkActivityDTO networkActivity)
+		{
 			ZonedDateTime startTime = networkActivity.getEventTime().orElse(ZonedDateTime.now())
 					.withZoneSameInstant(ZoneId.of(userAnonymized.getTimeZoneId()));
 			return new ActivityPayload(Optional.of(networkActivity.getURL()), startTime, startTime, Optional.empty());
 		}
 
-		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, ZonedDateTime startTime,
-				ZonedDateTime endTime, String application) {
+		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, ZonedDateTime startTime, ZonedDateTime endTime,
+				String application)
+		{
 			ZoneId userTimeZone = ZoneId.of(userAnonymized.getTimeZoneId());
 			return new ActivityPayload(Optional.empty(), startTime.withZoneSameInstant(userTimeZone),
 					endTime.withZoneSameInstant(userTimeZone), Optional.of(application));

--- a/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -33,8 +33,7 @@ import nu.yona.server.subscriptions.service.UserAnonymizedDTO;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
 
 @Service
-public class AnalysisEngineService
-{
+public class AnalysisEngineService {
 	private static final Duration ONE_MINUTE = Duration.ofMinutes(1);
 	@Autowired
 	private YonaProperties yonaProperties;
@@ -51,12 +50,10 @@ public class AnalysisEngineService
 	@Autowired(required = false)
 	private DayActivityRepository dayActivityRepository;
 
-	public void analyze(UUID userAnonymizedID, AppActivityDTO appActivities)
-	{
+	public void analyze(UUID userAnonymizedID, AppActivityDTO appActivities) {
 		UserAnonymizedDTO userAnonymized = userAnonymizedService.getUserAnonymized(userAnonymizedID);
 		Duration deviceTimeOffset = determineDeviceTimeOffset(appActivities);
-		for (AppActivityDTO.Activity appActivity : appActivities.getActivities())
-		{
+		for (AppActivityDTO.Activity appActivity : appActivities.getActivities()) {
 			Set<ActivityCategoryDTO> matchingActivityCategories = activityCategoryService
 					.getMatchingCategoriesForApp(appActivity.getApplication());
 			analyze(createActivityPayload(deviceTimeOffset, appActivity, userAnonymized), userAnonymized,
@@ -64,47 +61,47 @@ public class AnalysisEngineService
 		}
 	}
 
-	private Duration determineDeviceTimeOffset(AppActivityDTO appActivities)
-	{
+	private Duration determineDeviceTimeOffset(AppActivityDTO appActivities) {
 		Duration offset = Duration.between(ZonedDateTime.now(), appActivities.getDeviceDateTime());
-		return (offset.abs().compareTo(Duration.ofSeconds(10)) > 0) ? offset : Duration.ZERO; // Ignore if less than 10 seconds
+		return (offset.abs().compareTo(Duration.ofSeconds(10)) > 0) ? offset : Duration.ZERO; // Ignore
+																								// if
+																								// less
+																								// than
+																								// 10
+																								// seconds
 	}
 
 	private ActivityPayload createActivityPayload(Duration deviceTimeOffset, AppActivityDTO.Activity appActivity,
-			UserAnonymizedDTO userAnonymized)
-	{
+			UserAnonymizedDTO userAnonymized) {
 		ZonedDateTime correctedStartTime = correctTime(deviceTimeOffset, appActivity.getStartTime());
 		ZonedDateTime correctedEndTime = correctTime(deviceTimeOffset, appActivity.getEndTime());
-		return ActivityPayload.createInstance(userAnonymized, correctedStartTime, correctedEndTime, appActivity.getApplication());
+		return ActivityPayload.createInstance(userAnonymized, correctedStartTime, correctedEndTime,
+				appActivity.getApplication());
 	}
 
-	private ZonedDateTime correctTime(Duration deviceTimeOffset, ZonedDateTime time)
-	{
+	private ZonedDateTime correctTime(Duration deviceTimeOffset, ZonedDateTime time) {
 		return time.minus(deviceTimeOffset);
 	}
 
-	public void analyze(NetworkActivityDTO networkActivity)
-	{
+	public void analyze(NetworkActivityDTO networkActivity) {
 		UserAnonymizedDTO userAnonymized = userAnonymizedService.getUserAnonymized(networkActivity.getVPNLoginID());
 		Set<ActivityCategoryDTO> matchingActivityCategories = activityCategoryService
 				.getMatchingCategoriesForSmoothwallCategories(networkActivity.getCategories());
-		analyze(ActivityPayload.createInstance(userAnonymized, networkActivity), userAnonymized, matchingActivityCategories);
+		analyze(ActivityPayload.createInstance(userAnonymized, networkActivity), userAnonymized,
+				matchingActivityCategories);
 	}
 
 	private void analyze(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Set<ActivityCategoryDTO> matchingActivityCategories)
-	{
-		Set<GoalDTO> matchingGoalsOfUser = determineMatchingGoalsForUser(userAnonymized, matchingActivityCategories);
-		for (GoalDTO matchingGoalOfUser : matchingGoalsOfUser)
-		{
+			Set<ActivityCategoryDTO> matchingActivityCategories) {
+		Set<GoalDTO> matchingGoalsOfUser = determineMatchingGoalsForUser(userAnonymized, matchingActivityCategories,
+				payload.startTime);
+		for (GoalDTO matchingGoalOfUser : matchingGoalsOfUser) {
 			addOrUpdateActivity(payload, userAnonymized, matchingGoalOfUser);
 		}
 	}
 
-	private void addOrUpdateActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal)
-	{
-		if (isCrossDayActivity(payload, userAnonymized))
-		{
+	private void addOrUpdateActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal) {
+		if (isCrossDayActivity(payload, userAnonymized)) {
 			// assumption: activity never crosses 2 days
 			ActivityPayload truncatedPayload = ActivityPayload.copyTillEndTime(payload,
 					getEndOfDay(payload.startTime, userAnonymized));
@@ -113,173 +110,143 @@ public class AnalysisEngineService
 
 			addOrUpdateDayTruncatedActivity(truncatedPayload, userAnonymized, matchingGoal);
 			addOrUpdateDayTruncatedActivity(nextDayPayload, userAnonymized, matchingGoal);
-		}
-		else
-		{
+		} else {
 			addOrUpdateDayTruncatedActivity(payload, userAnonymized, matchingGoal);
 		}
 	}
 
-	private void addOrUpdateDayTruncatedActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal)
-	{
+	private void addOrUpdateDayTruncatedActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
+			GoalDTO matchingGoal) {
 		DayActivityCacheResult dayActivity = getRegisteredDayActivity(payload, userAnonymized, matchingGoal);
 		Activity lastRegisteredActivity = dayActivity.content == null ? null : dayActivity.content.getLastActivity();
-		if (canCombineWithLastRegisteredActivity(payload, lastRegisteredActivity))
-		{
-			if (isBeyondSkipWindowAfterLastRegisteredActivity(payload, lastRegisteredActivity))
-			{
-				// Update message only if it is within five seconds to avoid unnecessary cache flushes.
+		if (canCombineWithLastRegisteredActivity(payload, lastRegisteredActivity)) {
+			if (isBeyondSkipWindowAfterLastRegisteredActivity(payload, lastRegisteredActivity)) {
+				// Update message only if it is within five seconds to avoid
+				// unnecessary cache flushes.
 				updateActivityEndTime(payload, userAnonymized, matchingGoal, dayActivity, lastRegisteredActivity);
 			}
-		}
-		else
-		{
+		} else {
 			addActivity(payload, userAnonymized, matchingGoal, dayActivity);
 		}
 	}
 
-	private boolean isBeyondSkipWindowAfterLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
-	{
+	private boolean isBeyondSkipWindowAfterLastRegisteredActivity(ActivityPayload payload,
+			Activity lastRegisteredActivity) {
 		return Duration.between(lastRegisteredActivity.getEndTime(), payload.endTime)
 				.compareTo(yonaProperties.getAnalysisService().getUpdateSkipWindow()) >= 0;
 	}
 
-	private boolean canCombineWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
-	{
-		if (lastRegisteredActivity == null)
-		{
+	private boolean canCombineWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity) {
+		if (lastRegisteredActivity == null) {
 			return false;
 		}
 
-		if (precedesLastRegisteredActivity(payload, lastRegisteredActivity))
-		{
+		if (precedesLastRegisteredActivity(payload, lastRegisteredActivity)) {
 			// This can happen with app activity.
 			// Do not try to combine, add separately.
 			return false;
 		}
 
-		if (isBeyondCombineIntervalWithLastRegisteredActivity(payload, lastRegisteredActivity))
-		{
+		if (isBeyondCombineIntervalWithLastRegisteredActivity(payload, lastRegisteredActivity)) {
 			return false;
 		}
 
 		return true;
 	}
 
-	private boolean precedesLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
-	{
+	private boolean precedesLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity) {
 		return payload.startTime.isBefore(lastRegisteredActivity.getStartTime());
 	}
 
-	private boolean isBeyondCombineIntervalWithLastRegisteredActivity(ActivityPayload payload, Activity lastRegisteredActivity)
-	{
+	private boolean isBeyondCombineIntervalWithLastRegisteredActivity(ActivityPayload payload,
+			Activity lastRegisteredActivity) {
 		ZonedDateTime intervalEndTime = lastRegisteredActivity.getEndTime()
 				.plus(yonaProperties.getAnalysisService().getConflictInterval());
 		return payload.startTime.isAfter(intervalEndTime);
 	}
 
 	private DayActivityCacheResult getRegisteredDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			GoalDTO matchingGoal)
-	{
+			GoalDTO matchingGoal) {
 		DayActivity lastRegisteredDayActivity = cacheService.fetchLastDayActivityForUser(userAnonymized.getID(),
 				matchingGoal.getID());
-		if (lastRegisteredDayActivity == null)
-		{
+		if (lastRegisteredDayActivity == null) {
 			return DayActivityCacheResult.none();
-		}
-		else if (isOnPrecedingDay(payload, lastRegisteredDayActivity))
-		{
+		} else if (isOnPrecedingDay(payload, lastRegisteredDayActivity)) {
 			// Fetch from the database because it is no longer in the cache
 			return DayActivityCacheResult.preceding(dayActivityRepository.findOne(userAnonymized.getID(),
 					getStartOfDay(payload.startTime, userAnonymized).toLocalDate(), matchingGoal.getID()));
-		}
-		else if (isOnFollowingDay(payload, lastRegisteredDayActivity))
-		{
+		} else if (isOnFollowingDay(payload, lastRegisteredDayActivity)) {
 			return DayActivityCacheResult.following();
-		}
-		else
-		{
+		} else {
 			return DayActivityCacheResult.fromCache(lastRegisteredDayActivity);
 		}
 	}
 
-	private boolean isOnFollowingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity)
-	{
+	private boolean isOnFollowingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity) {
 		return payload.startTime.isAfter(lastRegisteredDayActivity.getEndTime());
 	}
 
-	private boolean isOnPrecedingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity)
-	{
+	private boolean isOnPrecedingDay(ActivityPayload payload, DayActivity lastRegisteredDayActivity) {
 		return payload.startTime.isBefore(lastRegisteredDayActivity.getStartTime());
 	}
 
-	private boolean isCrossDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized)
-	{
-		return getStartOfDay(payload.startTime, userAnonymized).isBefore(getStartOfDay(payload.endTime, userAnonymized));
+	private boolean isCrossDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized) {
+		return getStartOfDay(payload.startTime, userAnonymized)
+				.isBefore(getStartOfDay(payload.endTime, userAnonymized));
 	}
 
 	private void addActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal,
-			DayActivityCacheResult dayActivityCacheResult)
-	{
-		Goal matchingGoalEntity = goalService.getGoalEntityForUserAnonymizedID(userAnonymized.getID(), matchingGoal.getID());
+			DayActivityCacheResult dayActivityCacheResult) {
+		Goal matchingGoalEntity = goalService.getGoalEntityForUserAnonymizedID(userAnonymized.getID(),
+				matchingGoal.getID());
 		DayActivity updatedDayActivity = createNewActivity(dayActivityCacheResult.content, payload, userAnonymized,
 				matchingGoalEntity);
 		dayActivityRepository.save(updatedDayActivity);
-		if (dayActivityCacheResult.shouldUpdateCache())
-		{
+		if (dayActivityCacheResult.shouldUpdateCache()) {
 			cacheService.updateLastDayActivityForUser(updatedDayActivity);
 		}
 
-		if (matchingGoal.isNoGoGoal())
-		{
+		if (matchingGoal.isNoGoGoal()) {
 			sendConflictMessageToAllDestinationsOfUser(payload, userAnonymized, updatedDayActivity.getLastActivity(),
 					matchingGoalEntity);
 		}
 	}
 
 	private void updateActivityEndTime(ActivityPayload payload, UserAnonymizedDTO userAnonymized, GoalDTO matchingGoal,
-			DayActivityCacheResult dayActivity, Activity activity)
-	{
+			DayActivityCacheResult dayActivity, Activity activity) {
 		assert userAnonymized.getID().equals(dayActivity.content.getUserAnonymized().getID());
 		assert matchingGoal.getID().equals(dayActivity.content.getGoal().getID());
 
 		activity.setEndTime(payload.endTime);
 		dayActivityRepository.save(dayActivity.content);
-		if (dayActivity.shouldUpdateCache())
-		{
+		if (dayActivity.shouldUpdateCache()) {
 			cacheService.updateLastDayActivityForUser(dayActivity.content);
 		}
 	}
 
-	private ZonedDateTime getStartOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
-	{
+	private ZonedDateTime getStartOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
 		return time.withZoneSameInstant(ZoneId.of(userAnonymized.getTimeZoneId())).truncatedTo(ChronoUnit.DAYS);
 	}
 
-	private ZonedDateTime getEndOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
-	{
+	private ZonedDateTime getEndOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
 		return getStartOfDay(time, userAnonymized).plusHours(23).plusMinutes(59).plusSeconds(59);
 	}
 
-	private ZonedDateTime getStartOfWeek(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
-	{
+	private ZonedDateTime getStartOfWeek(ZonedDateTime time, UserAnonymizedDTO userAnonymized) {
 		ZonedDateTime startOfDay = getStartOfDay(time, userAnonymized);
-		switch (startOfDay.getDayOfWeek())
-		{
-			case SUNDAY:
-				// take as the first day of week
-				return startOfDay;
-			default:
-				// MONDAY=1, etc.
-				return startOfDay.minusDays(startOfDay.getDayOfWeek().getValue());
+		switch (startOfDay.getDayOfWeek()) {
+		case SUNDAY:
+			// take as the first day of week
+			return startOfDay;
+		default:
+			// MONDAY=1, etc.
+			return startOfDay.minusDays(startOfDay.getDayOfWeek().getValue());
 		}
 	}
 
-	private DayActivity createNewActivity(DayActivity dayActivity, ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Goal matchingGoal)
-	{
-		if (dayActivity == null)
-		{
+	private DayActivity createNewActivity(DayActivity dayActivity, ActivityPayload payload,
+			UserAnonymizedDTO userAnonymized, Goal matchingGoal) {
+		if (dayActivity == null) {
 			dayActivity = createNewDayActivity(payload, userAnonymized, matchingGoal);
 		}
 
@@ -289,18 +256,16 @@ public class AnalysisEngineService
 		return dayActivity;
 	}
 
-	private ZonedDateTime ensureMinimumDurationOneMinute(ActivityPayload payload)
-	{
+	private ZonedDateTime ensureMinimumDurationOneMinute(ActivityPayload payload) {
 		Duration duration = Duration.between(payload.startTime, payload.endTime);
-		if (duration.compareTo(ONE_MINUTE) < 0)
-		{
+		if (duration.compareTo(ONE_MINUTE) < 0) {
 			return payload.endTime.plus(ONE_MINUTE);
 		}
 		return payload.endTime;
 	}
 
-	private DayActivity createNewDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, Goal matchingGoal)
-	{
+	private DayActivity createNewDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
+			Goal matchingGoal) {
 		UserAnonymized userAnonymizedEntity = userAnonymizedService.getUserAnonymizedEntity(userAnonymized.getID());
 
 		DayActivity dayActivity = DayActivity.createInstance(userAnonymizedEntity, matchingGoal,
@@ -309,8 +274,7 @@ public class AnalysisEngineService
 		ZonedDateTime startOfWeek = getStartOfWeek(payload.startTime, userAnonymized);
 		WeekActivity weekActivity = cacheService.fetchWeekActivityForUser(userAnonymized.getID(), matchingGoal.getID(),
 				startOfWeek.toLocalDate());
-		if (weekActivity == null)
-		{
+		if (weekActivity == null) {
 			weekActivity = WeekActivity.createInstance(userAnonymizedEntity, matchingGoal, startOfWeek);
 		}
 		dayActivityRepository.save(dayActivity);
@@ -319,17 +283,15 @@ public class AnalysisEngineService
 		return dayActivity;
 	}
 
-	public Set<String> getRelevantSmoothwallCategories()
-	{
-		return activityCategoryService.getAllActivityCategories().stream().flatMap(g -> g.getSmoothwallCategories().stream())
-				.collect(Collectors.toSet());
+	public Set<String> getRelevantSmoothwallCategories() {
+		return activityCategoryService.getAllActivityCategories().stream()
+				.flatMap(g -> g.getSmoothwallCategories().stream()).collect(Collectors.toSet());
 	}
 
 	private void sendConflictMessageToAllDestinationsOfUser(ActivityPayload payload, UserAnonymizedDTO userAnonymized,
-			Activity activity, Goal matchingGoal)
-	{
-		GoalConflictMessage selfGoalConflictMessage = GoalConflictMessage.createInstance(userAnonymized.getID(), activity,
-				matchingGoal, payload.url);
+			Activity activity, Goal matchingGoal) {
+		GoalConflictMessage selfGoalConflictMessage = GoalConflictMessage.createInstance(userAnonymized.getID(),
+				activity, matchingGoal, payload.url);
 		messageService.sendMessage(selfGoalConflictMessage, userAnonymized.getAnonymousDestination());
 
 		messageService.broadcastMessageToBuddies(userAnonymized,
@@ -337,94 +299,80 @@ public class AnalysisEngineService
 	}
 
 	private Set<GoalDTO> determineMatchingGoalsForUser(UserAnonymizedDTO userAnonymized,
-			Set<ActivityCategoryDTO> matchingActivityCategories)
-	{
+			Set<ActivityCategoryDTO> matchingActivityCategories, ZonedDateTime activityStartTime) {
 		Set<UUID> matchingActivityCategoryIDs = matchingActivityCategories.stream().map(ac -> ac.getID())
 				.collect(Collectors.toSet());
 		Set<GoalDTO> goalsOfUser = userAnonymized.getGoals();
 		Set<GoalDTO> matchingGoalsOfUser = goalsOfUser.stream().filter(g -> !g.isHistoryItem())
-				.filter(g -> matchingActivityCategoryIDs.contains(g.getActivityCategoryID())).collect(Collectors.toSet());
+				.filter(g -> matchingActivityCategoryIDs.contains(g.getActivityCategoryID()))
+				.filter(g -> g.getCreationTime().get().isBefore(activityStartTime)).collect(Collectors.toSet());
 		return matchingGoalsOfUser;
 	}
 
-	private enum DayActivityCacheResultStatus
-	{
+	private enum DayActivityCacheResultStatus {
 		CACHE_EMPTY, FROM_CACHE, FOLLOWING_LAST_CACHED, PRECEDING_LAST_CACHED
 	}
 
-	private static class DayActivityCacheResult
-	{
+	private static class DayActivityCacheResult {
 		public final DayActivityCacheResultStatus status;
 		public DayActivity content;
 
-		public DayActivityCacheResult(DayActivity content, DayActivityCacheResultStatus status)
-		{
+		public DayActivityCacheResult(DayActivity content, DayActivityCacheResultStatus status) {
 			this.status = status;
 			this.content = content;
 		}
 
-		public boolean shouldUpdateCache()
-		{
+		public boolean shouldUpdateCache() {
 			return this.status != DayActivityCacheResultStatus.PRECEDING_LAST_CACHED;
 		}
 
-		public static DayActivityCacheResult none()
-		{
+		public static DayActivityCacheResult none() {
 			return new DayActivityCacheResult(null, DayActivityCacheResultStatus.CACHE_EMPTY);
 		}
 
-		public static DayActivityCacheResult fromCache(DayActivity lastRegisteredDayActivity)
-		{
+		public static DayActivityCacheResult fromCache(DayActivity lastRegisteredDayActivity) {
 			return new DayActivityCacheResult(lastRegisteredDayActivity, DayActivityCacheResultStatus.FROM_CACHE);
 		}
 
-		public static DayActivityCacheResult following()
-		{
+		public static DayActivityCacheResult following() {
 			return new DayActivityCacheResult(null, DayActivityCacheResultStatus.FROM_CACHE);
 		}
 
-		public static DayActivityCacheResult preceding(DayActivity resultFromDatabase)
-		{
+		public static DayActivityCacheResult preceding(DayActivity resultFromDatabase) {
 			return new DayActivityCacheResult(resultFromDatabase, DayActivityCacheResultStatus.PRECEDING_LAST_CACHED);
 		}
 	}
 
-	private static class ActivityPayload
-	{
+	private static class ActivityPayload {
 		public final Optional<String> url;
 		public final ZonedDateTime startTime;
 		public final ZonedDateTime endTime;
 		public final Optional<String> application;
 
 		private ActivityPayload(Optional<String> url, ZonedDateTime startTime, ZonedDateTime endTime,
-				Optional<String> application)
-		{
+				Optional<String> application) {
 			this.url = url;
 			this.startTime = startTime;
 			this.endTime = endTime;
 			this.application = application;
 		}
 
-		static ActivityPayload copyTillEndTime(ActivityPayload payload, ZonedDateTime endTime)
-		{
+		static ActivityPayload copyTillEndTime(ActivityPayload payload, ZonedDateTime endTime) {
 			return new ActivityPayload(payload.url, payload.startTime, endTime, payload.application);
 		}
 
-		static ActivityPayload copyFromStartTime(ActivityPayload payload, ZonedDateTime startTime)
-		{
+		static ActivityPayload copyFromStartTime(ActivityPayload payload, ZonedDateTime startTime) {
 			return new ActivityPayload(payload.url, startTime, payload.endTime, payload.application);
 		}
 
-		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, NetworkActivityDTO networkActivity)
-		{
+		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, NetworkActivityDTO networkActivity) {
 			ZonedDateTime startTime = networkActivity.getEventTime().orElse(ZonedDateTime.now())
 					.withZoneSameInstant(ZoneId.of(userAnonymized.getTimeZoneId()));
 			return new ActivityPayload(Optional.of(networkActivity.getURL()), startTime, startTime, Optional.empty());
 		}
 
-		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, ZonedDateTime startTime, ZonedDateTime endTime,
-				String application)
-		{
+		static ActivityPayload createInstance(UserAnonymizedDTO userAnonymized, ZonedDateTime startTime,
+				ZonedDateTime endTime, String application) {
 			ZoneId userTimeZone = ZoneId.of(userAnonymized.getTimeZoneId());
 			return new ActivityPayload(Optional.empty(), startTime.withZoneSameInstant(userTimeZone),
 					endTime.withZoneSameInstant(userTimeZone), Optional.of(application));


### PR DESCRIPTION
Can you have a look at this?
To my surprise, I have one failing test: ActivityTest."Add activity after retrieving the report with multiple days"
```
Condition not satisfied:

dayActivityOverview.dayActivities?.size() == expectedValues[shortDay].size()
|                   |              |      |  |             ||         |
|                   |              2      |  |             |Wed       1
|                   |                     |  |             [[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]]
|                   |                     |  [Mon:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]], Tue:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]], Wed:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]], Thu:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]], Fri:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]], Sat:[[goal:nu.yona.server.test.BudgetGoal@4295f2a0, data:[goalAccomplished:true, minutesBeyondGoal:0, spread:[]]]]]
|                   |                     false
|                   [[_links:[yona:dayDetails:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/activity/days/2016-07-13/details/166d8e92-1869-4c92-92e5-ada9a8565fd1], yona:goal:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/goals/166d8e92-1869-4c92-92e5-ada9a8565fd1]], goalAccomplished:true, totalActivityDurationMinutes:0, totalMinutesBeyondGoal:0], [_links:[yona:dayDetails:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/activity/days/2016-07-13/details/236e80a0-6407-4a14-84e6-51e168092f33], yona:goal:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/goals/236e80a0-6407-4a14-84e6-51e168092f33]], goalAccomplished:true, totalActivityDurationMinutes:0, totalMinutesBeyondGoal:0]]
[date:2016-07-13, dayActivities:[[_links:[yona:dayDetails:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/activity/days/2016-07-13/details/166d8e92-1869-4c92-92e5-ada9a8565fd1], yona:goal:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/goals/166d8e92-1869-4c92-92e5-ada9a8565fd1]], goalAccomplished:true, totalActivityDurationMinutes:0, totalMinutesBeyondGoal:0], [_links:[yona:dayDetails:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/activity/days/2016-07-13/details/236e80a0-6407-4a14-84e6-51e168092f33], yona:goal:[href:http://localhost:8082/users/acc386ef-ac65-4069-b0fb-3c7fe9a095dc/goals/236e80a0-6407-4a14-84e6-51e168092f33]], goalAccomplished:true, totalActivityDurationMinutes:0, totalMinutesBeyondGoal:0]], timeZoneId:Europe/Amsterdam]

	at nu.yona.server.AbstractAppServiceIntegrationTest.assertDayOverviewForGoal(AbstractAppServiceIntegrationTest.groovy:250)
	at nu.yona.server.AbstractAppServiceIntegrationTest.assertDayOverviewForBudgetGoal(AbstractAppServiceIntegrationTest.groovy:272)
	at nu.yona.server.ActivityTest.Add activity after retrieving the report with multiple days(ActivityTest.groovy:372)
```

I don't understand how this relates to the code change and suspect a different issue.

