### PR TITLE
YD-413 Improved start script

### DIFF
--- a/scripts/servers_debug.cmd
+++ b/scripts/servers_debug.cmd
@@ -1,3 +1,0 @@
-@echo off
- 
-call servers_start.cmd -Pdebug.all=true

--- a/scripts/servers_start.cmd
+++ b/scripts/servers_start.cmd
@@ -41,7 +41,8 @@ if ERRORLEVEL 1 goto error
 echo.
 echo Load the activity categories
 echo.
-curl -X PUT --header "Content-Type: application/json" -d @dbinit/data/activityCategories.json http://localhost:8080/activityCategories/
+curl -f -X PUT --header "Content-Type: application/json" -d @dbinit/data/activityCategories.json http://localhost:8080/activityCategories/
+if ERRORLEVEL 1 goto error
 
 echo.
 echo.

--- a/scripts/servers_start.cmd
+++ b/scripts/servers_start.cmd
@@ -2,31 +2,57 @@
  
 call servers_stop.cmd
 
-call gradlew %1 build
-if ERRORLEVEL 1 goto end
+call gradlew build
+if ERRORLEVEL 1 goto error
 
+if "%1"=="-keepDB" goto updateDB
 echo.
 echo Recreating Yona database
 echo.
 call mysql --user=%YONA_DB_USER_NAME% --password=%YONA_DB_PASSWORD% < scripts\recreateYonaDB.sql
-if ERRORLEVEL 1 goto end
+if ERRORLEVEL 1 goto error
 
+:updateDB
 call gradlew :dbinit:liquibaseUpdate
-if ERRORLEVEL 1 goto end
+if ERRORLEVEL 1 goto error
 
+echo.
 echo Verifying the database schema
+echo.
 call gradlew :dbinit:bootRun
-if ERRORLEVEL 1 goto end
+if ERRORLEVEL 1 goto error
 
-start "Admin service" cmd /c gradlew %1 :adminservice:bootRun
-start "Analysis service" cmd /c gradlew %1 :analysisservice:bootRun
-start "App service" cmd /c gradlew %1 :appservice:bootRun
-start "Batch service" cmd /c gradlew %1 :batchservice:bootRun
+call gradlew adminservice:build && start "Admin service" java -Xdebug -Xrunjdwp:transport=dt_socket,address=8840,server=y,suspend=n -jar adminservice\build\libs\adminservice-0.0.8-SNAPSHOT-full.jar --server.port=8080 --management.port=9080 --spring.jpa.hibernate.ddl-auto=none
+call gradlew analysisservice:build && start "Analysis service" java -Xdebug -Xrunjdwp:transport=dt_socket,address=8841,server=y,suspend=n -jar analysisservice\build\libs\analysisservice-0.0.8-SNAPSHOT-full.jar --server.port=8081 --management.port=9081 --spring.jpa.hibernate.ddl-auto=none
+call gradlew appservice:build && start "App service" java -Xdebug -Xrunjdwp:transport=dt_socket,address=8842,server=y,suspend=n -jar appservice\build\libs\appservice-0.0.8-SNAPSHOT-full.jar --server.port=8082 --management.port=9082 --spring.jpa.hibernate.ddl-auto=none
+call gradlew batchservice:build && start "Batch service" java -Xdebug -Xrunjdwp:transport=dt_socket,address=8843,server=y,suspend=n -jar batchservice\build\libs\batchservice-0.0.8-SNAPSHOT-full.jar --server.port=8083 --management.port=9083 --spring.jpa.hibernate.ddl-auto=none
 
-set GRADLE_OPTS=
+echo.
 echo Wait until all services are started.
-pause
+echo.
+set CURLOPT=-s --retry-connrefused --retry-delay 3 --retry 20
+curl %CURLOPT% http://localhost:8080/activityCategories/ > nul
+if ERRORLEVEL 1 goto error
+curl %CURLOPT% http://localhost:8081/relevantSmoothwallCategories/ > nul
+if ERRORLEVEL 1 goto error
+curl %CURLOPT% http://localhost:8082/activityCategories/ > nul
+if ERRORLEVEL 1 goto error
+
+echo.
+echo Load the activity categories
+echo.
 curl -X PUT --header "Content-Type: application/json" -d @dbinit/data/activityCategories.json http://localhost:8080/activityCategories/
+
+echo.
+echo.
+echo Start the integration tests
+echo.
 cmd /c gradlew --rerun-tasks :adminservice:intTest :analysisservice:intTest :appservice:intTest 
+
+goto end
+
+:error
+echo.
+echo *** ERROR OCCURRED
 
 :end


### PR DESCRIPTION
Improved the test run script in the following ways:
* Now doesn't run Gradle in parallel anymore. This addresses the random class loading error and makes the service start up faster
* Now automatically starts the tests when all services are up and running (no need to hit enter anymore)
* Gives a more clear error message when something fails

Note that this requires curl 7.51.1 or later, as we use curl/curl#1064