### PR TITLE
YD-382 Simplify Hazelcast shutdown

### DIFF
--- a/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
+++ b/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
@@ -20,8 +20,6 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
-import com.hazelcast.core.Hazelcast;
-
 import nu.yona.server.admin.batch.config.MainConfiguration;
 
 @SpringBootApplication(scanBasePackages = { "nu.yona.server" }, exclude = { BatchAutoConfiguration.class,
@@ -32,18 +30,7 @@ public class AdminServiceApplication extends SpringBootServletInitializer
 {
 	public static void main(String[] args)
 	{
-		try
-		{
-			SpringApplication.run(AdminServiceApplication.class, args);
-		}
-		catch (Exception ex)
-		{
-			// Issue in Hazelcast: it doesn't shutdown automatically: see https://github.com/hazelcast/hazelcast/issues/6339
-			// If service start up fails, we want the the process to exit, so in that case we are shutting down Hazelcast
-			// explicitly.
-			Hazelcast.shutdownAll();
-			throw ex;
-		}
+		SpringApplication.run(AdminServiceApplication.class, args);
 	}
 
 	@Override

--- a/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
+++ b/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
@@ -13,8 +13,6 @@ import org.springframework.boot.context.web.SpringBootServletInitializer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 
-import com.hazelcast.core.Hazelcast;
-
 import nu.yona.server.util.LockPool;
 
 @SpringBootApplication
@@ -23,18 +21,7 @@ public class AnalysisServiceApplication extends SpringBootServletInitializer
 {
 	public static void main(String[] args)
 	{
-		try
-		{
-			SpringApplication.run(AnalysisServiceApplication.class, args);
-		}
-		catch (Exception ex)
-		{
-			// Issue in Hazelcast: it doesn't shutdown automatically: see https://github.com/hazelcast/hazelcast/issues/6339
-			// If service start up fails, we want the the process to exit, so in that case we are shutting down Hazelcast
-			// explicitly.
-			Hazelcast.shutdownAll();
-			throw ex;
-		}
+		SpringApplication.run(AnalysisServiceApplication.class, args);
 	}
 
 	@Override

--- a/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
+++ b/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
@@ -15,8 +15,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-import com.hazelcast.core.Hazelcast;
-
 import nu.yona.server.properties.YonaProperties;
 
 @SpringBootApplication
@@ -28,18 +26,7 @@ public class AppServiceApplication extends SpringBootServletInitializer
 
 	public static void main(String[] args)
 	{
-		try
-		{
-			SpringApplication.run(AppServiceApplication.class, args);
-		}
-		catch (Exception ex)
-		{
-			// Issue in Hazelcast: it doesn't shutdown automatically: see https://github.com/hazelcast/hazelcast/issues/6339
-			// If service start up fails, we want the the process to exit, so in that case we are shutting down Hazelcast
-			// explicitly.
-			Hazelcast.shutdownAll();
-			throw ex;
-		}
+		SpringApplication.run(AppServiceApplication.class, args);
 	}
 
 	@Override

--- a/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
+++ b/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
@@ -15,8 +15,6 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 
-import com.hazelcast.core.Hazelcast;
-
 @EnableCaching
 @EnableBatchProcessing
 @EnableScheduling
@@ -25,18 +23,7 @@ public class BatchServiceApplication extends SpringBootServletInitializer
 {
 	public static void main(String[] args)
 	{
-		try
-		{
-			SpringApplication.run(BatchServiceApplication.class, args);
-		}
-		catch (Exception ex)
-		{
-			// Issue in Hazelcast: it doesn't shutdown automatically: see https://github.com/hazelcast/hazelcast/issues/6339
-			// If service start up fails, we want the the process to exit, so in that case we are shutting down Hazelcast
-			// explicitly.
-			Hazelcast.shutdownAll();
-			throw ex;
-		}
+		SpringApplication.run(BatchServiceApplication.class, args);
 	}
 
 	@Override

--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -170,8 +170,13 @@ public class CoreConfiguration extends CachingConfigurerSupport
 	@Bean
 	public CacheManager cacheManager()
 	{
-		HazelcastInstance client = Hazelcast.newHazelcastInstance(new Config());
-		return new HazelcastCacheManager(client);
+		return new HazelcastCacheManager(hazelcastInstance());
+	}
+
+	@Bean // By making this a bean, Spring takes care of shutting down Hazelcast
+	public HazelcastInstance hazelcastInstance()
+	{
+		return Hazelcast.newHazelcastInstance(new Config());
 	}
 
 	@Bean

--- a/dbinit/src/main/java/nu/yona/server/DatabaseInitializationApplication.java
+++ b/dbinit/src/main/java/nu/yona/server/DatabaseInitializationApplication.java
@@ -9,8 +9,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
 
-import com.hazelcast.core.Hazelcast;
-
 @ComponentScan("nu.yona.server")
 @SpringBootApplication
 @EnableBatchProcessing
@@ -18,19 +16,8 @@ public class DatabaseInitializationApplication
 {
 	public static void main(String[] args)
 	{
-		try
-		{
-			SpringApplication app = new SpringApplication(DatabaseInitializationApplication.class);
-			app.setWebEnvironment(false);
-			app.run(args);
-		}
-		finally
-		{
-
-			// issue in Hazelcast: it doesn't shutdown automatically,
-			// while we want this for the short running database initializer
-			// see https://github.com/hazelcast/hazelcast/issues/6339
-			Hazelcast.shutdownAll();
-		}
+		SpringApplication app = new SpringApplication(DatabaseInitializationApplication.class);
+		app.setWebEnvironment(false);
+		app.run(args).close();
 	}
 }


### PR DESCRIPTION
As pointed out by @wilkinsona on spring-projects/spring-boot#7418, our Hazelcast initialization was wrong. Spring couldn't see the Hazelcast bean and therefore couldn't shut it down. Corrected that now.