### PR TITLE
YD-411 Fixed week already full error

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -15,6 +15,7 @@ import nu.yona.server.test.BudgetGoal
 import nu.yona.server.test.Goal
 import nu.yona.server.test.TimeZoneGoal
 import nu.yona.server.test.User
+import spock.lang.IgnoreRest
 
 class EditGoalsTest extends AbstractAppServiceIntegrationTest
 {
@@ -345,7 +346,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
-		BudgetGoal addedGoal = appService.addGoal(appService.&assertResponseStatusCreated, richard, BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 60), "Going to monitor my social time!")
+		BudgetGoal addedGoal = addBudgetGoal(richard, SOCIAL_ACT_CAT_URL, 60, "W-1 Thu 18:00")
 		postFacebookActivityPastHour(richard)
 		BudgetGoal updatedGoal = BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 120)
 		bob = appService.reloadUser(bob)
@@ -362,6 +363,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		responseGoalsAfterUpdate.status == 200
 		responseGoalsAfterUpdate.responseData._embedded."yona:goals".size() == 4
 		findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 120
+		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, YonaServer.now)
 
 		def allSocialGoals = findGoalsIncludingHistoryItems(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL)
 		allSocialGoals.size() == 2

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
@@ -79,7 +79,8 @@ public class WeekActivity extends IntervalActivity
 	{
 		if (dayActivities.size() >= 7)
 		{
-			throw new IllegalStateException("Week is already full (" + dayActivities.size() + " days present)");
+			throw new IllegalStateException("Week starting at " + getStartDate() + " is already full (" + dayActivities.size()
+					+ " days present) while trying to add day activity for " + dayActivity.getStartDate());
 		}
 
 		dayActivity.setWeekActivity(this);
@@ -101,7 +102,7 @@ public class WeekActivity extends IntervalActivity
 
 	private List<Integer> sumSpread(List<Integer> one, List<Integer> other)
 	{
-		List<Integer> result = new ArrayList<Integer>(IntervalActivity.SPREAD_COUNT);
+		List<Integer> result = new ArrayList<>(IntervalActivity.SPREAD_COUNT);
 		for (int i = 0; i < IntervalActivity.SPREAD_COUNT; i++)
 		{
 			result.add(one.get(i) + other.get(i));

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
@@ -79,8 +79,9 @@ public class WeekActivity extends IntervalActivity
 	{
 		if (dayActivities.size() >= 7)
 		{
-			throw new IllegalStateException("Week starting at " + getStartDate() + " is already full (" + dayActivities.size()
-					+ " days present) while trying to add day activity for " + dayActivity.getStartDate());
+			throw new IllegalStateException("Week starting at " + getStartDate() + " for goal with ID " + getGoal().getId()
+					+ " is already full (" + dayActivities.size() + " days present) while trying to add day activity for "
+					+ dayActivity.getStartDate());
 		}
 
 		dayActivity.setWeekActivity(this);

--- a/core/src/main/java/nu/yona/server/goals/service/GoalService.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalService.java
@@ -146,9 +146,9 @@ public class GoalService
 	private void updateGoal(User userEntity, Goal existingGoal, GoalDto newGoalDto, Optional<String> message)
 	{
 		UserAnonymized userAnonymizedEntity = userEntity.getAnonymized();
-		cloneExistingGoalAsHistoryItem(userAnonymizedEntity, existingGoal,
-				newGoalDto.getCreationTime().orElse(TimeUtil.utcNow()));
-		newGoalDto.getCreationTime().ifPresent(ct -> existingGoal.setCreationTime(ct));
+		LocalDateTime goalChangeTime = newGoalDto.getCreationTime().orElse(TimeUtil.utcNow());
+		cloneExistingGoalAsHistoryItem(userAnonymizedEntity, existingGoal, goalChangeTime);
+		existingGoal.setCreationTime(goalChangeTime);
 		newGoalDto.updateGoalEntity(existingGoal);
 		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity.getId(), userAnonymizedEntity);
 


### PR DESCRIPTION
The cause was that upon a goal change, we create a copy of the goal, but both copies had the same start time. The history item should carry the original creation time, but the "actual" goal should have its creation time updated to the current time. Once the data is corrected, the "week already full" issue will disappear. The fix of this change set will prevent from creating the wrong data again.