### PR TITLE
YD-397 Moved password generation to the server

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -60,7 +60,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	User addRichard(boolean reload = true)
 	{
-		def richard = appService.addUser(appService.&assertUserCreationResponseDetails, "AES:128:RichardPasswordp1ORubw==", "Richard", "Quinn", "RQ",
+		User richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
 				"+$timestamp")
 		richard = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, richard)
 		def response = appService.addGoal(richard, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
@@ -70,7 +70,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	User addBob(boolean reload = true)
 	{
-		def bob = appService.addUser(appService.&assertUserCreationResponseDetails, "AES:128:BobPasswordnMnrp1ORubw==", "Bob", "Dunn", "BD",
+		User bob = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob", "Dunn", "BD",
 				"+$timestamp")
 		bob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bob)
 		def response = appService.addGoal(bob, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
@@ -80,7 +80,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	User addBea(boolean reload = true)
 	{
-		def bea = appService.addUser(appService.&assertUserCreationResponseDetails, "AES:128:BeaPasswordnMnrp1ORubw==", "Bea", "Dundee", "BDD",
+		User bea = appService.addUser(appService.&assertUserCreationResponseDetails, "Bea", "Dundee", "BDD",
 				"+$timestamp")
 		bea = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bea)
 		return reload? appService.reloadUser(bea) : bea

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -122,6 +122,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
 		appService.updateUser(inviteUrl, updatedBobJson, newPassword)
 		def bobFromGetAfterUpdate = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataIgnoreNickname, bob.url, true, newPassword)
@@ -130,7 +131,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def againChangedNickname = "Robert"
 		def againUpdatedBobJson = bobFromGetAfterUpdate.convertToJson()
 		againUpdatedBobJson.nickname = againChangedNickname
-		def againUpdatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(againUpdatedBobJson, newPassword))
+		def againUpdatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(againUpdatedBobJson))
 
 		then:
 		againUpdatedBob.nickname == againChangedNickname
@@ -150,8 +151,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, newPassword), inviteUrl)
+		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 
 		when:
 		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
@@ -180,8 +182,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, newPassword), inviteUrl)
+		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 
@@ -212,8 +215,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, newPassword), inviteUrl)
+		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], newPassword)
@@ -248,8 +252,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, newPassword), inviteUrl)
+		def updatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], newPassword)

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -182,7 +182,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		//buddy info change
 		def updatedRichardJson = richard.convertToJson()
 		updatedRichardJson.nickname = "Richardo"
-		richard = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedRichardJson, richard.password))
+		richard = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedRichardJson))
 
 		when:
 		def message = "Goodbye friends! I deinstalled the Internet"

--- a/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
@@ -21,7 +21,7 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		when:
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.nickname = "Bobby"
-		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, bob.password))
+		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
 		assert richardMessagesAfterUpdate.status == 200
 		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
@@ -64,7 +64,7 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.firstName = "Robert"
 		updatedBobJson.lastName = "Dunstan"
-		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson, bob.password))
+		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
 		assert richardMessagesAfterUpdate.status == 200
 		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1874,6 +1874,10 @@ definitions:
     allOf:
       - $ref: '#/definitions/PrivateUserDataNoVPN'
     properties:
+      yonaPassword:
+        type: string
+        description: The Yona password for subsequent requests
+        example: AES:128:YXNkZnNhZGZnMnrp1ORubw==
       vpnProfile:
         $ref: '#/definitions/VPNProfile'
   PostPutUser:

--- a/core/src/main/java/nu/yona/server/crypto/CryptoSession.java
+++ b/core/src/main/java/nu/yona/server/crypto/CryptoSession.java
@@ -28,7 +28,7 @@ import nu.yona.server.exceptions.YonaException;
 
 public class CryptoSession implements AutoCloseable
 {
-	public static final String AES_128_MARKER = "AES:128:";
+	private static final String AES_128_MARKER = "AES:128:";
 	static final byte CURRENT_CRYPTO_VARIANT_NUMBER = 1;
 	private static final String CIPHER_TYPE = "AES/CBC/PKCS5Padding";
 	private static final String SECRET_KEY_ALGORITHM = "PBKDF2WithHmacSHA256";
@@ -117,7 +117,7 @@ public class CryptoSession implements AutoCloseable
 
 	public static CryptoSession start(String password)
 	{
-		return start(getSecretKey(password, ITERATIONS_FOR_MULTIUSE_KEY));
+		return start(getSecretKey(password));
 	}
 
 	public static CryptoSession start(SecretKey secretKey)
@@ -134,6 +134,11 @@ public class CryptoSession implements AutoCloseable
 			throw CryptoException.noActiveCryptoSession(Thread.currentThread());
 		}
 		return cryptoSession;
+	}
+
+	public String getKeyString()
+	{
+		return encodeAesKey(secretKey);
 	}
 
 	/**
@@ -158,6 +163,11 @@ public class CryptoSession implements AutoCloseable
 		return CryptoUtil.decrypt(CURRENT_CRYPTO_VARIANT_NUMBER, getDecryptionCipher(), ciphertext);
 	}
 
+	public static SecretKey getSecretKey(String password)
+	{
+		return getSecretKey(password, ITERATIONS_FOR_MULTIUSE_KEY);
+	}
+
 	private static SecretKey getSecretKey(String password, int iterations)
 	{
 		try
@@ -175,6 +185,11 @@ public class CryptoSession implements AutoCloseable
 		{
 			throw CryptoException.creatingSecretKey(e);
 		}
+	}
+
+	private static String encodeAesKey(SecretKey key)
+	{
+		return AES_128_MARKER + Base64.getEncoder().encodeToString(key.getEncoded());
 	}
 
 	private static SecretKey decodeAesKey(String password)

--- a/core/src/main/java/nu/yona/server/crypto/CryptoUtil.java
+++ b/core/src/main/java/nu/yona/server/crypto/CryptoUtil.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -210,6 +212,20 @@ public class CryptoUtil
 		if (ciphertext[0] != cryptoVariantNumber)
 		{
 			throw CryptoException.decryptingData();
+		}
+	}
+
+	public static SecretKey generateRandomSecretKey()
+	{
+		try
+		{
+			KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+			keyGen.init(128);
+			return keyGen.generateKey();
+		}
+		catch (NoSuchAlgorithmException e)
+		{
+			throw CryptoException.generatingKey(e);
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/crypto/PublicKeyEncryptor.java
+++ b/core/src/main/java/nu/yona/server/crypto/PublicKeyEncryptor.java
@@ -5,11 +5,9 @@
 package nu.yona.server.crypto;
 
 import java.security.GeneralSecurityException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 
 import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 
 public class PublicKeyEncryptor implements Encryptor
@@ -53,28 +51,12 @@ public class PublicKeyEncryptor implements Encryptor
 	@Override
 	public byte[] executeInCryptoSession(Runnable runnable)
 	{
-		SecretKey secretKey = generateRandomSecretKey();
+		SecretKey secretKey = CryptoUtil.generateRandomSecretKey();
 		try (CryptoSession cryptoSession = CryptoSession.start(secretKey))
 		{
 			byte[] decryptionInfo = getDecryptionInfo(secretKey);
 			runnable.run();
 			return decryptionInfo;
-		}
-	}
-
-	private SecretKey generateRandomSecretKey()
-	{
-		try
-		{
-			KeyGenerator keyGen;
-			keyGen = KeyGenerator.getInstance("AES");
-			keyGen.init(128);
-			SecretKey secretKey = keyGen.generateKey();
-			return secretKey;
-		}
-		catch (NoSuchAlgorithmException e)
-		{
-			throw CryptoException.generatingKey(e);
 		}
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import nu.yona.server.Constants;
+import nu.yona.server.crypto.CryptoSession;
 import nu.yona.server.exceptions.MobileNumberConfirmationException;
 import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.subscriptions.entities.User;
@@ -45,14 +46,15 @@ public class UserDto
 	/*
 	 * Only intended for test purposes.
 	 */
-	private UserDto(UUID id, LocalDateTime creationTime, String firstName, String lastName, String nickname, String mobileNumber,
-			boolean isConfirmed, UUID namedMessageSourceId, UUID namedMessageDestinationId, UUID anonymousMessageSourceId,
-			UUID anonymousMessageDestinationId, Set<GoalDto> goals, Set<UUID> buddyIds,
+	private UserDto(UUID id, LocalDateTime creationTime, String firstName, String lastName, String yonaPassword, String nickname,
+			String mobileNumber, boolean isConfirmed, UUID namedMessageSourceId, UUID namedMessageDestinationId,
+			UUID anonymousMessageSourceId, UUID anonymousMessageDestinationId, Set<GoalDto> goals, Set<UUID> buddyIds,
 			Function<Set<UUID>, Set<BuddyDto>> buddyIdToDtoMapper, UUID userAnonymizedId, VPNProfileDto vpnProfile)
 	{
 		this(id, firstName, lastName, null, mobileNumber, Optional.of(creationTime), isConfirmed,
-				new UserPrivateDto(nickname, namedMessageSourceId, namedMessageDestinationId, anonymousMessageSourceId,
-						anonymousMessageDestinationId, goals, buddyIds, buddyIdToDtoMapper, userAnonymizedId, vpnProfile));
+				new UserPrivateDto(yonaPassword, nickname, namedMessageSourceId, namedMessageDestinationId,
+						anonymousMessageSourceId, anonymousMessageDestinationId, goals, buddyIds, buddyIdToDtoMapper,
+						userAnonymizedId, vpnProfile));
 	}
 
 	private UserDto(UUID id, String firstName, String lastName, String mobileNumber, LocalDateTime creationTime,
@@ -190,9 +192,10 @@ public class UserDto
 	static UserDto createInstanceWithPrivateData(User userEntity, Function<Set<UUID>, Set<BuddyDto>> buddyIdToDtoMapper)
 	{
 		return new UserDto(userEntity.getId(), userEntity.getCreationTime(), userEntity.getFirstName(), userEntity.getLastName(),
-				userEntity.getNickname(), userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(),
-				userEntity.getNamedMessageSource().getId(), userEntity.getNamedMessageDestination().getId(),
-				userEntity.getAnonymousMessageSource().getId(), userEntity.getAnonymousMessageSource().getDestination().getId(),
+				CryptoSession.getCurrent().getKeyString(), userEntity.getNickname(), userEntity.getMobileNumber(),
+				userEntity.isMobileNumberConfirmed(), userEntity.getNamedMessageSource().getId(),
+				userEntity.getNamedMessageDestination().getId(), userEntity.getAnonymousMessageSource().getId(),
+				userEntity.getAnonymousMessageSource().getDestination().getId(),
 				UserAnonymizedDto.getGoalsIncludingHistoryItems(userEntity.getAnonymized()), getBuddyIds(userEntity),
 				buddyIdToDtoMapper, userEntity.getUserAnonymizedId(), VPNProfileDto.createInstance(userEntity));
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserPrivateDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserPrivateDto.java
@@ -20,6 +20,7 @@ import nu.yona.server.goals.service.GoalDto;
 @JsonRootName("userPrivate")
 public class UserPrivateDto
 {
+	private final String yonaPassword;
 	private final String nickname;
 	private final Set<GoalDto> goals;
 	private final VPNProfileDto vpnProfile;
@@ -34,16 +35,17 @@ public class UserPrivateDto
 	@JsonCreator
 	public UserPrivateDto(@JsonProperty("nickname") String nickname)
 	{
-		this(nickname, null, null, null, null, Collections.emptySet(), Collections.emptySet(), null, null,
+		this(null, nickname, null, null, null, null, Collections.emptySet(), Collections.emptySet(), null, null,
 				new VPNProfileDto(null));
 	}
 
-	UserPrivateDto(String nickname, UUID namedMessageSourceId, UUID namedMessageDestinationId, UUID anonymousMessageSourceId,
-			UUID anonymousMessageDestinationId, Set<GoalDto> goals, Set<UUID> buddyIds,
+	UserPrivateDto(String yonaPassword, String nickname, UUID namedMessageSourceId, UUID namedMessageDestinationId,
+			UUID anonymousMessageSourceId, UUID anonymousMessageDestinationId, Set<GoalDto> goals, Set<UUID> buddyIds,
 			Function<Set<UUID>, Set<BuddyDto>> buddyIdToDtoMapper, UUID userAnonymizedId, VPNProfileDto vpnProfile)
 	{
 		Objects.requireNonNull(goals);
 		Objects.requireNonNull(buddyIds);
+		this.yonaPassword = yonaPassword;
 		this.nickname = nickname;
 		this.namedMessageSourceId = namedMessageSourceId;
 		this.namedMessageDestinationId = namedMessageDestinationId;
@@ -54,6 +56,11 @@ public class UserPrivateDto
 		this.buddyIdToDtoMapper = buddyIdToDtoMapper;
 		this.userAnonymizedId = userAnonymizedId;
 		this.vpnProfile = vpnProfile;
+	}
+
+	public String getYonaPassword()
+	{
+		return yonaPassword;
 	}
 
 	public String getNickname()

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -27,18 +27,31 @@ class AppService extends Service
 	{
 		def response = confirmMobileNumber(user.mobileNumberConfirmationUrl, """{ "code":"1234" }""", user.password)
 		asserter(response)
-		return (isSuccess(response)) ? new User(response.responseData, user.password, true) : null
+		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(Closure asserter, password, firstName, lastName, nickname, mobileNumber, parameters = [:])
+	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, parameters = [:])
+	{
+		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber)
+		def response = addUser(jsonStr, parameters)
+		asserter(response)
+		return (isSuccess(response)) ? new User(response.responseData) : null
+	}
+
+	def addUser(jsonString, parameters = [:])
+	{
+		yonaServer.createResource(USERS_PATH, jsonString, parameters)
+	}
+
+	def addUser(Closure asserter, String password, firstName, lastName, nickname, mobileNumber, parameters = [:])
 	{
 		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber)
 		def response = addUser(jsonStr, password, parameters)
 		asserter(response)
-		return (isSuccess(response)) ? new User(response.responseData, password) : null
+		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(jsonString, password, parameters = [:])
+	def addUser(jsonString, String password, parameters = [:])
 	{
 		yonaServer.createResourceWithPassword(USERS_PATH, jsonString, password, parameters)
 	}
@@ -55,7 +68,7 @@ class AppService extends Service
 			response = yonaServer.getResourceWithPassword(userUrl, password)
 		}
 		asserter(response)
-		return (isSuccess(response)) ? new User(response.responseData, password, includePrivateData) : null
+		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
 	def getUser(userUrl, boolean includePrivateData, password = null)
@@ -83,14 +96,14 @@ class AppService extends Service
 			response = yonaServer.getResourceWithPassword(user.url, user.password)
 			assertUserGetResponseDetailsWithoutPrivateData(response)
 		}
-		return (isSuccess(response)) ? new User(response.responseData, user.password, user.hasPrivateData) : null
+		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
 	def updateUser(Closure asserter, User user, url = null)
 	{
 		def response = updateUser((url) ?: user.url, user.convertToJson(), user.password)
 		asserter(response)
-		return (isSuccess(response)) ? new User(response.responseData, user.password) : null
+		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
 	def updateUser(userUrl, jsonString, password)


### PR DESCRIPTION
The app can still provide the password upon user sign-up, but this is only temporary. Once both app implementations are updated, this will be disabled.

The Yona password is now returned as part of the private user data. This happens when signing up, but also in other scenarios where the private user data is returned (e.g. GET on user). The app should take the password as returned in the user data and use that in subsequent requests.

Changes:
* Added yonaPassword to the Swagger spec
* Included it in the UserPrivateDto
* Rearranged some crypto-related code
* Made UserController.addUser generate the key if the Yona-Password header was not provided
* Updated the Groovy tests. Most tests now use the server-generated password. Some tests still generated it in the client, which is good for backward compatibility testing.