### PR TITLE
YD-261 Fixed delete failure after user overwrite

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -281,7 +281,7 @@ public class AnalysisEngineService
 
 	private ZonedDateTime getEndOfDay(ZonedDateTime time, UserAnonymizedDTO userAnonymized)
 	{
-		return getStartOfDay(time, userAnonymized).plusHours(23).plusMinutes(59).plusSeconds(59);
+		return getStartOfDay(time, userAnonymized).withHour(23).withMinute(59).withSecond(59);
 	}
 
 	private ZonedDateTime getStartOfWeek(ZonedDateTime time, UserAnonymizedDTO userAnonymized)

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityServiceTests.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityServiceTests.java
@@ -406,7 +406,7 @@ public class ActivityServiceTests
 		assertSpread(activityStartTime, activityDuration, expectedSpread);
 	}
 
-	private void assertSpread(Duration activityStartTime, Duration activityDuration, int[] expectedSpread)
+	private void assertSpread(Duration activityStartOffsetOnDay, Duration activityDuration, int[] expectedSpread)
 	{
 		ZonedDateTime today = getDayStartTime(ZonedDateTime.now(userAnonZone));
 		ZonedDateTime yesterday = today.minusDays(1);
@@ -414,8 +414,10 @@ public class ActivityServiceTests
 		// gambling goal was created 2 weeks ago, see above
 		// mock some activity on yesterday 20:58-21:00
 		DayActivity yesterdayRecordedActivity = DayActivity.createInstance(userAnonEntity, gamblingGoal, yesterday);
-		Activity recordedActivity = Activity.createInstance(yesterday.plus(activityStartTime),
-				yesterday.plus(activityStartTime).plus(activityDuration));
+		ZonedDateTime activityStartTime = yesterday.withHour((int) activityStartOffsetOnDay.toHours())
+				.withMinute((int) activityStartOffsetOnDay.toMinutes() % 60)
+				.withSecond((int) activityStartOffsetOnDay.getSeconds() % 60);
+		Activity recordedActivity = Activity.createInstance(activityStartTime, activityStartTime.plus(activityDuration));
 		yesterdayRecordedActivity.addActivity(recordedActivity);
 		when(mockDayActivityRepository.findOne(userAnonID, yesterday.toLocalDate(), gamblingGoal.getID()))
 				.thenReturn(yesterdayRecordedActivity);

--- a/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
@@ -64,6 +64,7 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 
 		cleanup:
 		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Try set new device request with wrong information'()

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -41,6 +41,10 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.buddy.only.twoway.buddies.allowed"
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Richard requests Bob to become his buddy'()
@@ -313,6 +317,10 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		def getMessagesBobResponse = appService.getMessages(bob)
 		getMessagesBobResponse.status == 200
 		getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}.size() == 1
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Goal conflict of Bob is reported to Richard and Bob'()
@@ -673,6 +681,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		makeBuddies(bob, richard)
 		assertGoalConflictIsReportedToBuddy(bob, richard)
 		assertGoalConflictIsReportedToBuddy(richard, bob)
+
 		cleanup:
 		appService.deleteUser(richard)
 		appService.deleteUser(bob)

--- a/appservice/src/intTest/groovy/nu/yona/server/MessagingTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/MessagingTest.groovy
@@ -58,6 +58,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		secondPageMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}.size() == 1
 		secondPageMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}.size() == 1
 		secondPageMessagesResponse.responseData.page.totalElements == 4
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Richard retrieves only unread messages'()
@@ -101,19 +105,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[0]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href
 		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[2]._links.self.href
 		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[2]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[4]._links.self.href
-	}
 
-	void markRead(User user, def message)
-	{
-		assert message._links?."yona:markRead"?.href
-		appService.postMessageActionWithPassword(message._links."yona:markRead".href, [ : ], user.password)
-	}
-
-	void markUnread(User user, def message)
-	{
-		assert message._links?."yona:markUnread"?.href
-		def response = appService.postMessageActionWithPassword(message._links."yona:markUnread".href, [ : ], user.password)
-		assert response.status == 200
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Bob tries to delete Richard\'s buddy request before it is processed'()
@@ -133,6 +128,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		def buddyConnectRequestMessages = appService.getMessages(bob).responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}
 		buddyConnectRequestMessages.size() == 1
 		!buddyConnectRequestMessages[0]._links.edit
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Bob deletes Richard\'s buddy request after it is processed'()
@@ -151,6 +150,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 200
 		!appService.getMessages(bob).responseData._embedded?."yona:messages"?.size()
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Richard tries to delete Bob\'s buddy acceptance before it is processed'()
@@ -172,6 +175,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		def buddyConnectResponseMessages = appService.getMessages(richard).responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
 		buddyConnectResponseMessages.size() == 1
 		!buddyConnectResponseMessages[0]._links.edit
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Richard deletes Bob\'s buddy acceptance after it is processed'()
@@ -192,6 +199,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 200
 		!appService.getMessages(richard).responseData._embedded?."yona:messages"?.size()
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Richard deletes a goal conflict message. After that, Bob still has it'()
@@ -211,6 +222,10 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		appService.getMessages(richard).responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"}.size() == 0
 
 		appService.getMessages(bob).responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}.size() == 1
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
 	}
 
 	def 'Bob deletes a goal conflict message. After that, Richard still has it'()
@@ -230,5 +245,22 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		appService.getMessages(richard).responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}.size() == 1
 
 		appService.getMessages(bob).responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"}.size() == 0
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
+	}
+
+	private void markRead(User user, def message)
+	{
+		assert message._links?."yona:markRead"?.href
+		appService.postMessageActionWithPassword(message._links."yona:markRead".href, [ : ], user.password)
+	}
+
+	private void markUnread(User user, def message)
+	{
+		assert message._links?."yona:markUnread"?.href
+		def response = appService.postMessageActionWithPassword(message._links."yona:markUnread".href, [ : ], user.password)
+		assert response.status == 200
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -337,7 +337,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		}
 	}
 
-	def assertUserOverwriteResponseDetails(def response)
+	private def assertUserOverwriteResponseDetails(def response)
 	{
 		appService.assertResponseStatusCreated(response)
 		appService.assertUserWithPrivateData(response.responseData)

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -37,6 +37,9 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		newRichard
+
+		cleanup:
+		appService.deleteUser(newRichard)
 	}
 
 	def 'Remove Richard while being a buddy of Bob and verify that Bob receives a buddy disconnect message'()

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -311,18 +311,18 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		responseAppleAppSiteAssociation.responseData.applinks.details[0].appID ==~ /.*\.yona/
 	}
 
-	def confirmMobileNumber(User user, code)
+	private def confirmMobileNumber(User user, code)
 	{
 		appService.confirmMobileNumber(user.mobileNumberConfirmationUrl, """{ "code":"${code}" } """, user.password)
 	}
 
-	User createJohnDoe(def ts)
+	private User createJohnDoe(def ts)
 	{
 		appService.addUser(appService.&assertUserCreationResponseDetails, password, firstName, lastName, nickname,
 				"+$ts")
 	}
 
-	void testUser(User user, includePrivateData, mobileNumberConfirmed, timestamp)
+	private void testUser(User user, includePrivateData, mobileNumberConfirmed, timestamp)
 	{
 		assert user.firstName == "John"
 		assert user.lastName == "Doe"

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -241,6 +241,12 @@ public class BuddyService
 		return messageToBeProcessed.isPresent();
 	}
 
+	public void processPossiblePendingBuddyResponseMessages(User userEntity)
+	{
+		getBuddyEntitiesOfUser(userEntity.getID()).stream()
+				.forEach(b -> processPossiblePendingBuddyResponseMessage(userEntity, b));
+	}
+
 	private Optional<UUID> getUserID(BuddyConnectResponseMessage message)
 	{
 		return message.getSenderUser().map(u -> u.getID());
@@ -279,6 +285,7 @@ public class BuddyService
 		{
 			// Buddy request was accepted
 			removeMessagesSentByBuddy(user, buddy);
+			removeMessagesSentByUserToBuddy(user, buddy);
 
 			// Send message to "self", to notify the user about the removed buddy user
 			UUID buddyUserAnonymizedID = getUserAnonymizedIDForBuddy(buddy);
@@ -337,16 +344,34 @@ public class BuddyService
 		return buddyIDs.stream().map(id -> getBuddy(id)).collect(Collectors.toSet());
 	}
 
+	private Set<Buddy> getBuddyEntitiesOfUser(UUID forUserID)
+	{
+		UserDTO user = userService.getPrivateUser(forUserID);
+		return getBuddyEntities(user.getPrivateData().getBuddyIDs());
+	}
+
+	private Set<Buddy> getBuddyEntities(Set<UUID> buddyIDs)
+	{
+		return buddyIDs.stream().map(id -> getEntityByID(id)).collect(Collectors.toSet());
+	}
+
 	private void removeMessagesSentByBuddy(User user, Buddy buddy)
 	{
-		Optional<UUID> userAnonymizedID = buddy.getUserAnonymizedID();
-		if (!userAnonymizedID.isPresent())
+		Optional<UUID> buddyUserAnonymizedID = buddy.getUserAnonymizedID();
+		if (!buddyUserAnonymizedID.isPresent())
 		{
 			return;
 		}
-		removeNamedMessagesSentByUser(user, userAnonymizedID.get());
+		removeNamedMessagesSentByUser(user, buddyUserAnonymizedID.get());
 		UserAnonymizedDTO userAnonymized = userAnonymizedService.getUserAnonymized(user.getUserAnonymizedID());
-		removeAnonymousMessagesSentByUser(userAnonymized, userAnonymizedID.get());
+		removeAnonymousMessagesSentByUser(userAnonymized, buddyUserAnonymizedID.get());
+	}
+
+	private void removeMessagesSentByUserToBuddy(User user, Buddy buddy)
+	{
+		UUID buddyUserAnonymizedID = getUserAnonymizedIDForBuddy(buddy);
+		UserAnonymizedDTO buddyUserAnonymized = userAnonymizedService.getUserAnonymized(buddyUserAnonymizedID);
+		removeAnonymousMessagesSentByUser(buddyUserAnonymized, user.getUserAnonymizedID());
 	}
 
 	private void sendDropBuddyMessage(User requestingUser, Buddy requestingUserBuddy, Optional<String> message,
@@ -384,16 +409,16 @@ public class BuddyService
 		// Else: user who requested buddy relationship didn't process the accept message yet
 	}
 
-	private void removeNamedMessagesSentByUser(User user, UUID sentByUserAnonymizedID)
+	private void removeNamedMessagesSentByUser(User receivingUser, UUID sentByUserAnonymizedID)
 	{
-		MessageDestination namedMessageDestination = user.getNamedMessageDestination();
+		MessageDestination namedMessageDestination = receivingUser.getNamedMessageDestination();
 		messageService.removeMessagesFromUser(MessageDestinationDTO.createInstance(namedMessageDestination),
 				sentByUserAnonymizedID);
 	}
 
-	private void removeAnonymousMessagesSentByUser(UserAnonymizedDTO userAnonymized, UUID sentByUserAnonymizedID)
+	private void removeAnonymousMessagesSentByUser(UserAnonymizedDTO receivingUserAnonymized, UUID sentByUserAnonymizedID)
 	{
-		MessageDestinationDTO anonymousMessageDestination = userAnonymized.getAnonymousDestination();
+		MessageDestinationDTO anonymousMessageDestination = receivingUserAnonymized.getAnonymousDestination();
 		messageService.removeMessagesFromUser(anonymousMessageDestination, sentByUserAnonymizedID);
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -372,6 +372,9 @@ public class BuddyService
 		UUID buddyUserAnonymizedID = getUserAnonymizedIDForBuddy(buddy);
 		UserAnonymizedDTO buddyUserAnonymized = userAnonymizedService.getUserAnonymized(buddyUserAnonymizedID);
 		removeAnonymousMessagesSentByUser(buddyUserAnonymized, user.getUserAnonymizedID());
+		// We are not removing the named messages because we don't have User entity anymore
+		// (this method is being called from removeBuddyInfoForRemovedUser) and thus we don't know the named destination.
+		// Given that the user and the named destination are both removed, this is not causing any issues.
 	}
 
 	private void sendDropBuddyMessage(User requestingUser, Buddy requestingUserBuddy, Optional<String> message,

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -384,6 +384,9 @@ public class UserService
 	public void deleteUser(UUID id, Optional<String> message)
 	{
 		User userEntity = getUserEntityByID(id);
+		buddyService.processPossiblePendingBuddyResponseMessages(userEntity);
+
+		handleBuddyUsersRemovedWhileOffline(userEntity);
 
 		userEntity.getBuddies().forEach(buddyEntity -> buddyService.removeBuddyInfoForBuddy(userEntity, buddyEntity, message,
 				DropBuddyReason.USER_ACCOUNT_DELETED));

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -105,7 +105,7 @@ class AppService extends Service
 			return null
 		}
 		def response = yonaServer.deleteResourceWithPassword(user.editURL, user.password, ["message":message])
-		// assert response.status == 200 Enable this after fixing YD-261
+		assert response.status == 200
 		return response
 	}
 


### PR DESCRIPTION
The solution comprises of the following as part of ``UserService.deleteUser``:
* Process any pending buddy response messages, to ensure a standard state
* Handle buddy users removed while offline
* When handling buddy users removed while offline, also remove the messages sent by this user to the user that was removed while offline

Besides this:
* Fixed DST issues
* Added missing clean-ups