### PR TITLE
YD-313 fixed inconsistency in totals

### DIFF
--- a/core/src/main/java/nu/yona/server/goals/entities/TimeZoneGoal.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/TimeZoneGoal.java
@@ -101,7 +101,9 @@ public class TimeZoneGoal extends Goal
 	public int computeTotalMinutesBeyondGoal(DayActivity dayActivity)
 	{
 		int[] spread = determineSpreadOutsideGoal(dayActivity);
-		return Arrays.stream(spread).sum();
+		int sumOfSpreadOutsideGoal = Arrays.stream(spread).sum();
+		// Due to rounding, the sum of the spread might be more than the total duration, so take the lowest of the two
+		return Math.min(dayActivity.getTotalActivityDurationMinutes(), sumOfSpreadOutsideGoal);
 	}
 
 	public static TimeZoneGoal createInstance(ZonedDateTime creationTime, ActivityCategory activityCategory, List<String> zones)


### PR DESCRIPTION
For a time zone goal, the time beyond the goal is calculated by summing the conflicting spread cells. Due to rounding, that sum might be more than the total time spent. This is confusing, so it's corrected now.