### PR TITLE
YD-227 Time stamp on BuddyAnonymized

### DIFF
--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -52,6 +52,7 @@ import nu.yona.server.subscriptions.service.BuddyService;
 import nu.yona.server.subscriptions.service.BuddyServiceException;
 import nu.yona.server.subscriptions.service.UserDTO;
 import nu.yona.server.subscriptions.service.UserService;
+import nu.yona.server.util.TimeUtil;
 
 @Controller
 @ExposesResourceFor(BuddyResource.class)
@@ -161,7 +162,8 @@ public class BuddyController
 		{
 			throw BuddyServiceException.missingUser(userRelName);
 		}
-		return new BuddyDTO(user, postPutBuddy.message, postPutBuddy.sendingStatus, postPutBuddy.receivingStatus);
+		return new BuddyDTO(user, postPutBuddy.message, postPutBuddy.sendingStatus, postPutBuddy.receivingStatus,
+				TimeUtil.utcNow());
 	}
 
 	public static Resources<BuddyResource> createAllBuddiesCollectionResource(CurieProvider curieProvider, UUID userID,

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -2188,6 +2188,11 @@ definitions:
         type: string
         description: The nickname of the buddy
         example: RQ
+      lastStatusChangeTime:
+        type: string
+        format: dateTime
+        description: The time of the last status change (request/accept/reject) of this buddy
+        example: 2016-02-23T21:28:58.556+0000
       _embedded:
         type: object
         properties:
@@ -2217,6 +2222,7 @@ definitions:
           - $ref: '#/definitions/WeeklyActivityReportsLink'
           - $ref: '#/definitions/DailyActivityReportsLink'
     required:
+      - lastStatusChangeTime
       - _embedded
       - _links
   NewDeviceRequest:

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
@@ -5,6 +5,7 @@
 package nu.yona.server.messaging.entities;
 
 import java.security.PublicKey;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -87,6 +88,11 @@ public class MessageDestination extends EntityWithID
 
 		}
 		return Message.getRepository().findReceivedMessagesFromDestination(this.getID(), pageable);
+	}
+
+	public Page<Message> getReceivedMessages(Pageable pageable, LocalDateTime earliestDateTime)
+	{
+		return Message.getRepository().findReceivedMessagesFromDestinationSinceDate(this.getID(), earliestDateTime, pageable);
 	}
 
 	private PublicKey loadPublicKey()

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -30,4 +31,8 @@ public interface MessageRepository extends CrudRepository<Message, UUID>
 			+ " order by threadHeadMessage.creationTime asc, m.creationTime asc")
 	Page<Message> findByActivityID(@Param("destinationID") UUID destinationID, @Param("activityID") UUID activityID,
 			Pageable pageable);
+
+	@Query("select m from Message m, MessageDestination d where d.id = :destinationID and m.creationTime >= :earliestDateTime and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
+	Page<Message> findReceivedMessagesFromDestinationSinceDate(@Param("destinationID") UUID destinationID,
+			@Param("earliestDateTime") LocalDateTime earliestDateTime, Pageable pageable);
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
@@ -6,6 +6,7 @@ package nu.yona.server.messaging.entities;
 
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -82,6 +83,13 @@ public class MessageSource extends EntityWithID
 	public Page<Message> getReceivedMessages(Pageable pageable, boolean onlyUnreadMessages)
 	{
 		Page<Message> messages = messageDestination.getReceivedMessages(pageable, onlyUnreadMessages);
+		decryptMessagePage(messages);
+		return messages;
+	}
+
+	public Page<Message> getReceivedMessages(Pageable pageable, LocalDateTime earliestDateTime)
+	{
+		Page<Message> messages = messageDestination.getReceivedMessages(pageable, earliestDateTime);
 		decryptMessagePage(messages);
 		return messages;
 	}

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.messaging.service;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,13 @@ public class MessageService
 
 		MessageSource messageSource = getAnonymousMessageSource(user);
 		return messageSource.getReceivedMessages(pageable, onlyUnreadMessages);
+	}
+
+	public Page<Message> getReceivedMessageEntitiesSinceDate(UUID userID, LocalDateTime earliestDateTime, Pageable pageable)
+	{
+		UserDTO user = userService.getPrivateValidatedUser(userID);
+		MessageSource messageSource = getAnonymousMessageSource(user);
+		return messageSource.getReceivedMessages(pageable, earliestDateTime);
 	}
 
 	@Transactional

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -117,6 +118,11 @@ public class Buddy extends EntityWithID
 	public Status getSendingStatus()
 	{
 		return getBuddyAnonymized().getSendingStatus();
+	}
+
+	public LocalDateTime getLastStatusChangeTime()
+	{
+		return getBuddyAnonymized().getLastStatusChangeTime();
 	}
 
 	public void setUserAnonymizedID(UUID userAnonymizedID)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
@@ -4,6 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,6 +16,7 @@ import org.hibernate.annotations.Type;
 
 import nu.yona.server.entities.EntityWithID;
 import nu.yona.server.entities.RepositoryProvider;
+import nu.yona.server.util.TimeUtil;
 
 @Entity
 @Table(name = "BUDDIES_ANONYMIZED")
@@ -45,6 +47,8 @@ public class BuddyAnonymized extends EntityWithID
 	 */
 	private Status receivingStatus = Status.NOT_REQUESTED;
 
+	private LocalDateTime lastStatusChangeTime;
+
 	// Default constructor is required for JPA
 	public BuddyAnonymized()
 	{
@@ -56,6 +60,7 @@ public class BuddyAnonymized extends EntityWithID
 		super(id);
 		this.sendingStatus = sendingStatus;
 		this.receivingStatus = receivingStatus;
+		setLastStatusChangeTimeToNow();
 	}
 
 	public static BuddyAnonymized createInstance(Status sendingStatus, Status receivingStatus)
@@ -79,7 +84,12 @@ public class BuddyAnonymized extends EntityWithID
 
 	public void setSendingStatus(Status sendingStatus)
 	{
+		if (this.sendingStatus == sendingStatus)
+		{
+			return;
+		}
 		this.sendingStatus = sendingStatus;
+		setLastStatusChangeTimeToNow();
 	}
 
 	public Status getReceivingStatus()
@@ -89,7 +99,12 @@ public class BuddyAnonymized extends EntityWithID
 
 	public void setReceivingStatus(Status receivingStatus)
 	{
+		if (this.receivingStatus == receivingStatus)
+		{
+			return;
+		}
 		this.receivingStatus = receivingStatus;
+		setLastStatusChangeTimeToNow();
 	}
 
 	public Optional<UUID> getUserAnonymizedID()
@@ -108,5 +123,16 @@ public class BuddyAnonymized extends EntityWithID
 		this.sendingStatus = Status.REJECTED;
 		this.receivingStatus = Status.REJECTED;
 		this.userAnonymizedID = null;
+		setLastStatusChangeTimeToNow();
+	}
+
+	public LocalDateTime getLastStatusChangeTime()
+	{
+		return lastStatusChangeTime;
+	}
+
+	private void setLastStatusChangeTimeToNow()
+	{
+		lastStatusChangeTime = TimeUtil.utcNow();
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -220,7 +220,8 @@ public class BuddyService
 		UserDTO user = userService.createUserDTOWithPrivateData(userEntity);
 		do
 		{
-			messagePage = messageService.getReceivedMessageEntities(user.getID(), new PageRequest(page++, pageSize));
+			messagePage = messageService.getReceivedMessageEntitiesSinceDate(user.getID(), buddy.getLastStatusChangeTime(),
+					new PageRequest(page++, pageSize));
 
 			messageFound = processPossiblePendingBuddyResponseMessage(user, buddy, messagePage);
 		}

--- a/core/src/testUtils/groovy/nu/yona/server/test/Buddy.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Buddy.groovy
@@ -14,6 +14,7 @@ class Buddy
 	final String nickname
 	final String receivingStatus
 	final String sendingStatus
+	final String lastStatusChangeTime
 	final User user
 	final List<Goal> goals
 	final String url
@@ -25,6 +26,7 @@ class Buddy
 		this.nickname = json.nickname
 		this.receivingStatus = json.receivingStatus
 		this.sendingStatus = json.sendingStatus
+		this.lastStatusChangeTime = json.lastStatusChangeTime
 		if (json._embedded?."yona:user")
 		{
 			this.user = new User(json._embedded."yona:user")

--- a/dbinit/liquibase.gradle
+++ b/dbinit/liquibase.gradle
@@ -52,7 +52,7 @@ task liquibaseDiffChangelog(type: JavaExec) {
   classpath configurations.liquibase
   main = "liquibase.integration.commandline.Main"
 
-  args "--changeLogFile=${changeLogPath}/changelog-0000-yd-000.yml"
+  args "--changeLogFile=${changeLogPath}/updates/changelog-0000-yd-000.yml"
   args "--referenceUrl=${hibernateUrl}"
   args "--url=${databaseUrl}"
   args "--driver=org.hsqldb.jdbc.JDBCDriver"

--- a/dbinit/src/main/liquibase/base/entity.yml
+++ b/dbinit/src/main/liquibase/base/entity.yml
@@ -179,21 +179,6 @@ databaseChangeLog:
             type: timestamp(255)
         tableName: confirmation_codes
 - changeSet:
-    id: 1478805823199-10
-    author: Bert (generated)
-    changes:
-    - createTable:
-        columns:
-        - column:
-            constraints:
-              nullable: false
-            name: id
-            type: VARCHAR(255)
-        - column:
-            name: name
-            type: VARCHAR(255)
-        tableName: devices
-- changeSet:
     id: 1478805823199-11
     author: Bert (generated)
     changes:
@@ -726,14 +711,6 @@ databaseChangeLog:
         columnNames: id
         constraintName: confirmation_codesPK
         tableName: confirmation_codes
-- changeSet:
-    id: 1478805823199-38
-    author: Bert (generated)
-    changes:
-    - addPrimaryKey:
-        columnNames: id
-        constraintName: devicesPK
-        tableName: devices
 - changeSet:
     id: 1478805823199-39
     author: Bert (generated)

--- a/dbinit/src/main/liquibase/changelog.yml
+++ b/dbinit/src/main/liquibase/changelog.yml
@@ -2,6 +2,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: base/base.yml
-#  - include:
-#      relativeToChangelogFile: true
-#      file: update/updates.yml
+  - include:
+      relativeToChangelogFile: true
+      file: updates/updates.yml

--- a/dbinit/src/main/liquibase/updates/changelog-0000-yd-227.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0000-yd-227.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+- changeSet:
+    id: 1479543132473-1
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: last_status_change_time
+            type: timestamp
+        tableName: buddies_anonymized

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -1,0 +1,4 @@
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0000-yd-227.yml


### PR DESCRIPTION
Added lastStatusChangeTime to BuddyAnonymized. It is updated when the buddy request is created, accepted, rejected or disconnected.

As this is the first change that requires a schema change, several other changes are included:
* Introduction of updates.yml, the file accumulating includes for all schema changes
* Corrected destination path in liquibase.gradle in task liquibaseDiffChangelog
* Removed the devices table from entity.yml. This shouldn't have been there as the Device class was removed already as part of PR #267. This was missed when merging these changes into the work for the Liquibase introduction.

Unfortunately, we always need to update the generated change log manually due to liquibase/liquibase-hibernate#134. This is included in the wiki procedure: http://wiki.yona.nu/display/DEV/Schema+evolution+with+liquibase