### PR TITLE
YD-309 Added app activity validations

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -309,7 +309,6 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		getMessagesRichardResponse.status == 200
-		ZonedDateTime goalConflictTime = YonaServer.now
 		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"}?.size()
 		// Don't poke into the messages. The app activity spans many days and we only support activities spanning at most two days
 

--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -38,6 +38,9 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.decrypting.data"
+
+		cleanup:
+		appService.deleteUser(richard)
 	}
 
 	def 'Goal conflict of Richard is reported to Richard and Bob'()
@@ -152,6 +155,10 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		getMessagesBobResponse.status == 200
 		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesBob.size() == 1
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Send multiple app activities after offline period'()
@@ -189,6 +196,10 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
 		assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
 		assertEquals(goalConflictMessagesRichard[0].activityEndTime, endTime1)
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Activity before goal creation is ignored'()
@@ -209,5 +220,100 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		getMessagesRichardResponse.status == 200
 		ZonedDateTime goalConflictTime = YonaServer.now
 		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"} == null
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
+	def 'Try send app activity with end before start'()
+	{
+		given:
+		def richard = addRichard()
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
+		ZonedDateTime testStartTime = YonaServer.now
+		ZonedDateTime startTime = testStartTime.minusDays(1)
+		ZonedDateTime endTime = startTime.minusMinutes(15)
+
+		when:
+		def response = appService.postAppActivityToAnalysisEngine(richard,
+				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
+
+		then:
+		response.status == 400
+		response.responseData.code == "error.analysis.invalid.app.activity.data.end.before.start"
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
+	def 'Try send app activity with end in future'()
+	{
+		given:
+		def richard = addRichard()
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
+		ZonedDateTime testStartTime = YonaServer.now
+		ZonedDateTime startTime = testStartTime
+		ZonedDateTime endTime = startTime.plusMinutes(1)
+
+		when:
+		def response = appService.postAppActivityToAnalysisEngine(richard,
+				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
+
+		then:
+		response.status == 400
+		response.responseData.code == "error.analysis.invalid.app.activity.data.ends.in.future"
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
+	def 'Try send app activity with start in future'()
+	{
+		given:
+		def richard = addRichard()
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
+		ZonedDateTime testStartTime = YonaServer.now
+		ZonedDateTime startTime = testStartTime.plusMinutes(1)
+		ZonedDateTime endTime = startTime.plusMinutes(1)
+
+		when:
+		def response = appService.postAppActivityToAnalysisEngine(richard,
+				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
+
+		then:
+		response.status == 400
+		response.responseData.code == "error.analysis.invalid.app.activity.data.starts.in.future"
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
+	def 'Send app activity within device time inacuracy window'()
+	{
+		given:
+		def richard = addRichard()
+		String goalCreationTimeStr = "W-1 Mon 02:18"
+		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, goalCreationTimeStr)
+		ZonedDateTime testStartTime = YonaServer.now
+		// Device time inaccuracy window is plus or minus 10 seconds.
+		// Try posting an event that starts 5 seconds before the goal creation time and ends 5 seconds in the future
+		ZonedDateTime startTime = YonaServer.relativeDateTimeStringToZonedDateTime(goalCreationTimeStr).minusSeconds(5)
+		ZonedDateTime endTime = testStartTime.plusSeconds(5)
+		
+		when:
+		def response = appService.postAppActivityToAnalysisEngine(richard,
+				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
+
+		then:
+		response.status == 200
+
+		def getMessagesRichardResponse = appService.getMessages(richard)
+		getMessagesRichardResponse.status == 200
+		ZonedDateTime goalConflictTime = YonaServer.now
+		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"}?.size()
+		// Don't poke into the messages. The app activity spans many days and we only support activities spanning at most two days
+
+		cleanup:
+		appService.deleteUser(richard)
 	}
 }

--- a/core/src/main/java/nu/yona/server/exceptions/AnalysisException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/AnalysisException.java
@@ -8,14 +8,11 @@ import java.time.ZonedDateTime;
 import java.util.UUID;
 
 /**
- * This exception is to be used in case data is wrong in DTOs. So whenever a field has a wrong value you should throw this
- * exception.
- * 
- * @author pgussow
+ * This exception is thrown for various issues that can occur during analysis of app or network activity.
  */
 public class AnalysisException extends YonaException
 {
-	private static final long serialVersionUID = -7917208280838423613L;
+	private static final long serialVersionUID = -366842642655183778L;
 
 	private AnalysisException(String messageId, Object... parameters)
 	{

--- a/core/src/main/java/nu/yona/server/exceptions/AnalysisException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/AnalysisException.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.exceptions;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+/**
+ * This exception is to be used in case data is wrong in DTOs. So whenever a field has a wrong value you should throw this
+ * exception.
+ * 
+ * @author pgussow
+ */
+public class AnalysisException extends YonaException
+{
+	private static final long serialVersionUID = -7917208280838423613L;
+
+	private AnalysisException(String messageId, Object... parameters)
+	{
+		super(messageId, parameters);
+	}
+
+	private AnalysisException(Throwable t, String messageId, Object... parameters)
+	{
+		super(t, messageId, parameters);
+	}
+
+	public static AnalysisException appActivityStartAfterEnd(UUID userAnonymizedID, String application, ZonedDateTime startTime,
+			ZonedDateTime endTime)
+	{
+		return new AnalysisException("error.analysis.invalid.app.activity.data.end.before.start", userAnonymizedID, application,
+				startTime, endTime);
+	}
+
+	public static AnalysisException appActivityStartsInFuture(UUID userAnonymizedID, String application, ZonedDateTime startTime)
+	{
+		return new AnalysisException("error.analysis.invalid.app.activity.data.starts.in.future", userAnonymizedID, application,
+				startTime);
+	}
+
+	public static AnalysisException appActivityEndsInFuture(UUID userAnonymizedID, String application, ZonedDateTime endTime)
+	{
+		return new AnalysisException("error.analysis.invalid.app.activity.data.ends.in.future", userAnonymizedID, application, endTime);
+	}
+}

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -120,5 +120,9 @@ error.email.sending.failed=E-mail sending failed: {0}
 error.sms.sending.failed.exception=SMS sending failed: {0}
 error.sms.sending.failed.httpStatus=Unexpected status code received from SMS service: {0}. Message: {1}
 
+error.analysis.invalid.app.activity.data.end.before.start=Invalid app activity data: end time ({3}) is before start time ({2}). For user anonymized ''{0}'' and application ''{1}'' 
+error.analysis.invalid.app.activity.data.starts.in.future=Invalid app activity data: start time ({2}) is in the future. For user anonymized ''{0}'' and application ''{1}'' 
+error.analysis.invalid.app.activity.data.ends.in.future=Invalid app activity data: end time ({2}) is in the future. For user anonymized ''{0}'' and application ''{1}'' 
+
 # Use this wisely! This should only be used around sensitive parts
 error.unexpected=Unexpected error

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -120,5 +120,9 @@ error.email.sending.failed=Versturen e-mail mislukt: {0}
 error.sms.sending.failed.exception=Versturen SMS mislukt: {0}
 error.sms.sending.failed.httpStatus=Onverwachte status code ontvangen van SMS service: {0}. Bericht: {1}
 
+error.analysis.invalid.app.activity.data.end.before.start=Onjuiste app activity data: eindtijd ({3}) is voorbij begintijd ({2}). Voor user anonymized ''{0}'' en applicatie''{1}'' 
+error.analysis.invalid.app.activity.data.starts.in.future=Onjuiste app activity data: starttijd ({2}) ligt in de toekomst. Voor user anonymized ''{0}'' en applicatie ''{1}'' 
+error.analysis.invalid.app.activity.data.ends.in.future=Onjuiste app activity data: eindtijd ({2}) ligt in de toekomst. Voor user anonymized ''{0}'' en applicatie ''{1}'' 
+
 # Use this wisely! This should only be used around sensitive parts
 error.unexpected=Onverwachte fout


### PR DESCRIPTION
* Start time must be before end type
* Start time and end time cannot be in the future

Added tests. Made explicit that we accept a 10 second deviation between the app and the server time.