### PR TITLE
YD-337 Add notification links

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1170,7 +1170,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 	private void assertCommentMessageDetails(message, User user, boolean isWeek, sender, expectedDetailsUrl, expectedText, threadHeadMessage, repliedMessage = null) {
 		assert message."@type" == "ActivityCommentMessage"
 		assert message.message == expectedText
-		assert message.nickname == sender.nickname
+		assert message.nickname == ((user.url == sender.url) ? "<self>" : sender.nickname)
 
 		assert message._links?.self?.href?.startsWith(YonaServer.stripQueryString(user.messagesUrl))
 		assert message._links?.edit?.href == message._links.self.href

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -195,7 +195,8 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == connectResponseMessage.selfURL
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
-		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:buddy" != null
+		def buddyURL = response.responseData._embedded."yona:affectedMessages"[0]._links."yona:buddy"?.href
+		buddyURL != null
 
 		def buddies = appService.getBuddies(richard)
 		buddies.size() == 1
@@ -203,7 +204,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		buddies[0].nickname == bob.nickname
 		buddies[0].sendingStatus == "ACCEPTED"
 		buddies[0].receivingStatus == "ACCEPTED"
-		buddies[0].url == connectResponseMessage.buddyURL
+		buddies[0].url == buddyURL
 
 		def richardWithBuddy = appService.reloadUser(richard)
 		richardWithBuddy.buddies != null
@@ -335,6 +336,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		richardGoalConflictMessages[0].nickname == bob.nickname
 		richardGoalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		richardGoalConflictMessages[0].url == null
+		// link to Bob's activity present
 		def dayActivityDetailUrlRichard = richardGoalConflictMessages[0]._links."yona:dayDetails".href
 		dayActivityDetailUrlRichard
 		def dayActivityDetailRichard = appService.getResourceWithPassword(dayActivityDetailUrlRichard, richard.password)
@@ -349,6 +351,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		bobGoalConflictMessages[0].nickname == "<self>"
 		bobGoalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		bobGoalConflictMessages[0].url == "http://www.poker.com"
+		// link to own activity present
 		def dayActivityDetailUrlBob = bobGoalConflictMessages[0]._links."yona:dayDetails".href
 		dayActivityDetailUrlBob
 		def dayActivityDetailBob = appService.getResourceWithPassword(dayActivityDetailUrlBob, bob.password)

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -195,6 +195,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == connectResponseMessage.selfURL
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
+		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:buddy" != null
 
 		def buddies = appService.getBuddies(richard)
 		buddies.size() == 1
@@ -202,6 +203,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		buddies[0].nickname == bob.nickname
 		buddies[0].sendingStatus == "ACCEPTED"
 		buddies[0].receivingStatus == "ACCEPTED"
+		buddies[0].url == connectResponseMessage.buddyURL
 
 		def richardWithBuddy = appService.reloadUser(richard)
 		richardWithBuddy.buddies != null

--- a/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
@@ -8,8 +8,6 @@ package nu.yona.server
 
 import groovy.json.*
 
-import java.time.ZonedDateTime
-
 class DisclosureTest extends AbstractAppServiceIntegrationTest
 {
 	def 'Disclosure link is available to buddy, not to <self>'()
@@ -79,6 +77,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0]._links?.related?.href == getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links.self.href
 		disclosureRequestMessages[0]._links."yona:accept"?.href
 		disclosureRequestMessages[0]._links."yona:reject"?.href
+		disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 
 		assertMarkReadUnread(richard, disclosureRequestMessages[0])
 
@@ -118,6 +117,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0].status == "DISCLOSURE_ACCEPTED"
 		disclosureRequestMessages[0]._links."yona:accept" == null
 		disclosureRequestMessages[0]._links."yona:reject" == null
+		disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 
 		def getBobMessagesResponse = appService.getMessages(bob)
 		getBobMessagesResponse.status == 200
@@ -135,6 +135,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
 		disclosureResponseMessage._links?."yona:user"?.href == richard.url
 		disclosureResponseMessage._embedded?."yona:user" == null
+		disclosureResponseMessage._links."yona:dayDetails"?.href
 
 		assertMarkReadUnread(bob, disclosureResponseMessage)
 
@@ -181,6 +182,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0].status == "DISCLOSURE_REJECTED"
 		disclosureRequestMessages[0]._links."yona:accept" == null
 		disclosureRequestMessages[0]._links."yona:reject" == null
+		disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 
 		def getBobMessagesResponse = appService.getMessages(bob)
 		getBobMessagesResponse.status == 200
@@ -197,6 +199,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
 		disclosureResponseMessage._links?."yona:user"?.href == richard.url
 		disclosureResponseMessage._embedded?."yona:user" == null
+		disclosureResponseMessage._links."yona:dayDetails"?.href
 
 		//check delete
 		disclosureResponseMessage._links.edit

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -265,9 +265,9 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertEquals(goalChangeMessages[0].creationTime, YonaServer.now)
 		goalChangeMessages[0].message == "Want to become a bit more social :)"
 		goalChangeMessages[0]._links.edit
-		goalChangeMessages[0]._links."yona:dayOverview"?.href == buddyRichardUrl + "/activity/days/"
+		goalChangeMessages[0]._links."yona:dailyActivityReports"?.href == buddyRichardUrl + "/activity/days/"
 		goalChangeMessages[1].change == 'GOAL_ADDED'
-		goalChangeMessages[1]._links."yona:dayOverview"?.href == buddyRichardUrl + "/activity/days/"
+		goalChangeMessages[1]._links."yona:dailyActivityReports"?.href == buddyRichardUrl + "/activity/days/"
 
 		def richardMessagesResponse = appService.getMessages(richard)
 		richardMessagesResponse.responseData._embedded."yona:messages".findAll

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -232,6 +232,8 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		BudgetGoal addedGoal = appService.addGoal(appService.&assertResponseStatusCreated, richard, BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 60), "Going to monitor my social time!")
 		postFacebookActivityPastHour(richard)
 		BudgetGoal updatedGoal = BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 120)
+		bob = appService.reloadUser(bob)
+		def buddyRichardUrl = bob.buddies[0].url
 
 		when:
 		def response = appService.updateGoal(richard, addedGoal.url, updatedGoal, "Want to become a bit more social :)")
@@ -263,7 +265,9 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertEquals(goalChangeMessages[0].creationTime, YonaServer.now)
 		goalChangeMessages[0].message == "Want to become a bit more social :)"
 		goalChangeMessages[0]._links.edit
+		goalChangeMessages[0]._links."yona:dayOverview"?.href == buddyRichardUrl + "/activity/days/"
 		goalChangeMessages[1].change == 'GOAL_ADDED'
+		goalChangeMessages[1]._links."yona:dayOverview"?.href == buddyRichardUrl + "/activity/days/"
 
 		def richardMessagesResponse = appService.getMessages(richard)
 		richardMessagesResponse.responseData._embedded."yona:messages".findAll

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityControllerBase.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityControllerBase.java
@@ -47,6 +47,9 @@ import nu.yona.server.subscriptions.service.UserService;
  */
 abstract class ActivityControllerBase
 {
+	public static final String WEEK_DETAIL_LINK = "weekDetails";
+	public static final String DAY_DETAIL_LINK = "dayDetails";
+
 	@Autowired
 	protected ActivityService activityService;
 
@@ -161,14 +164,14 @@ abstract class ActivityControllerBase
 	{
 		message.add(linkProvider
 				.getWeekActivityDetailLinkBuilder(WeekActivityDTO.formatDate(activity.getDate()), activity.getGoal().getID())
-				.withRel("weekDetails"));
+				.withRel(WEEK_DETAIL_LINK));
 	}
 
 	private void addDayDetailsLink(LinkProvider linkProvider, IntervalActivity activity, ActivityCommentMessageDTO message)
 	{
 		message.add(linkProvider
 				.getDayActivityDetailLinkBuilder(DayActivityDTO.formatDate(activity.getDate()), activity.getGoal().getID())
-				.withRel("dayDetails"));
+				.withRel(DAY_DETAIL_LINK));
 	}
 
 	private void addThreadHeadMessageLink(UUID userID, ActivityCommentMessageDTO message)

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityControllerBase.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/ActivityControllerBase.java
@@ -49,6 +49,8 @@ abstract class ActivityControllerBase
 {
 	public static final String DAY_DETAIL_LINK = "dayDetails";
 	public static final String WEEK_DETAIL_LINK = "weekDetails";
+	public static final String DAY_OVERVIEW_LINK = "dailyActivityReports";
+	public static final String WEEK_OVERVIEW_LINK = "weeklyActivityReports";
 
 	@Autowired
 	protected ActivityService activityService;
@@ -188,7 +190,7 @@ abstract class ActivityControllerBase
 
 	private void addBuddyLink(UUID userID, UUID buddyID, ActivityCommentMessageDTO message)
 	{
-		message.add(BuddyController.getBuddyLinkBuilder(userID, buddyID).withRel("buddy"));
+		message.add(BuddyController.getBuddyLinkBuilder(userID, buddyID).withRel(BuddyController.BUDDY_LINK));
 	}
 
 	interface LinkProvider

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
@@ -415,7 +415,7 @@ public class UserActivityController extends ActivityControllerBase
 
 		private void addBuddyLink(UUID userID, UUID buddyID, ActivityForOneUserResource dayActivityResource)
 		{
-			dayActivityResource.add(BuddyController.getBuddyLinkBuilder(userID, buddyID).withRel("buddy"));
+			dayActivityResource.add(BuddyController.getBuddyLinkBuilder(userID, buddyID).withRel(BuddyController.BUDDY_LINK));
 		}
 	}
 }

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -312,7 +312,7 @@ public class MessageController
 		{
 			message.add(BuddyActivityController
 					.getBuddyDayActivityOverviewsLinkBuilder(goalIDMapping.getUserID(), message.getSenderBuddyID().get())
-					.withRel("dayOverview"));
+					.withRel(BuddyActivityController.DAY_OVERVIEW_LINK));
 		}
 
 		private void addDayActivityDetailLinkIfDisclosureAccepted(DisclosureResponseMessageDTO message)
@@ -328,7 +328,7 @@ public class MessageController
 			if (message.getSenderBuddyID().isPresent())
 			{
 				message.add(BuddyController.getBuddyLinkBuilder(goalIDMapping.getUserID(), message.getSenderBuddyID().get())
-						.withRel("buddy"));
+						.withRel(BuddyController.BUDDY_LINK));
 			}
 		}
 

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -310,7 +310,9 @@ public class MessageController
 
 		private void addDayActivityOverviewLink(GoalChangeMessageDTO message)
 		{
-
+			message.add(BuddyActivityController
+					.getBuddyDayActivityOverviewsLinkBuilder(goalIDMapping.getUserID(), message.getSenderBuddyID().get())
+					.withRel("dayOverview"));
 		}
 
 		private void addDayActivityDetailLinkIfDisclosureAccepted(DisclosureResponseMessageDTO message)

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import nu.yona.server.analysis.entities.GoalConflictMessage;
 import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.analysis.rest.BuddyActivityController;
 import nu.yona.server.analysis.rest.UserActivityController;
@@ -289,15 +290,34 @@ public class MessageController
 			}
 			if (message instanceof DisclosureResponseMessageDTO)
 			{
-				addDayActivityDetailLink((DisclosureResponseMessageDTO) message);
+				addDayActivityDetailLinkIfDisclosureAccepted((DisclosureResponseMessageDTO) message);
 			}
 			if (message instanceof GoalChangeMessageDTO)
 			{
-				addRelatedActivityCategoryLink((GoalChangeMessageDTO) message);
+				addGoalChangeMessageLinks((GoalChangeMessageDTO) message);
 			}
 			if (message instanceof ActivityCommentMessageDTO)
 			{
 				addActivityCommentMessageLinks((ActivityCommentMessageDTO) message);
+			}
+		}
+
+		private void addGoalChangeMessageLinks(GoalChangeMessageDTO message)
+		{
+			addRelatedActivityCategoryLink(message);
+			addDayActivityOverviewLink(message);
+		}
+
+		private void addDayActivityOverviewLink(GoalChangeMessageDTO message)
+		{
+
+		}
+
+		private void addDayActivityDetailLinkIfDisclosureAccepted(DisclosureResponseMessageDTO message)
+		{
+			if (message.getStatus() == GoalConflictMessage.Status.DISCLOSURE_ACCEPTED)
+			{
+				addDayActivityDetailLink(message);
 			}
 		}
 

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -58,6 +58,8 @@ import nu.yona.server.subscriptions.service.UserService;
 @RequestMapping(value = "/users/{requestingUserID}/buddies", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class BuddyController
 {
+	public static final String BUDDY_LINK = "buddy";
+
 	@Autowired
 	private BuddyService buddyService;
 
@@ -324,14 +326,14 @@ public class BuddyController
 		{
 			buddyResource.add(BuddyActivityController
 					.getBuddyWeekActivityOverviewsLinkBuilder(requestingUserID, buddyResource.getContent().getID())
-					.withRel("weeklyActivityReports"));
+					.withRel(BuddyActivityController.WEEK_OVERVIEW_LINK));
 		}
 
 		private void addDayActivityOverviewsLink(BuddyResource buddyResource)
 		{
 			buddyResource.add(BuddyActivityController
 					.getBuddyDayActivityOverviewsLinkBuilder(requestingUserID, buddyResource.getContent().getID())
-					.withRel("dailyActivityReports"));
+					.withRel(BuddyActivityController.DAY_OVERVIEW_LINK));
 		}
 	}
 }

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -8,9 +8,9 @@ import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
-import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -491,7 +491,7 @@ public class UserController
 		{
 			userResource.add(new Link(
 					ServletUriComponentsBuilder.fromCurrentContextPath().path(SSL_ROOT_CERTIFICATE_PATH).build().toUriString(),
-							"sslRootCert"));
+					"sslRootCert"));
 		}
 
 		@Override
@@ -531,13 +531,13 @@ public class UserController
 		private void addWeekActivityOverviewsLink(UserResource userResource)
 		{
 			userResource.add(UserActivityController.getUserWeekActivityOverviewsLinkBuilder(userResource.getContent().getID())
-					.withRel("weeklyActivityReports"));
+					.withRel(UserActivityController.WEEK_OVERVIEW_LINK));
 		}
 
 		private void addDayActivityOverviewsLink(UserResource userResource)
 		{
 			userResource.add(UserActivityController.getUserDayActivityOverviewsLinkBuilder(userResource.getContent().getID())
-					.withRel("dailyActivityReports"));
+					.withRel(UserActivityController.DAY_OVERVIEW_LINK));
 		}
 
 		private void addDayActivityOverviewsWithBuddiesLink(UserResource userResource)

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -2341,6 +2341,7 @@ definitions:
           - $ref: '#/definitions/Curies'
           - $ref: '#/definitions/SelfLink'
           - $ref: '#/definitions/UserLink'
+          - $ref: '#/definitions/BuddyLink'
           - $ref: '#/definitions/EditLink'
           - $ref: '#/definitions/MarkReadLink'
           - $ref: '#/definitions/MarkUnreadLink'
@@ -2444,6 +2445,7 @@ definitions:
           - $ref: '#/definitions/SelfLink'
           - $ref: '#/definitions/EditLink'
           - $ref: '#/definitions/ActivityCategoryLink'
+          - $ref: '#/definitions/DailyActivityReportsLink'
     required:
       - change
       - _links
@@ -2465,6 +2467,7 @@ definitions:
           - $ref: '#/definitions/RelatedLink'
           - $ref: '#/definitions/AcceptLink'
           - $ref: '#/definitions/RejectLink'
+          - $ref: '#/definitions/DayDetailsLink'
     required:
       - status
       - _links
@@ -2483,6 +2486,7 @@ definitions:
           - $ref: '#/definitions/MarkReadLink'
           - $ref: '#/definitions/MarkUnreadLink'
           - $ref: '#/definitions/RelatedLink'
+          - $ref: '#/definitions/DayDetailsLink'
     required:
       - status
       - _links

--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDTO.java
@@ -31,20 +31,17 @@ public class ActivityCommentMessageDTO extends BuddyMessageLinkedUserDTO
 {
 	private static final String MESSAGE_PROPERTY = "message";
 	private static final String REPLY = "reply";
-	private final boolean canReplyTo;
 	private final UUID activityID;
 	private final Optional<UUID> repliedMessageID;
 	private final UUID threadHeadMessageID;
 
-	private ActivityCommentMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser, UUID senderUserAnonymizedID,
-			String senderNickname, UUID activityID, UUID threadHeadMessageID, Optional<UUID> repliedMessageID, String message,
-			boolean canReplyTo)
+	private ActivityCommentMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser,
+			UUID activityID, UUID threadHeadMessageID, Optional<UUID> repliedMessageID, String message)
 	{
-		super(id, creationTime, isRead, senderUser, senderNickname, message);
+		super(id, sender, creationTime, isRead, senderUser, message);
 		this.activityID = activityID;
 		this.threadHeadMessageID = threadHeadMessageID;
 		this.repliedMessageID = repliedMessageID;
-		this.canReplyTo = canReplyTo;
 	}
 
 	@Override
@@ -57,7 +54,7 @@ public class ActivityCommentMessageDTO extends BuddyMessageLinkedUserDTO
 	public Set<String> getPossibleActions()
 	{
 		Set<String> possibleActions = super.getPossibleActions();
-		if (canReplyTo)
+		if (this.isSentFromBuddy())
 		{
 			possibleActions.add(REPLY);
 		}
@@ -87,13 +84,13 @@ public class ActivityCommentMessageDTO extends BuddyMessageLinkedUserDTO
 		return repliedMessageID;
 	}
 
-	public static ActivityCommentMessageDTO createInstance(UserDTO actingUser, ActivityCommentMessage messageEntity)
+	public static ActivityCommentMessageDTO createInstance(UserDTO actingUser, ActivityCommentMessage messageEntity,
+			SenderInfo sender)
 	{
-		boolean canReplyTo = !actingUser.getID().equals(messageEntity.getSenderUserID());
-		return new ActivityCommentMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getRelatedUserAnonymizedID(),
-				messageEntity.getSenderNickname(), messageEntity.getActivityID(), messageEntity.getThreadHeadMessageID(),
-				messageEntity.getRepliedMessageID(), messageEntity.getMessage(), canReplyTo);
+		return new ActivityCommentMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(),
+				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()),
+				messageEntity.getActivityID(), messageEntity.getThreadHeadMessageID(), messageEntity.getRepliedMessageID(),
+				messageEntity.getMessage());
 	}
 
 	@Component
@@ -115,7 +112,8 @@ public class ActivityCommentMessageDTO extends BuddyMessageLinkedUserDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			return ActivityCommentMessageDTO.createInstance(actingUser, (ActivityCommentMessage) messageEntity);
+			return ActivityCommentMessageDTO.createInstance(actingUser, (ActivityCommentMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override

--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDTO.java
@@ -24,6 +24,7 @@ import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
 import nu.yona.server.messaging.service.MessageServiceException;
+import nu.yona.server.messaging.service.SenderInfo;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("activityCommentMessage")

--- a/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDTO.java
@@ -28,6 +28,7 @@ import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
 import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
+import nu.yona.server.messaging.service.SenderInfo;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
 import nu.yona.server.subscriptions.service.UserDTO;
 

--- a/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDTO.java
@@ -28,18 +28,13 @@ import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageDestinationDTO;
 import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
-import nu.yona.server.subscriptions.service.BuddyDTO;
-import nu.yona.server.subscriptions.service.BuddyService;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("goalConflictMessage")
 public class GoalConflictMessageDTO extends MessageDTO
 {
-	private static final String SELF_NICKNAME = "<self>";
 	private static final String REQUEST_DISCLOSURE = "requestDisclosure";
-	private final String nickname;
-	private final Optional<UUID> buddyID;
 	private final Optional<String> url;
 	private final Status status;
 	private final ZonedDateTime activityStartTime;
@@ -47,13 +42,11 @@ public class GoalConflictMessageDTO extends MessageDTO
 	private final UUID goalID;
 	private final UUID activityCategoryID;
 
-	private GoalConflictMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, String nickname, Optional<UUID> buddyID,
-			UUID goalID, UUID activityCategoryID, Optional<String> url, Status status, ZonedDateTime activityStartTime,
+	private GoalConflictMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UUID goalID,
+			UUID activityCategoryID, Optional<String> url, Status status, ZonedDateTime activityStartTime,
 			ZonedDateTime activityEndTime)
 	{
-		super(id, creationTime, isRead);
-		this.nickname = nickname;
-		this.buddyID = buddyID;
+		super(id, sender, creationTime, isRead);
 		this.goalID = goalID;
 		this.activityCategoryID = activityCategoryID;
 		this.url = url;
@@ -72,28 +65,11 @@ public class GoalConflictMessageDTO extends MessageDTO
 	public Set<String> getPossibleActions()
 	{
 		Set<String> possibleActions = super.getPossibleActions();
-		if (this.isFromBuddy() && this.status == Status.ANNOUNCED)
+		if (this.isSentFromBuddy() && this.status == Status.ANNOUNCED)
 		{
 			possibleActions.add(REQUEST_DISCLOSURE);
 		}
 		return possibleActions;
-	}
-
-	@JsonIgnore
-	public boolean isFromBuddy()
-	{
-		return buddyID.isPresent();
-	}
-
-	public String getNickname()
-	{
-		return nickname;
-	}
-
-	@JsonIgnore
-	public Optional<UUID> getBuddyID()
-	{
-		return buddyID;
 	}
 
 	@JsonIgnore
@@ -136,23 +112,10 @@ public class GoalConflictMessageDTO extends MessageDTO
 		return true;
 	}
 
-	public static GoalConflictMessageDTO createInstance(GoalConflictMessage messageEntity, Optional<BuddyDTO> buddy)
+	private static GoalConflictMessageDTO createInstance(GoalConflictMessage messageEntity, SenderInfo sender)
 	{
-		String nickname;
-		Optional<UUID> buddyID;
-		if (buddy.isPresent())
-		{
-			nickname = buddy.get().getNickname();
-			buddyID = Optional.of(buddy.get().getID());
-		}
-		else
-		{
-			nickname = SELF_NICKNAME;
-			buddyID = Optional.empty();
-		}
-
-		return new GoalConflictMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				nickname, buddyID, messageEntity.getGoal().getID(), messageEntity.getActivity().getActivityCategory().getID(),
+		return new GoalConflictMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(), messageEntity.isRead(),
+				messageEntity.getGoal().getID(), messageEntity.getActivity().getActivityCategory().getID(),
 				messageEntity.isUrlDisclosed() ? messageEntity.getURL() : Optional.empty(), messageEntity.getStatus(),
 				messageEntity.getActivity().getStartTime(), messageEntity.getActivity().getEndTime());
 	}
@@ -162,9 +125,6 @@ public class GoalConflictMessageDTO extends MessageDTO
 	{
 		@Autowired
 		private TheDTOManager theDTOFactory;
-
-		@Autowired
-		private BuddyService buddyService;
 
 		@Autowired
 		private UserAnonymizedService userAnonymizedService;
@@ -181,8 +141,8 @@ public class GoalConflictMessageDTO extends MessageDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			Optional<BuddyDTO> buddy = getBuddy(actingUser, (GoalConflictMessage) messageEntity);
-			return GoalConflictMessageDTO.createInstance((GoalConflictMessage) messageEntity, buddy);
+			return GoalConflictMessageDTO.createInstance((GoalConflictMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override
@@ -217,25 +177,6 @@ public class GoalConflictMessageDTO extends MessageDTO
 		{
 			messageEntity.setStatus(Status.DISCLOSURE_REQUESTED);
 			return GoalConflictMessage.getRepository().save(messageEntity);
-		}
-
-		private Optional<BuddyDTO> getBuddy(UserDTO actingUser, GoalConflictMessage messageEntity)
-		{
-			UUID userAnonymizedID = messageEntity.getRelatedUserAnonymizedID();
-			if (actingUser.getPrivateData().getUserAnonymizedID().equals(userAnonymizedID))
-			{
-				return Optional.empty();
-			}
-
-			Set<BuddyDTO> buddies = buddyService.getBuddies(actingUser.getPrivateData().getBuddyIDs());
-			for (BuddyDTO buddy : buddies)
-			{
-				if (buddy.getUserAnonymizedID().filter(id -> id.equals(userAnonymizedID)).isPresent())
-				{
-					return Optional.of(buddy);
-				}
-			}
-			throw new IllegalStateException("Cannot find buddy for user anonymized ID '" + userAnonymizedID + "'");
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
@@ -23,6 +23,7 @@ import nu.yona.server.messaging.service.BuddyMessageLinkedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
+import nu.yona.server.messaging.service.SenderInfo;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("goalChangeMessage")

--- a/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDTO.java
@@ -32,10 +32,10 @@ public class GoalChangeMessageDTO extends BuddyMessageLinkedUserDTO
 	private final GoalDTO changedGoal;
 	private final Change change;
 
-	private GoalChangeMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO user, String nickname,
+	private GoalChangeMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO user,
 			GoalDTO changedGoal, Change change, String message)
 	{
-		super(id, creationTime, isRead, user, nickname, message);
+		super(id, sender, creationTime, isRead, user, message);
 
 		this.changedGoal = changedGoal;
 		this.change = change;
@@ -71,10 +71,10 @@ public class GoalChangeMessageDTO extends BuddyMessageLinkedUserDTO
 		return true;
 	}
 
-	public static GoalChangeMessageDTO createInstance(UserDTO actingUser, GoalChangeMessage messageEntity)
+	public static GoalChangeMessageDTO createInstance(UserDTO actingUser, GoalChangeMessage messageEntity, SenderInfo sender)
 	{
-		return new GoalChangeMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(),
+		return new GoalChangeMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(), messageEntity.isRead(),
+				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()),
 				GoalDTO.createInstance(messageEntity.getChangedGoal()), messageEntity.getChange(), messageEntity.getMessage());
 	}
 
@@ -93,7 +93,8 @@ public class GoalChangeMessageDTO extends BuddyMessageLinkedUserDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			return GoalChangeMessageDTO.createInstance(actingUser, (GoalChangeMessage) messageEntity);
+			return GoalChangeMessageDTO.createInstance(actingUser, (GoalChangeMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override

--- a/core/src/main/java/nu/yona/server/messaging/entities/DisclosureRequestMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/DisclosureRequestMessage.java
@@ -1,9 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
 
@@ -25,11 +22,10 @@ public class DisclosureRequestMessage extends BuddyMessage
 	// Default constructor is required for JPA
 	public DisclosureRequestMessage()
 	{
-
 	}
 
-	private DisclosureRequestMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID,
-			UUID targetGoalConflictMessageID, String senderUserNickname, String message)
+	private DisclosureRequestMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, UUID targetGoalConflictMessageID,
+			String senderUserNickname, String message)
 	{
 		super(id, senderUserID, senderUserAnonymizedID, senderUserNickname, message);
 		this.targetGoalConflictMessageID = targetGoalConflictMessageID;

--- a/core/src/main/java/nu/yona/server/messaging/entities/DisclosureResponseMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/DisclosureResponseMessage.java
@@ -1,9 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
 
@@ -28,8 +25,8 @@ public class DisclosureResponseMessage extends BuddyMessage
 
 	}
 
-	private DisclosureResponseMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID,
-			UUID targetGoalConflictMessageID, Status status, String senderNickname, String message)
+	private DisclosureResponseMessage(UUID id, UUID senderUserID, UUID senderUserAnonymizedID, UUID targetGoalConflictMessageID,
+			Status status, String senderNickname, String message)
 	{
 		super(id, senderUserID, senderUserAnonymizedID, senderNickname, message);
 		this.targetGoalConflictMessageID = targetGoalConflictMessageID;
@@ -61,7 +58,7 @@ public class DisclosureResponseMessage extends BuddyMessage
 	public static DisclosureResponseMessage createInstance(UUID senderUserID, UUID senderUserAnonymizedID,
 			UUID targetGoalConflictMessageID, Status status, String senderNickname, String message)
 	{
-		return new DisclosureResponseMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID,
-				targetGoalConflictMessageID, status, senderNickname, message);
+		return new DisclosureResponseMessage(UUID.randomUUID(), senderUserID, senderUserAnonymizedID, targetGoalConflictMessageID,
+				status, senderNickname, message);
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageDTO.java
@@ -16,23 +16,21 @@ import nu.yona.server.subscriptions.service.UserDTO;
 public abstract class BuddyMessageDTO extends MessageDTO
 {
 	private UserDTO senderUser;
-	private final String senderNickname;
 	private final String message;
 
-	protected BuddyMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser, String senderNickname, String message)
+	protected BuddyMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser,
+			String message)
 	{
-		super(id, creationTime, isRead);
+		super(id, sender, creationTime, isRead);
 		this.senderUser = senderUser;
-		this.senderNickname = senderNickname;
 		this.message = message;
 	}
 
-	protected BuddyMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID, UserDTO senderUser, String senderNickname,
-			String message)
+	protected BuddyMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID,
+			UserDTO senderUser, String message)
 	{
-		super(id, creationTime, isRead, relatedMessageID);
+		super(id, sender, creationTime, isRead, relatedMessageID);
 		this.senderUser = senderUser;
-		this.senderNickname = senderNickname;
 		this.message = message;
 	}
 
@@ -40,11 +38,6 @@ public abstract class BuddyMessageDTO extends MessageDTO
 	public UserDTO getUser()
 	{
 		return senderUser;
-	}
-
-	public String getNickname()
-	{
-		return senderNickname;
 	}
 
 	public String getMessage()

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDTO.java
@@ -19,15 +19,17 @@ public abstract class BuddyMessageEmbeddedUserDTO extends BuddyMessageDTO
 {
 	private Map<String, Object> embeddedResources = Collections.emptyMap();
 
-	protected BuddyMessageEmbeddedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser, String senderNickname, String message)
+	protected BuddyMessageEmbeddedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO senderUser,
+			String senderNickname, String message)
 	{
-		super(id, creationTime, isRead, senderUser, senderNickname, message);
+		super(id, SenderInfo.createInstanceBuddyDetached(senderUser, senderNickname), creationTime, isRead, senderUser, message);
 	}
 
-	protected BuddyMessageEmbeddedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UUID targetGoalConflictMessageOriginID,
-			UserDTO user, String nickname, String message)
+	protected BuddyMessageEmbeddedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID,
+			UserDTO senderUser, String senderNickname, String message)
 	{
-		super(id, creationTime, isRead, user, nickname, message);
+		super(id, SenderInfo.createInstanceBuddyDetached(senderUser, senderNickname), creationTime, isRead, relatedMessageID,
+				senderUser, message);
 	}
 
 	@JsonProperty("_embedded")

--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageLinkedUserDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageLinkedUserDTO.java
@@ -12,14 +12,15 @@ import nu.yona.server.subscriptions.service.UserDTO;
 public abstract class BuddyMessageLinkedUserDTO extends BuddyMessageDTO
 {
 
-	protected BuddyMessageLinkedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO user, String nickname, String message)
-	{
-		super(id, creationTime, isRead, user, nickname, message);
-	}
-
-	protected BuddyMessageLinkedUserDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID, UserDTO user, String nickname,
+	protected BuddyMessageLinkedUserDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO user,
 			String message)
 	{
-		super(id, creationTime, isRead, relatedMessageID, user, nickname, message);
+		super(id, sender, creationTime, isRead, user, message);
+	}
+
+	protected BuddyMessageLinkedUserDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead,
+			UUID relatedMessageID, UserDTO senderUser, String message)
+	{
+		super(id, sender, creationTime, isRead, relatedMessageID, senderUser, message);
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDTO.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.messaging.service;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.analysis.entities.GoalConflictMessage;
@@ -30,12 +32,17 @@ public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 	private static final String ACCEPT = "accept";
 	private static final String REJECT = "reject";
 
+	private final UUID targetGoalConflictGoalID;
+	private final LocalDate targetGoalConflictDate;
 	private final Status status;
 
-	private DisclosureRequestMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO user, String nickname,
-			String message, Status status, UUID targetGoalConflictMessageID)
+	private DisclosureRequestMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO user,
+			String message, Status status, UUID targetGoalConflictMessageID, UUID targetGoalConflictGoalID,
+			LocalDate targetGoalConflictDate)
 	{
-		super(id, creationTime, isRead, targetGoalConflictMessageID, user, nickname, message);
+		super(id, sender, creationTime, isRead, targetGoalConflictMessageID, user, message);
+		this.targetGoalConflictGoalID = targetGoalConflictGoalID;
+		this.targetGoalConflictDate = targetGoalConflictDate;
 		this.status = status;
 	}
 
@@ -57,6 +64,18 @@ public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 		return possibleActions;
 	}
 
+	@JsonIgnore
+	public UUID getTargetGoalConflictGoalID()
+	{
+		return targetGoalConflictGoalID;
+	}
+
+	@JsonIgnore
+	public LocalDate getTargetGoalConflictDate()
+	{
+		return targetGoalConflictDate;
+	}
+
 	public Status getStatus()
 	{
 		return status;
@@ -68,13 +87,15 @@ public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 		return this.status == Status.DISCLOSURE_ACCEPTED || this.status == Status.DISCLOSURE_REJECTED;
 	}
 
-	public static DisclosureRequestMessageDTO createInstance(UserDTO actingUser, DisclosureRequestMessage messageEntity)
+	public static DisclosureRequestMessageDTO createInstance(UserDTO actingUser, DisclosureRequestMessage messageEntity,
+			SenderInfo sender)
 	{
 		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
-		return new DisclosureRequestMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(),
-				messageEntity.getMessage(), messageEntity.getStatus(),
-				targetGoalConflictMessage.getOriginGoalConflictMessageID());
+		return new DisclosureRequestMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(),
+				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()),
+				messageEntity.getMessage(), messageEntity.getStatus(), targetGoalConflictMessage.getOriginGoalConflictMessageID(),
+				targetGoalConflictMessage.getGoal().getID(),
+				targetGoalConflictMessage.getActivity().getStartTime().toLocalDate());
 	}
 
 	@Component
@@ -98,7 +119,8 @@ public class DisclosureRequestMessageDTO extends BuddyMessageLinkedUserDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			return DisclosureRequestMessageDTO.createInstance(actingUser, (DisclosureRequestMessage) messageEntity);
+			return DisclosureRequestMessageDTO.createInstance(actingUser, (DisclosureRequestMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDTO.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.messaging.service;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.UUID;
@@ -13,6 +14,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
 import nu.yona.server.analysis.entities.GoalConflictMessage;
@@ -25,13 +27,18 @@ import nu.yona.server.subscriptions.service.UserDTO;
 @JsonRootName("disclosureResponseMessage")
 public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 {
+	private final UUID targetGoalConflictGoalID;
+	private final LocalDate targetGoalConflictDate;
 	private final Status status;
 
-	private DisclosureResponseMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO user, Status status,
-			String nickname, String message, UUID targetGoalConflictMessageID)
+	private DisclosureResponseMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO user,
+			Status status, String message, UUID targetGoalConflictMessageID, UUID targetGoalConflictGoalID,
+			LocalDate targetGoalConflictDate)
 	{
-		super(id, creationTime, isRead, targetGoalConflictMessageID, user, nickname, message);
+		super(id, sender, creationTime, isRead, targetGoalConflictMessageID, user, message);
 		this.status = status;
+		this.targetGoalConflictGoalID = targetGoalConflictGoalID;
+		this.targetGoalConflictDate = targetGoalConflictDate;
 	}
 
 	@Override
@@ -47,6 +54,18 @@ public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 		return possibleActions;
 	}
 
+	@JsonIgnore
+	public UUID getTargetGoalConflictGoalID()
+	{
+		return targetGoalConflictGoalID;
+	}
+
+	@JsonIgnore
+	public LocalDate getTargetGoalConflictDate()
+	{
+		return targetGoalConflictDate;
+	}
+
 	public Status getStatus()
 	{
 		return status;
@@ -58,12 +77,14 @@ public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 		return true;
 	}
 
-	public static DisclosureResponseMessageDTO createInstance(UserDTO actingUser, DisclosureResponseMessage messageEntity)
+	public static DisclosureResponseMessageDTO createInstance(UserDTO actingUser, DisclosureResponseMessage messageEntity,
+			SenderInfo sender)
 	{
 		GoalConflictMessage targetGoalConflictMessage = messageEntity.getTargetGoalConflictMessage();
-		return new DisclosureResponseMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getStatus(),
-				messageEntity.getSenderNickname(), messageEntity.getMessage(), targetGoalConflictMessage.getID());
+		return new DisclosureResponseMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(),
+				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getStatus(),
+				messageEntity.getMessage(), targetGoalConflictMessage.getID(), targetGoalConflictMessage.getGoal().getID(),
+				targetGoalConflictMessage.getActivity().getStartTime().toLocalDate());
 	}
 
 	@Component
@@ -81,7 +102,8 @@ public class DisclosureResponseMessageDTO extends BuddyMessageLinkedUserDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			return DisclosureResponseMessageDTO.createInstance(actingUser, (DisclosureResponseMessage) messageEntity);
+			return DisclosureResponseMessageDTO.createInstance(actingUser, (DisclosureResponseMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -174,7 +174,7 @@ public abstract class MessageDTO extends PolymorphicDTO
 			if (messageEntity instanceof BuddyMessage)
 			{
 				// this buddy may be not yet connected or no longer connected
-				return getSenderBuddyNotPresent((BuddyMessage) messageEntity);
+				return getSenderBuddyDetached((BuddyMessage) messageEntity);
 			}
 
 			throw new IllegalStateException("Cannot find buddy for user anonymized ID '" + senderUserAnonymizedID + "'");
@@ -190,9 +190,9 @@ public abstract class MessageDTO extends PolymorphicDTO
 			return SenderInfo.createInstanceBuddy(buddy.getUser().getID(), buddy.getNickname(), buddy.getID());
 		}
 
-		private SenderInfo getSenderBuddyNotPresent(BuddyMessage messageEntity)
+		private SenderInfo getSenderBuddyDetached(BuddyMessage messageEntity)
 		{
-			return SenderInfo.createInstanceBuddyNotPresent(messageEntity.getSenderUserID(), messageEntity.getSenderNickname());
+			return SenderInfo.createInstanceBuddyDetached(messageEntity.getSenderUserID(), messageEntity.getSenderNickname());
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -24,6 +24,7 @@ import nu.yona.server.Constants;
 import nu.yona.server.analysis.service.ActivityCommentMessageDTO;
 import nu.yona.server.analysis.service.GoalConflictMessageDTO;
 import nu.yona.server.goals.service.GoalChangeMessageDTO;
+import nu.yona.server.messaging.entities.BuddyMessage;
 import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.service.MessageService.DTOManager;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
@@ -170,6 +171,15 @@ public abstract class MessageDTO extends PolymorphicDTO
 					return SenderInfo.createInstanceBuddy(buddy.getUser().getID(), buddy.getNickname(), buddy.getID());
 				}
 			}
+
+			if (messageEntity instanceof BuddyMessage)
+			{
+				BuddyMessage buddyMessageEntity = (BuddyMessage) messageEntity;
+				// this buddy may be not yet connected or no longer connected
+				return SenderInfo.createInstanceBuddyNotPresent(buddyMessageEntity.getSenderUserID(),
+						buddyMessageEntity.getSenderNickname());
+			}
+
 			throw new IllegalStateException("Cannot find buddy for user anonymized ID '" + userAnonymizedID + "'");
 		}
 	}
@@ -198,6 +208,11 @@ public abstract class MessageDTO extends PolymorphicDTO
 			return new SenderInfo(userID, nickname, true, Optional.of(buddyID));
 		}
 
+		public static SenderInfo createInstanceBuddyNotPresent(UUID userID, String nickname)
+		{
+			return new SenderInfo(userID, nickname, true, Optional.empty());
+		}
+
 		public static SenderInfo createInstanceBuddyDetached(UserDTO user, String nickname)
 		{
 			// user may be null if removed
@@ -206,7 +221,8 @@ public abstract class MessageDTO extends PolymorphicDTO
 
 		public static SenderInfo createInstanceSelf(UUID userID, String nickname)
 		{
-			return new SenderInfo(userID, nickname, false, Optional.empty());
+			// TODO: return real nickname?
+			return new SenderInfo(userID, "<self>", false, Optional.empty());
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -173,7 +173,8 @@ public abstract class MessageDTO extends PolymorphicDTO
 
 			if (messageEntity instanceof BuddyMessage)
 			{
-				return getSenderBuddyNotPresent(messageEntity);
+				// this buddy may be not yet connected or no longer connected
+				return getSenderBuddyNotPresent((BuddyMessage) messageEntity);
 			}
 
 			throw new IllegalStateException("Cannot find buddy for user anonymized ID '" + senderUserAnonymizedID + "'");
@@ -189,12 +190,9 @@ public abstract class MessageDTO extends PolymorphicDTO
 			return SenderInfo.createInstanceBuddy(buddy.getUser().getID(), buddy.getNickname(), buddy.getID());
 		}
 
-		private SenderInfo getSenderBuddyNotPresent(Message messageEntity)
+		private SenderInfo getSenderBuddyNotPresent(BuddyMessage messageEntity)
 		{
-			BuddyMessage buddyMessageEntity = (BuddyMessage) messageEntity;
-			// this buddy may be not yet connected or no longer connected
-			return SenderInfo.createInstanceBuddyNotPresent(buddyMessageEntity.getSenderUserID(),
-					buddyMessageEntity.getSenderNickname());
+			return SenderInfo.createInstanceBuddyNotPresent(messageEntity.getSenderUserID(), messageEntity.getSenderNickname());
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDTO.java
@@ -6,6 +6,7 @@ package nu.yona.server.messaging.service;
 
 import java.time.ZonedDateTime;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -29,7 +30,9 @@ import nu.yona.server.messaging.service.MessageService.TheDTOManager;
 import nu.yona.server.rest.PolymorphicDTO;
 import nu.yona.server.subscriptions.service.BuddyConnectRequestMessageDTO;
 import nu.yona.server.subscriptions.service.BuddyConnectResponseMessageDTO;
+import nu.yona.server.subscriptions.service.BuddyDTO;
 import nu.yona.server.subscriptions.service.BuddyDisconnectMessageDTO;
+import nu.yona.server.subscriptions.service.BuddyService;
 import nu.yona.server.subscriptions.service.UserDTO;
 
 @JsonRootName("message")
@@ -46,18 +49,20 @@ public abstract class MessageDTO extends PolymorphicDTO
 	private static final String MARK_UNREAD = "markUnread";
 	private static final String MARK_READ = "markRead";
 	private final UUID id;
+	private final SenderInfo sender;
 	private final ZonedDateTime creationTime;
 	private final UUID relatedMessageID;
 	private final boolean isRead;
 
-	protected MessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead)
+	protected MessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead)
 	{
-		this(id, creationTime, isRead, null);
+		this(id, sender, creationTime, isRead, null);
 	}
 
-	protected MessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID)
+	protected MessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UUID relatedMessageID)
 	{
 		this.id = id;
+		this.sender = sender;
 		this.creationTime = creationTime;
 		this.isRead = isRead;
 		this.relatedMessageID = relatedMessageID;
@@ -67,6 +72,24 @@ public abstract class MessageDTO extends PolymorphicDTO
 	public UUID getID()
 	{
 		return id;
+	}
+
+	@JsonIgnore
+	public boolean isSentFromBuddy()
+	{
+		return sender.isBuddy;
+	}
+
+	@JsonProperty("nickname")
+	public String getSenderNickname()
+	{
+		return sender.nickname;
+	}
+
+	@JsonIgnore
+	public Optional<UUID> getSenderBuddyID()
+	{
+		return sender.buddyID;
 	}
 
 	@JsonFormat(pattern = Constants.ISO_DATE_PATTERN)
@@ -104,6 +127,9 @@ public abstract class MessageDTO extends PolymorphicDTO
 		@Autowired
 		private TheDTOManager theDTOFactory;
 
+		@Autowired
+		private BuddyService buddyService;
+
 		@Override
 		public MessageActionDTO handleAction(UserDTO actingUser, Message messageEntity, String action,
 				MessageActionDTO requestPayload)
@@ -126,6 +152,61 @@ public abstract class MessageDTO extends PolymorphicDTO
 			Message savedMessageEntity = Message.getRepository().save(messageEntity);
 
 			return MessageActionDTO.createInstanceActionDone(theDTOFactory.createInstance(actingUser, savedMessageEntity));
+		}
+
+		protected SenderInfo getSender(UserDTO actingUser, Message messageEntity)
+		{
+			UUID userAnonymizedID = messageEntity.getRelatedUserAnonymizedID();
+			if (actingUser.getPrivateData().getUserAnonymizedID().equals(userAnonymizedID))
+			{
+				return SenderInfo.createInstanceSelf(actingUser.getID(), actingUser.getPrivateData().getNickname());
+			}
+
+			Set<BuddyDTO> buddies = buddyService.getBuddies(actingUser.getPrivateData().getBuddyIDs());
+			for (BuddyDTO buddy : buddies)
+			{
+				if (buddy.getUserAnonymizedID().filter(id -> id.equals(userAnonymizedID)).isPresent())
+				{
+					return SenderInfo.createInstanceBuddy(buddy.getUser().getID(), buddy.getNickname(), buddy.getID());
+				}
+			}
+			throw new IllegalStateException("Cannot find buddy for user anonymized ID '" + userAnonymizedID + "'");
+		}
+	}
+
+	/*
+	 * Sender info of the message. The class contents can only be determined when the user reads incoming messages, because buddy
+	 * IDs are only known to the user, and for the analysis service sending goal conflicts the user ID and nickname are not known.
+	 */
+	public final static class SenderInfo
+	{
+		public final UUID userID;
+		public final String nickname;
+		public final boolean isBuddy;
+		public final Optional<UUID> buddyID;
+
+		private SenderInfo(UUID userID, String nickname, boolean isBuddy, Optional<UUID> buddyID)
+		{
+			this.userID = userID;
+			this.nickname = nickname;
+			this.isBuddy = isBuddy;
+			this.buddyID = buddyID;
+		}
+
+		public static SenderInfo createInstanceBuddy(UUID userID, String nickname, UUID buddyID)
+		{
+			return new SenderInfo(userID, nickname, true, Optional.of(buddyID));
+		}
+
+		public static SenderInfo createInstanceBuddyDetached(UserDTO user, String nickname)
+		{
+			// user may be null if removed
+			return new SenderInfo(user != null ? user.getID() : null, nickname, true, Optional.empty());
+		}
+
+		public static SenderInfo createInstanceSelf(UUID userID, String nickname)
+		{
+			return new SenderInfo(userID, nickname, false, Optional.empty());
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -60,6 +60,7 @@ public class MessageService
 		return messageSource.getReceivedMessages(pageable, onlyUnreadMessages);
 	}
 
+	@Transactional
 	public MessageDTO getMessage(UUID userID, UUID messageID)
 	{
 		UserDTO user = userService.getPrivateValidatedUser(userID);
@@ -68,6 +69,7 @@ public class MessageService
 		return dtoManager.createInstance(user, messageSource.getMessage(messageID));
 	}
 
+	@Transactional
 	public MessageActionDTO handleMessageAction(UUID userID, UUID id, String action, MessageActionDTO requestPayload)
 	{
 		UserDTO user = userService.getPrivateValidatedUser(userID);

--- a/core/src/main/java/nu/yona/server/messaging/service/SenderInfo.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/SenderInfo.java
@@ -1,0 +1,67 @@
+package nu.yona.server.messaging.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import nu.yona.server.subscriptions.service.UserDTO;
+
+/*
+ * Sender info of the message. The class contents can only be determined when the user reads incoming messages, because buddy IDs
+ * are only known to the user, and for the analysis service sending goal conflicts the user ID and nickname are not known.
+ */
+public final class SenderInfo
+{
+	private final UUID userID;
+	private final String nickname;
+	private final boolean isBuddy;
+	private final Optional<UUID> buddyID;
+
+	private SenderInfo(UUID userID, String nickname, boolean isBuddy, Optional<UUID> buddyID)
+	{
+		this.userID = userID;
+		this.nickname = nickname;
+		this.isBuddy = isBuddy;
+		this.buddyID = buddyID;
+	}
+
+	public UUID getUserID()
+	{
+		return userID;
+	}
+
+	public String getNickname()
+	{
+		return nickname;
+	}
+
+	public boolean isBuddy()
+	{
+		return isBuddy;
+	}
+
+	public Optional<UUID> getBuddyID()
+	{
+		return buddyID;
+	}
+
+	public static SenderInfo createInstanceBuddy(UUID userID, String nickname, UUID buddyID)
+	{
+		return new SenderInfo(userID, nickname, true, Optional.of(buddyID));
+	}
+
+	public static SenderInfo createInstanceBuddyNotPresent(UUID userID, String nickname)
+	{
+		return new SenderInfo(userID, nickname, true, Optional.empty());
+	}
+
+	public static SenderInfo createInstanceBuddyDetached(UserDTO user, String nickname)
+	{
+		// user may be null if removed
+		return new SenderInfo(user != null ? user.getID() : null, nickname, true, Optional.empty());
+	}
+
+	public static SenderInfo createInstanceSelf(UUID userID, String nickname)
+	{
+		return new SenderInfo(userID, "<self>", false, Optional.empty());
+	}
+}

--- a/core/src/main/java/nu/yona/server/messaging/service/SenderInfo.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/SenderInfo.java
@@ -49,7 +49,7 @@ public final class SenderInfo
 		return new SenderInfo(userID, nickname, true, Optional.of(buddyID));
 	}
 
-	public static SenderInfo createInstanceBuddyNotPresent(UUID userID, String nickname)
+	public static SenderInfo createInstanceBuddyDetached(UUID userID, String nickname)
 	{
 		return new SenderInfo(userID, nickname, true, Optional.empty());
 	}
@@ -57,7 +57,7 @@ public final class SenderInfo
 	public static SenderInfo createInstanceBuddyDetached(UserDTO user, String nickname)
 	{
 		// user may be null if removed
-		return new SenderInfo(user != null ? user.getID() : null, nickname, true, Optional.empty());
+		return createInstanceBuddyDetached(user != null ? user.getID() : null, nickname);
 	}
 
 	public static SenderInfo createInstanceSelf(UUID userID, String nickname)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDTO.java
@@ -35,7 +35,8 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 	private Status status;
 
 	private BuddyConnectRequestMessageDTO(BuddyConnectRequestMessage buddyConnectRequestMessageEntity, UUID id,
-			ZonedDateTime creationTime, boolean isRead, UserDTO user, UUID userAnonymizedID, String nickname, String message, Status status)
+			ZonedDateTime creationTime, boolean isRead, UserDTO user, UUID userAnonymizedID, String nickname, String message,
+			Status status)
 	{
 		super(id, creationTime, isRead, user, nickname, message);
 
@@ -84,8 +85,9 @@ public class BuddyConnectRequestMessageDTO extends BuddyMessageEmbeddedUserDTO
 	public static BuddyConnectRequestMessageDTO createInstance(UserDTO actingUser, BuddyConnectRequestMessage messageEntity)
 	{
 		return new BuddyConnectRequestMessageDTO(messageEntity, messageEntity.getID(), messageEntity.getCreationTime(),
-				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getRelatedUserAnonymizedID(),
-				messageEntity.getSenderNickname(), messageEntity.getMessage(), messageEntity.getStatus());
+				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()),
+				messageEntity.getRelatedUserAnonymizedID(), messageEntity.getSenderNickname(), messageEntity.getMessage(),
+				messageEntity.getStatus());
 	}
 
 	@Component

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
@@ -33,10 +33,10 @@ public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 	private final Status status;
 	private final boolean isProcessed;
 
-	private BuddyConnectResponseMessageDTO(UUID id, ZonedDateTime creationTime, boolean isRead, UserDTO user, String nickname,
+	private BuddyConnectResponseMessageDTO(UUID id, SenderInfo sender, ZonedDateTime creationTime, boolean isRead, UserDTO user,
 			String message, Status status, boolean isProcessed)
 	{
-		super(id, creationTime, isRead, user, nickname, message);
+		super(id, sender, creationTime, isRead, user, message);
 		this.status = status;
 		this.isProcessed = isProcessed;
 	}
@@ -75,10 +75,11 @@ public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 		return this.isProcessed;
 	}
 
-	public static BuddyConnectResponseMessageDTO createInstance(UserDTO actingUser, BuddyConnectResponseMessage messageEntity)
+	public static BuddyConnectResponseMessageDTO createInstance(UserDTO actingUser, BuddyConnectResponseMessage messageEntity,
+			SenderInfo sender)
 	{
-		return new BuddyConnectResponseMessageDTO(messageEntity.getID(), messageEntity.getCreationTime(), messageEntity.isRead(),
-				UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()), messageEntity.getSenderNickname(),
+		return new BuddyConnectResponseMessageDTO(messageEntity.getID(), sender, messageEntity.getCreationTime(),
+				messageEntity.isRead(), UserDTO.createInstanceIfNotNull(messageEntity.getSenderUser()),
 				messageEntity.getMessage(), messageEntity.getStatus(), messageEntity.isProcessed());
 	}
 
@@ -102,7 +103,8 @@ public class BuddyConnectResponseMessageDTO extends BuddyMessageLinkedUserDTO
 		@Override
 		public MessageDTO createInstance(UserDTO actingUser, Message messageEntity)
 		{
-			return BuddyConnectResponseMessageDTO.createInstance(actingUser, (BuddyConnectResponseMessage) messageEntity);
+			return BuddyConnectResponseMessageDTO.createInstance(actingUser, (BuddyConnectResponseMessage) messageEntity,
+					getSender(actingUser, messageEntity));
 		}
 
 		@Override

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectResponseMessageDTO.java
@@ -23,6 +23,7 @@ import nu.yona.server.messaging.service.BuddyMessageLinkedUserDTO;
 import nu.yona.server.messaging.service.MessageActionDTO;
 import nu.yona.server.messaging.service.MessageDTO;
 import nu.yona.server.messaging.service.MessageService.TheDTOManager;
+import nu.yona.server.messaging.service.SenderInfo;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.BuddyConnectResponseMessage;
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -513,4 +513,17 @@ public class BuddyService
 			return null;
 		}
 	}
+
+	public Optional<BuddyDTO> getBuddyOfUserByUserAnonymizedID(UUID forUserID, UUID userAnonymizedID)
+	{
+		Set<BuddyDTO> buddies = getBuddiesOfUser(forUserID);
+		for (BuddyDTO buddy : buddies)
+		{
+			if (buddy.getUserAnonymizedID().filter(id -> id.equals(userAnonymizedID)).isPresent())
+			{
+				return Optional.of(buddy);
+			}
+		}
+		return Optional.empty();
+	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -216,7 +216,7 @@ public class BuddyService
 		final int pageSize = 50;
 		Page<Message> messagePage;
 		boolean messageFound = false;
-		UserDTO user = UserDTO.createInstance(userEntity);
+		UserDTO user = userService.createUserDTOWithPrivateData(userEntity);
 		do
 		{
 			messagePage = messageService.getReceivedMessageEntities(user.getID(), new PageRequest(page++, pageSize));

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -164,7 +164,7 @@ public class UserService
 		return userDTO;
 	}
 
-	private UserDTO createUserDTOWithPrivateData(User user)
+	UserDTO createUserDTOWithPrivateData(User user)
 	{
 		return UserDTO.createInstanceWithPrivateData(user,
 				(buddyIDs) -> buddyIDs.stream().map((bid) -> buddyService.getBuddy(bid)).collect(Collectors.toSet()));

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -321,6 +321,7 @@ class AppService extends Service
 		def message = buddyConnectResponseMessages[0]?.message ?: null
 		def status = buddyConnectResponseMessages[0]?.status ?: null
 		def processURL = buddyConnectResponseMessages[0]?._links?."yona:process"?.href
+		def buddyURL = buddyConnectResponseMessages[0]?._links?."yona:buddy"?.href
 		def result = [ : ]
 		if (selfURL)
 		{
@@ -337,6 +338,10 @@ class AppService extends Service
 		if (processURL)
 		{
 			result.processURL = processURL
+		}
+		if (buddyURL)
+		{
+			result.buddyURL = buddyURL
 		}
 
 		return result


### PR DESCRIPTION
- Added following links:
1.disclose request message: link of  URL from  day activity detail of myself 
2.disclose response message: link of URL from  day activity detail of  buddy (if disclosed)
3.buddy connect response message: link to  buddy URL in user
4.goal change message: link to URL of day activity overview of buddy
- Refactored sender structure (made it more consistent)
- Using <self> in activity comment message instead of nickname for consistency