### PR TITLE
YD-373 Implemented PUT for all act cats

### DIFF
--- a/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -76,6 +76,16 @@ public class ActivityCategoryController
 		return createOKResponse(activityCategoryService.updateActivityCategory(id, activityCategory));
 	}
 
+	@RequestMapping(value = "/", method = RequestMethod.PUT)
+	@ResponseBody
+	@JsonView(ActivityCategoryDTO.AdminView.class)
+	public HttpEntity<Resources<ActivityCategoryResource>> updateActivityCategorySet(
+			@RequestBody Set<ActivityCategoryDTO> activityCategorySet)
+	{
+		activityCategoryService.updateActivityCategorySet(activityCategorySet);
+		return createOKResponse(activityCategoryService.getAllActivityCategories(), getAllActivityCategoriesLinkBuilder());
+	}
+
 	@RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
 	@ResponseStatus(HttpStatus.OK)
 	public void deleteActivityCategory(@PathVariable UUID id)

--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/ActivityCacheService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/ActivityCacheService.java
@@ -28,13 +28,13 @@ public class ActivityCacheService
 	@Transactional
 	public ActivityDTO fetchLastActivityForUser(UUID userAnonymizedID, UUID goalID)
 	{
-		List<DayActivity> lastActivityList = DayActivity.getRepository().findLast(userAnonymizedID, goalID, new PageRequest(0, 1))
+		List<DayActivity> lastDayActivityList = DayActivity.getRepository().findLast(userAnonymizedID, goalID, new PageRequest(0, 1))
 				.getContent();
-		if (lastActivityList.isEmpty())
+		if (lastDayActivityList.isEmpty())
 		{
 			return null;
 		}
-		Activity lastActivity = lastActivityList.get(0).getLastActivity();
+		Activity lastActivity = lastDayActivityList.get(0).getLastActivity();
 		// this can be the case when a DayActivity is created with inactivity
 		return lastActivity == null ? null : ActivityDTO.createInstance(lastActivity);
 	}

--- a/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
@@ -52,11 +52,11 @@ public class ActivityCategory extends EntityWithID
 			Set<String> applications, Map<Locale, String> localizableDescription)
 	{
 		super(id);
-		this.localizableName = localizableName;
+		setLocalizableName(localizableName);
 		this.mandatoryNoGo = mandatoryNoGo;
-		this.smoothwallCategories = new HashSet<>(smoothwallCategories);
-		this.applications = new HashSet<>(applications);
-		this.localizableDescription = localizableDescription;
+		setSmoothwallCategories(smoothwallCategories);
+		setApplications(applications);
+		setLocalizableDescription(localizableDescription);
 	}
 
 	public Map<Locale, String> getLocalizableName()
@@ -64,9 +64,9 @@ public class ActivityCategory extends EntityWithID
 		return new HashMap<>(localizableName);
 	}
 
-	public void setLocalizableName(Map<Locale, String> name)
+	public final void setLocalizableName(Map<Locale, String> name)
 	{
-		this.localizableName = name;
+		this.localizableName = new HashMap<>(name);
 	}
 
 	public boolean isMandatoryNoGo()
@@ -84,7 +84,7 @@ public class ActivityCategory extends EntityWithID
 		return Collections.unmodifiableSet(smoothwallCategories);
 	}
 
-	public void setSmoothwallCategories(Set<String> smoothwallCategories)
+	public final void setSmoothwallCategories(Set<String> smoothwallCategories)
 	{
 		this.smoothwallCategories = new HashSet<>(smoothwallCategories);
 	}
@@ -94,9 +94,9 @@ public class ActivityCategory extends EntityWithID
 		return Collections.unmodifiableSet(applications);
 	}
 
-	public void setApplications(Set<String> applications)
+	public final void setApplications(Set<String> applications)
 	{
-		this.applications = applications;
+		this.applications = new HashSet<>(applications);
 	}
 
 	public Map<Locale, String> getLocalizableDescription()
@@ -104,9 +104,9 @@ public class ActivityCategory extends EntityWithID
 		return new HashMap<>(localizableDescription);
 	}
 
-	public void setLocalizableDescription(Map<Locale, String> localizableDescription)
+	public final void setLocalizableDescription(Map<Locale, String> localizableDescription)
 	{
-		this.localizableDescription = localizableDescription;
+		this.localizableDescription = new HashMap<>(localizableDescription);
 	}
 
 	public static ActivityCategory createInstance(UUID id, Map<Locale, String> localizableName, boolean mandatoryNoGo,

--- a/core/src/main/java/nu/yona/server/goals/entities/ActivityCategoryRepository.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/ActivityCategoryRepository.java
@@ -6,10 +6,10 @@ package nu.yona.server.goals.entities;
 
 import java.util.UUID;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ActivityCategoryRepository extends CrudRepository<ActivityCategory, UUID>
+public interface ActivityCategoryRepository extends JpaRepository<ActivityCategory, UUID>
 {
 }

--- a/core/src/main/java/nu/yona/server/goals/service/ActivityCategoryService.java
+++ b/core/src/main/java/nu/yona/server/goals/service/ActivityCategoryService.java
@@ -71,8 +71,7 @@ public class ActivityCategoryService
 	public ActivityCategoryDTO updateActivityCategory(UUID id, ActivityCategoryDTO activityCategoryDTO)
 	{
 		ActivityCategory originalEntity = getEntityByID(id);
-		logger.info("Updating activity category '{}' with ID '{}'",
-				originalEntity.getLocalizableName().get(Translator.EN_US_LOCALE), id);
+		logger.info("Updating activity category '{}' with ID '{}'", getName(originalEntity), id);
 		verifyNoDuplicateNames(Collections.singleton(id), activityCategoryDTO.getLocalizableNameByLocale());
 		return ActivityCategoryDTO.createInstance(updateActivityCategory(originalEntity, activityCategoryDTO));
 	}
@@ -93,8 +92,7 @@ public class ActivityCategoryService
 	@Transactional
 	public void deleteActivityCategory(UUID id)
 	{
-		logger.info("Deleting activity category with ID '{}'", id);
-		repository.delete(id);
+		deleteActivityCategory(getEntityByID(id));
 	}
 
 	public Set<ActivityCategoryDTO> getMatchingCategoriesForSmoothwallCategories(Set<String> smoothwallCategories)
@@ -110,6 +108,12 @@ public class ActivityCategoryService
 	{
 		return getAllActivityCategories().stream().filter(ac -> ac.getApplications().contains(application))
 				.collect(Collectors.toSet());
+	}
+
+	private void deleteActivityCategory(ActivityCategory entity)
+	{
+		logger.info("Deleting activity category '{}' with ID '{}'", getName(entity), entity.getID());
+		repository.delete(entity);
 	}
 
 	private void verifyNoDuplicateNames(Set<UUID> idsToSkip, Map<Locale, String> localizableName)
@@ -199,7 +203,12 @@ public class ActivityCategoryService
 				.collect(Collectors.toMap(ac -> ac.getID(), ac -> ac));
 
 		activityCategoriesInRepository.stream().filter(ac -> !activityCategoryDTOsMap.containsKey(ac.getID()))
-				.forEach(ac -> deleteActivityCategory(ac.getID()));
+				.forEach(ac -> deleteActivityCategory(ac));
+	}
+
+	private String getName(ActivityCategory entity)
+	{
+		return entity.getLocalizableName().get(Translator.EN_US_LOCALE);
 	}
 
 	/**

--- a/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceIntegrationTest.java
@@ -89,7 +89,7 @@ public class ActivityCategoryServiceIntegrationTest extends ActivityCategoryServ
 
 		activityCategories.add(news);
 		activityCategories.remove(gaming);
-		service.importActivityCategories(
+		service.updateActivityCategorySet(
 				activityCategories.stream().map(a -> ActivityCategoryDTO.createInstance(a)).collect(Collectors.toSet()));
 		assertGetAllActivityCategoriesResult("Cached set expected to be evicted after import", "gambling", "news");
 	}

--- a/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceTest.java
+++ b/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceTest.java
@@ -85,7 +85,7 @@ public class ActivityCategoryServiceTest extends ActivityCategoryServiceTestBase
 				new HashSet<String>(Arrays.asList("games")), new HashSet<String>(), usString("Descr"));
 		importActivityCategories.add(gaming);
 
-		service.importActivityCategories(importActivityCategories);
+		service.updateActivityCategorySet(importActivityCategories);
 
 		ArgumentCaptor<ActivityCategory> matchActivityCategory = ArgumentCaptor.forClass(ActivityCategory.class);
 		// 1 added and 1 updated

--- a/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceTestBase.java
+++ b/core/src/test/java/nu/yona/server/goals/service/ActivityCategoryServiceTestBase.java
@@ -7,12 +7,13 @@ package nu.yona.server.goals.service;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import org.mockito.invocation.InvocationOnMock;
@@ -25,7 +26,7 @@ import nu.yona.server.goals.entities.ActivityCategoryRepository;
 
 public abstract class ActivityCategoryServiceTestBase
 {
-	protected Set<ActivityCategory> activityCategories = new HashSet<ActivityCategory>();
+	protected List<ActivityCategory> activityCategories = new ArrayList<ActivityCategory>();
 
 	protected ActivityCategory gambling;
 	protected ActivityCategory news;
@@ -41,7 +42,7 @@ public abstract class ActivityCategoryServiceTestBase
 		activityCategories.add(gambling);
 		activityCategories.add(news);
 
-		when(mockRepository.findAll()).thenReturn(Collections.unmodifiableSet(activityCategories));
+		when(mockRepository.findAll()).thenReturn(Collections.unmodifiableList(activityCategories));
 		when(mockRepository.findOne(gambling.getID())).thenReturn(gambling);
 		when(mockRepository.findOne(news.getID())).thenReturn(news);
 		// save should not return null but the saved entity

--- a/dbinit/data/productionActivityCategories.json
+++ b/dbinit/data/productionActivityCategories.json
@@ -5,7 +5,7 @@
          "en-US": "Adult content",
          "nl-NL": "Adult"
       },
-      "mandatoryNoGo": false,
+      "mandatoryNoGo": true,
       "smoothwallCategories": [
          "Adult Sites",
          "Adult Themes",
@@ -14,7 +14,7 @@
          "Sexuality Sites"
       ],
       "applications": [
-
+         "com.baraka111.dirty.jokes.funny"
       ],
       "localizableDescription": {
          "en-US": "This challenge includes apps and sites with adult and porn",
@@ -57,12 +57,52 @@
          "lotto"
       ],
       "applications": [
-         "Poker App",
-         "Lotto App"
+         "com.dragonplay.liveholdempro"
       ],
       "localizableDescription": {
          "en-US": "This challenge includes apps and sites like Poker and Blackjack",
          "nl-NL": "Deze challenge bevat apps en sites zoals Poker en Blackjack"
+      }
+   },
+   {
+      "id": "0da5104b-eb24-4d75-bca3-4794a6d40e27",
+      "localizableName": {
+         "en-US": "Games",
+         "nl-NL": "Games"
+      },
+      "mandatoryNoGo": false,
+      "smoothwallCategories": [
+         "Computer Games",
+         "KS-Games",
+         "Online Games"
+      ],
+      "applications": [
+         "com.king.candycrushsaga",
+         "com.king.candycrushsodasaga",
+         "com.king.candycrushjellysaga",
+         "com.rovio.ABstellapop",
+         "com.rovio.angrybirds",
+         "com.rovio.angrybirdsfight",
+         "com.rovio.angrybirdsfriends",
+         "com.rovio.angrybirdsgo",
+         "com.rovio.angrybirdsrio",
+         "com.rovio.angrybirdsseasons",
+         "com.rovio.angrybirdsspace.ads",
+         "com.rovio.angrybirdsstarwars.ads.iap",
+         "com.rovio.angrybirdsstarwarsii.ads",
+         "com.rovio.angrybirdsstella",
+         "com.rovio.angrybirdstransformers",
+         "com.rovio.baba",
+         "com.rovio.BadPiggies",
+         "com.rovio.BadPiggiesHD",
+         "com.rovio.gold",
+         "com.rovio.popcorn",
+         "com.rovio.Toons.tv",
+         "com.nianticlabs.pokemongo"
+      ],
+      "localizableDescription": {
+         "en-US": "This challenge includes apps and sites like Candy Crush and Angry Birds",
+         "nl-NL": "Deze challenge bevat apps en sites zoals Candy Crush en Angry Birds"
       }
    },
    {
@@ -102,8 +142,7 @@
       ],
       "applications": [
          "nl.sanomamedia.android.nu",
-         "nl.nos.app",
-         "NU.nl"
+         "nl.nos.app"
       ],
       "localizableDescription": {
          "en-US": "This challenge includes apps and sites like NU.nl and NOS",
@@ -126,8 +165,7 @@
       "applications": [
          "com.facebook.katana",
          "com.instagram.android",
-         "com.twitter.android",
-         "Facebook"
+         "com.twitter.android"
       ],
       "localizableDescription": {
          "en-US": "This challenge includes apps and sites like Facebook and Instagram",

--- a/dbinit/src/main/java/nu/yona/server/dbinit/ActivityCategoryFileLoader.java
+++ b/dbinit/src/main/java/nu/yona/server/dbinit/ActivityCategoryFileLoader.java
@@ -47,7 +47,7 @@ public class ActivityCategoryFileLoader implements CommandLineRunner
 			Set<ActivityCategoryDTO> activityCategoriesFromFile = mapper.readValue(input,
 					new TypeReference<Set<ActivityCategoryDTO>>() {
 					});
-			activityCategoryService.importActivityCategories(activityCategoriesFromFile);
+			activityCategoryService.updateActivityCategorySet(activityCategoriesFromFile);
 			logger.info("Activity categories loaded successfully");
 		}
 		catch (IOException e)


### PR DESCRIPTION
* Implemented a PUT option on ``/activityCategories/``. This allows setting the production activity categories through a command like this: ``curl -X PUT http://localhost:8080/activityCategories/ -d @dbinit/data/productionActivityCategories.json --header "Content-Type: application/json"``
* There is an issue in HSQLDB, Spring or JPA that makes an implicit flush fail with ``java.sql.SQLException: invalid transaction state: read-only SQL-transaction``. Implemented an explicit flush to work around that issue.
* Added an extra JSON file with the production activity categories
* Removed  ``Games`` from the activity categories file used for testing
* Reformatted the activity categories in the JSON file, to increase readability and simplify comparison
* Renamed local variable in ``ActivityCacheService.fetchLastActivityForUser`` for consistency