### PR TITLE
YD-370 Generalized LockPool and added unit test

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
+++ b/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
@@ -4,6 +4,8 @@
  *******************************************************************************/
 package nu.yona.server;
 
+import java.util.UUID;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -11,7 +13,7 @@ import org.springframework.boot.context.web.SpringBootServletInitializer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 
-import nu.yona.server.analysis.service.UserAnonymizedSynchronizer;
+import nu.yona.server.util.LockPool;
 
 @SpringBootApplication
 @EnableCaching
@@ -29,8 +31,8 @@ public class AnalysisServiceApplication extends SpringBootServletInitializer
 	}
 
 	@Bean
-	public UserAnonymizedSynchronizer userAnonymizedSynchronizer()
+	public LockPool<UUID> userAnonymizedSynchronizer()
 	{
-		return new UserAnonymizedSynchronizer();
+		return new LockPool<>();
 	}
 }

--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -23,7 +23,6 @@ import nu.yona.server.analysis.entities.DayActivity;
 import nu.yona.server.analysis.entities.DayActivityRepository;
 import nu.yona.server.analysis.entities.GoalConflictMessage;
 import nu.yona.server.analysis.entities.WeekActivity;
-import nu.yona.server.analysis.service.UserAnonymizedSynchronizer.Lock;
 import nu.yona.server.exceptions.AnalysisException;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.service.ActivityCategoryDTO;
@@ -35,6 +34,7 @@ import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.service.UserAnonymizedDTO;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
+import nu.yona.server.util.LockPool;
 
 @Service
 public class AnalysisEngineService
@@ -56,7 +56,7 @@ public class AnalysisEngineService
 	@Autowired(required = false)
 	private DayActivityRepository dayActivityRepository;
 	@Autowired
-	private UserAnonymizedSynchronizer userAnonymizedSynchronizer;
+	private LockPool<UUID> userAnonymizedSynchronizer;
 
 	@Transactional
 	public void analyze(UUID userAnonymizedID, AppActivityDTO appActivities)
@@ -332,7 +332,7 @@ public class AnalysisEngineService
 
 	private DayActivity createNewDayActivity(ActivityPayload payload, UserAnonymizedDTO userAnonymized, Goal matchingGoal)
 	{
-		try (Lock lock = userAnonymizedSynchronizer.lock(userAnonymized.getID()))
+		try (LockPool<UUID>.Lock lock = userAnonymizedSynchronizer.lock(userAnonymized.getID()))
 		{
 			ZonedDateTime startOfDay = getStartOfDay(payload.startTime, userAnonymized);
 

--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/InactivityManagementService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/InactivityManagementService.java
@@ -21,11 +21,11 @@ import nu.yona.server.analysis.entities.DayActivity;
 import nu.yona.server.analysis.entities.DayActivityRepository;
 import nu.yona.server.analysis.entities.WeekActivity;
 import nu.yona.server.analysis.entities.WeekActivityRepository;
-import nu.yona.server.analysis.service.UserAnonymizedSynchronizer.Lock;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.service.GoalService;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
+import nu.yona.server.util.LockPool;
 
 @Service
 public class InactivityManagementService
@@ -43,12 +43,12 @@ public class InactivityManagementService
 	private GoalService goalService;
 
 	@Autowired
-	private UserAnonymizedSynchronizer userAnonymizedSynchronizer;
+	private LockPool<UUID> userAnonymizedSynchronizer;
 
 	@Transactional
 	public void createInactivityEntities(UUID userAnonymizedID, Set<IntervalInactivityDTO> intervalInactivities)
 	{
-		try (Lock lock = userAnonymizedSynchronizer.lock(userAnonymizedID))
+		try (LockPool<UUID>.Lock lock = userAnonymizedSynchronizer.lock(userAnonymizedID))
 		{
 			createWeekInactivityEntities(userAnonymizedID,
 					intervalInactivities.stream().filter(ia -> ia.getTimeUnit() == ChronoUnit.WEEKS).collect(Collectors.toSet()));

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTests.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTests.java
@@ -64,6 +64,7 @@ import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.service.UserAnonymizedDTO;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
+import nu.yona.server.util.LockPool;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AnalysisEngineServiceTests
@@ -85,7 +86,7 @@ public class AnalysisEngineServiceTests
 	@Mock
 	private DayActivityRepository mockDayActivityRepository;
 	@Mock
-	private UserAnonymizedSynchronizer userAnonymizedSynchronizer;
+	private LockPool<UUID> userAnonymizedSynchronizer;
 	@InjectMocks
 	private final AnalysisEngineService service = new AnalysisEngineService();
 

--- a/core/src/test/java/nu/yona/server/util/LockPoolTest.java
+++ b/core/src/test/java/nu/yona/server/util/LockPoolTest.java
@@ -1,0 +1,165 @@
+package nu.yona.server.util;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import nu.yona.server.exceptions.YonaException;
+
+public class LockPoolTest
+{
+	private final AtomicInteger freeLockID = new AtomicInteger(0);
+
+	@Test
+	public void testLockingNonReentrant()
+	{
+		final int numThreads = 10;
+		final int iterations = 10000;
+		assertThat(testConcurrently(numThreads, iterations, this::attemptNonReentrantAccess), equalTo(0));
+	}
+
+	@Test
+	public void testLockingReentrant()
+	{
+		final int numThreads = 10;
+		final int iterations = 10000;
+		assertThat(testConcurrently(numThreads, iterations, this::attemptReentrantAccess), equalTo(0));
+	}
+
+	@Test
+	public void testConcurrencyDifferentKeys()
+	{
+		final int numThreads = 10;
+		final int iterations = 5;
+		assertThat(testConcurrently(numThreads, iterations, this::attempImmediateAccessRandomID), equalTo(0));
+	}
+
+	private int testConcurrently(int numThreads, int iterations, AccessAttempt accessAttempt)
+	{
+		LockPool<Integer> lockPool = new LockPool<>();
+		ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+		CountDownLatch startSignal = new CountDownLatch(1);
+		CountDownLatch doneSignal = new CountDownLatch(numThreads);
+		AtomicBoolean concurrencyIndicator = new AtomicBoolean(false);
+		AtomicInteger failureCounter = new AtomicInteger(0);
+		for (int i = 0; (i < numThreads); i++)
+		{
+			threadPool.execute(() -> tryAccess(iterations, startSignal, lockPool, concurrencyIndicator, failureCounter,
+					doneSignal, accessAttempt));
+		}
+		startSignal.countDown();
+		awaitWithoutInterrupt(doneSignal);
+		threadPool.shutdown();
+		return failureCounter.get();
+	}
+
+	private void tryAccess(int iterations, CountDownLatch startSignal, LockPool<Integer> lockPool,
+			AtomicBoolean concurrencyIndicator, AtomicInteger failureCounter, CountDownLatch doneSignal,
+			AccessAttempt accessAtempt)
+	{
+		awaitWithoutInterrupt(startSignal);
+		for (int i = 0; (i < iterations); i++)
+		{
+			accessAtempt.attempt(lockPool, concurrencyIndicator, failureCounter);
+		}
+		doneSignal.countDown();
+	}
+
+	private void attemptNonReentrantAccess(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
+			AtomicInteger failureCounter)
+	{
+		int lockID = 0;
+		try (LockPool<Integer>.Lock lock = lockPool.lock(lockID))
+		{
+			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+		}
+	}
+
+	private void attemptReentrantAccess(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
+			AtomicInteger failureCounter)
+	{
+		int lockID = 0;
+		try (LockPool<Integer>.Lock lock1 = lockPool.lock(0))
+		{
+			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+			try (LockPool<Integer>.Lock lock2 = lockPool.lock(lockID))
+			{
+				verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+			}
+			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+		}
+	}
+
+	private void attempImmediateAccessRandomID(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
+			AtomicInteger failureCounter)
+	{
+		int lockID = freeLockID.incrementAndGet();
+		int sleepDuration = 500;
+		long startTime = System.currentTimeMillis();
+		long accessTime;
+		try (LockPool<Integer>.Lock lock1 = lockPool.lock(lockID))
+		{
+			try (LockPool<Integer>.Lock lock2 = lockPool.lock(lockID))
+			{
+				accessTime = System.currentTimeMillis();
+				sleepWithoutInterrupt(sleepDuration);
+			}
+		}
+		if (accessTime - startTime > sleepDuration / 2)
+		{
+			// Delay was more than half the sleep duration, so we apparently were held up
+			failureCounter.incrementAndGet();
+		}
+	}
+
+	private void verifyNonConcurrentExecution(AtomicBoolean concurrencyIndicator, AtomicInteger failureCounter)
+	{
+		if (concurrencyIndicator.compareAndSet(false, true))
+		{
+			// No one else is here
+			concurrencyIndicator.set(false);
+		}
+		else
+		{
+			// Someone else is here
+			failureCounter.incrementAndGet();
+		}
+	}
+
+	private void awaitWithoutInterrupt(CountDownLatch startSignal)
+	{
+		try
+		{
+			startSignal.await();
+		}
+		catch (InterruptedException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private void sleepWithoutInterrupt(long millis)
+	{
+		try
+		{
+			Thread.sleep(millis);
+		}
+		catch (InterruptedException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	@FunctionalInterface
+	static interface AccessAttempt
+	{
+		void attempt(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator, AtomicInteger testCounter);
+	}
+}

--- a/core/src/test/java/nu/yona/server/util/LockPoolTest.java
+++ b/core/src/test/java/nu/yona/server/util/LockPoolTest.java
@@ -21,16 +21,16 @@ public class LockPoolTest
 	public void testLockingNonReentrant()
 	{
 		final int numThreads = 10;
-		final int iterations = 10000;
-		assertThat(testConcurrently(numThreads, iterations, this::attemptNonReentrantAccess), equalTo(0));
+		final int iterations = 100;
+		assertThat(testConcurrently(numThreads, iterations, this::attemptNonReentrantAccess), equalTo(false));
 	}
 
 	@Test
 	public void testLockingReentrant()
 	{
 		final int numThreads = 10;
-		final int iterations = 10000;
-		assertThat(testConcurrently(numThreads, iterations, this::attemptReentrantAccess), equalTo(0));
+		final int iterations = 100;
+		assertThat(testConcurrently(numThreads, iterations, this::attemptReentrantAccess), equalTo(false));
 	}
 
 	@Test
@@ -38,67 +38,67 @@ public class LockPoolTest
 	{
 		final int numThreads = 10;
 		final int iterations = 5;
-		assertThat(testConcurrently(numThreads, iterations, this::attempImmediateAccessRandomID), equalTo(0));
+		assertThat(testConcurrently(numThreads, iterations, this::attempImmediateAccessRandomID), equalTo(false));
 	}
 
-	private int testConcurrently(int numThreads, int iterations, AccessAttempt accessAttempt)
+	private boolean testConcurrently(int numThreads, int iterations, AccessAttempt accessAttempt)
 	{
 		LockPool<Integer> lockPool = new LockPool<>();
 		ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
 		CountDownLatch startSignal = new CountDownLatch(1);
 		CountDownLatch doneSignal = new CountDownLatch(numThreads);
 		AtomicBoolean concurrencyIndicator = new AtomicBoolean(false);
-		AtomicInteger failureCounter = new AtomicInteger(0);
+		AtomicBoolean failureIndicator = new AtomicBoolean(false);
 		for (int i = 0; (i < numThreads); i++)
 		{
-			threadPool.execute(() -> tryAccess(iterations, startSignal, lockPool, concurrencyIndicator, failureCounter,
+			threadPool.execute(() -> tryAccess(iterations, startSignal, lockPool, concurrencyIndicator, failureIndicator,
 					doneSignal, accessAttempt));
 		}
 		startSignal.countDown();
 		awaitWithoutInterrupt(doneSignal);
 		threadPool.shutdown();
-		return failureCounter.get();
+		return failureIndicator.get();
 	}
 
 	private void tryAccess(int iterations, CountDownLatch startSignal, LockPool<Integer> lockPool,
-			AtomicBoolean concurrencyIndicator, AtomicInteger failureCounter, CountDownLatch doneSignal,
-			AccessAttempt accessAtempt)
+			AtomicBoolean concurrencyIndicator, AtomicBoolean failureIndicator, CountDownLatch doneSignal,
+			AccessAttempt accessAttempt)
 	{
 		awaitWithoutInterrupt(startSignal);
 		for (int i = 0; (i < iterations); i++)
 		{
-			accessAtempt.attempt(lockPool, concurrencyIndicator, failureCounter);
+			accessAttempt.attempt(lockPool, concurrencyIndicator, failureIndicator);
 		}
 		doneSignal.countDown();
 	}
 
 	private void attemptNonReentrantAccess(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
-			AtomicInteger failureCounter)
+			AtomicBoolean failureIndicator)
 	{
 		int lockID = 0;
 		try (LockPool<Integer>.Lock lock = lockPool.lock(lockID))
 		{
-			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+			verifyNonConcurrentExecution(concurrencyIndicator, failureIndicator);
 		}
 	}
 
 	private void attemptReentrantAccess(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
-			AtomicInteger failureCounter)
+			AtomicBoolean failureIndicator)
 	{
 		int lockID = 0;
-		try (LockPool<Integer>.Lock lock1 = lockPool.lock(0))
+		try (LockPool<Integer>.Lock lock1 = lockPool.lock(lockID))
 		{
-			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+			verifyNonConcurrentExecution(concurrencyIndicator, failureIndicator);
 			try (LockPool<Integer>.Lock lock2 = lockPool.lock(lockID))
 			{
-				verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+				verifyNonConcurrentExecution(concurrencyIndicator, failureIndicator);
 			}
-			verifyNonConcurrentExecution(concurrencyIndicator, failureCounter);
+			verifyNonConcurrentExecution(concurrencyIndicator, failureIndicator);
 		}
 	}
 
 	private void attempImmediateAccessRandomID(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator,
-			AtomicInteger failureCounter)
+			AtomicBoolean failureIndicator)
 	{
 		int lockID = freeLockID.incrementAndGet();
 		int sleepDuration = 500;
@@ -115,21 +115,24 @@ public class LockPoolTest
 		if (accessTime - startTime > sleepDuration / 2)
 		{
 			// Delay was more than half the sleep duration, so we apparently were held up
-			failureCounter.incrementAndGet();
+			// Comparing to the exact sleep duration is tricky, as the contract for Thread.sleep mentions accuracy of the system
+			// timers.
+			failureIndicator.set(true);
 		}
 	}
 
-	private void verifyNonConcurrentExecution(AtomicBoolean concurrencyIndicator, AtomicInteger failureCounter)
+	private void verifyNonConcurrentExecution(AtomicBoolean concurrencyIndicator, AtomicBoolean failureIndicator)
 	{
 		if (concurrencyIndicator.compareAndSet(false, true))
 		{
+			sleepWithoutInterrupt(1);
 			// No one else is here
 			concurrencyIndicator.set(false);
 		}
 		else
 		{
 			// Someone else is here
-			failureCounter.incrementAndGet();
+			failureIndicator.set(true);
 		}
 	}
 
@@ -160,6 +163,6 @@ public class LockPoolTest
 	@FunctionalInterface
 	static interface AccessAttempt
 	{
-		void attempt(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator, AtomicInteger testCounter);
+		void attempt(LockPool<Integer> lockPool, AtomicBoolean concurrencyIndicator, AtomicBoolean failureIndicator);
 	}
 }


### PR DESCRIPTION
* Renamed UserAnonymizedSynchronizer into LockPool
* Moved it into nu.yona.util, inside Core
* Made it generic, with the ID type as type parameter
* Added a unit test that verifies:
 * Nonconcurrency when using the lock in a nonreentrant way
 * Nonconcurrency when using the lock in a reentrant way
 * Immediate access when using different keys