### PR TITLE
YD-401 Limit the number of users

### DIFF
--- a/core/src/main/java/nu/yona/server/properties/YonaProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/YonaProperties.java
@@ -43,6 +43,8 @@ public class YonaProperties
 
 	private String appleAppId;
 
+	private int maxUsers;
+
 	public AnalysisServiceProperties getAnalysisService()
 	{
 		return analysisService;
@@ -104,4 +106,13 @@ public class YonaProperties
 		return appleAppId;
 	}
 
+	public int getMaxUsers()
+	{
+		return maxUsers;
+	}
+
+	public void setMaxUsers(String maxUsersString)
+	{
+		this.maxUsers = Integer.parseInt(maxUsersString);
+	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserServiceException.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserServiceException.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
 
@@ -61,5 +61,10 @@ public class UserServiceException extends YonaException
 	public static UserServiceException missingMobileNumber()
 	{
 		return new UserServiceException("error.user.missing.mobile.number");
+	}
+
+	public static UserServiceException maximumNumberOfUsersReached()
+	{
+		return new UserServiceException("error.user.maximum.number.reached");
 	}
 }

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -31,6 +31,7 @@ error.user.not.found.mobile=User with mobile number ''{0}'' not found
 error.user.not.found.id=User with ID ''{0}'' not found
 error.user.exists.created.on.buddy.request=User with mobile number ''{0}'' already exists created on buddy request
 error.user.exists=User with mobile number ''{0}'' already exists
+error.user.maximum.number.reached=Reached the maximum number of users that is currently allowed
 
 error.useranonymizedid.not.found=Anonymized user ID ''{0}'' not found
 

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -31,6 +31,7 @@ error.user.not.found.mobile=Gebruiker met mobiel nummer ''{0}'' niet gevonden
 error.user.not.found.id=Gebruiker met ID ''{0}'' niet gevonden
 error.user.exists.created.on.buddy.request=Gebruiker met mobiel nummer ''{0}'' bestaat al (aangemaakt op basis van een vriendschapsverzoek)
 error.user.exists=Gebruiker met mobiel nummer ''{0}'' bestaat al
+error.user.maximum.number.reached=Het maximum toegestane gebruikersaantal is bereikt
 
 error.useranonymizedid.not.found=VPN login ID ''{0}'' niet gevonden
 


### PR DESCRIPTION
It's done through a configuration property. This requires the service to be restarted when the maximum is updated. Given that this is a temporary feature and restarting is fast, this shouldn't be a problem.