### PR TITLE
YD-419 Messages are now automatically processed

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -205,7 +205,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(updatedBob)
 	}
 
-	def 'Richard processes Bob\'s buddy acceptance'()
+	def 'Richard finds Bob\'s buddy acceptance'()
 	{
 		given:
 		def richard = addRichard()
@@ -223,12 +223,19 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], newPassword)
 
 		when:
-		def processUrl = appService.fetchBuddyConnectResponseMessage(richard).processUrl
-		def response = appService.postMessageActionWithPassword(processUrl, [ : ], richard.password)
+		def response = appService.getMessages(richard)
 
 		then:
 		response.status == 200
-		response.responseData.properties.status == "done"
+		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll
+		{ it."@type" == "BuddyConnectResponseMessage" }
+		buddyConnectResponseMessages[0]._links?."yona:user"?.href == bob.url
+		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
+		buddyConnectResponseMessages[0].nickname == newNickname
+		assertEquals(buddyConnectResponseMessages[0].creationTime, YonaServer.now)
+		buddyConnectResponseMessages[0].status == "ACCEPTED"
+		buddyConnectResponseMessages[0]._links.self.href.startsWith(YonaServer.stripQueryString(richard.messagesUrl))
+		buddyConnectResponseMessages[0]._links."yona:process" == null // Processing happens automatically these days
 
 		def richardWithBuddy = appService.reloadUser(richard)
 		richardWithBuddy.buddies != null
@@ -422,11 +429,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		buddyConnectResponseMessage.message == "User account was deleted"
 		buddyConnectResponseMessage.nickname == "Bob Dunn"
 		buddyConnectResponseMessage._links.self.href.startsWith(YonaServer.stripQueryString(richard.messagesUrl))
-		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
-
-		def processUrl = buddyConnectResponseMessage._links."yona:process".href
-		def processBuddyConnectResponse = appService.postMessageActionWithPassword(processUrl, [:], richard.password)
-		processBuddyConnectResponse.status == 200
+		buddyConnectResponseMessage._links."yona:process" == null // Processing happens automatically these days
 
 		User richardAfterBobOverwrite = appService.reloadUser(richard)
 		richardAfterBobOverwrite.buddies.size() == 0

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -81,7 +81,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage.message == "User account was deleted"
 		disconnectMessage.nickname == richard.nickname
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		disconnectMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href)
+		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 
 		def buddies = appService.getBuddies(bob)
 		buddies.size() == 0
@@ -171,13 +171,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		buddyConnectResponseMessage.message == "User account was deleted"
 		buddyConnectResponseMessage.nickname == "$richard.firstName $richard.lastName"
 		buddyConnectResponseMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
-
-		def response = appService.postMessageActionWithPassword(buddyConnectResponseMessages[0]._links."yona:process".href, [:], bob.password)
-		response.status == 200
-		response.responseData._embedded."yona:affectedMessages".size() == 1
-		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyConnectResponseMessage._links.self.href
-		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
+		buddyConnectResponseMessage._links?."yona:process" == null // Processing happens automatically these days
 
 		cleanup:
 		appService.deleteUser(richardChanged)
@@ -225,7 +219,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage.message == "User account was deleted"
 		disconnectMessage.nickname == richard.nickname
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		disconnectMessage._links?."yona:process"?.href?.startsWith(getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href)
+		disconnectMessage._links?."yona:process" == null // Processing happens automatically these days
 
 		def buddies = appService.getBuddies(bob)
 		buddies.size() == 0

--- a/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
@@ -38,13 +38,7 @@ class RejectBuddyTest extends AbstractAppServiceIntegrationTest
 		def processResult = appService.fetchBuddyConnectResponseMessage(richard)
 		processResult.status == "REJECTED"
 		processResult.message == rejectMessage
-
-		// Have the requesting user process the buddy connect response
-		def processResponse = appService.postMessageActionWithPassword(processResult.processUrl, [ : ], richard.password)
-		processResponse.status == 200
-		processResponse.responseData._embedded."yona:affectedMessages".size() == 1
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links.self.href == processResult.selfUrl
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
+		processResult.processUrl == null // Processing happens automatically these days
 
 		// Verify that Bob is not in Richard's buddy list anymore
 		def buddiesRichard = appService.getBuddies(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -71,7 +71,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage.message == message
 		disconnectMessage.nickname == richard.nickname
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		disconnectMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href)
+		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 
 		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessages.size == 1
@@ -79,12 +79,6 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		goalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		goalConflictMessages[0].url =~ /poker/
 		getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}.size() == 0
-
-		def response = appService.postMessageActionWithPassword(buddyDisconnectMessages[0]._links."yona:process".href, [:], bob.password)
-		response.status == 200
-		response.responseData._embedded."yona:affectedMessages".size() == 1
-		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == disconnectMessage._links.self.href
-		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
 		cleanup:
 		appService.deleteUser(bob)
@@ -116,13 +110,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		buddyConnectResponseMessage.message == "User account was deleted"
 		buddyConnectResponseMessage.nickname == "$richard.firstName $richard.lastName"
 		buddyConnectResponseMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		buddyConnectResponseMessage._links?."yona:process"?.href?.startsWith(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}[0]._links.self.href)
-
-		def response = appService.postMessageActionWithPassword(buddyConnectResponseMessages[0]._links."yona:process".href, [:], bob.password)
-		response.status == 200
-		response.responseData._embedded."yona:affectedMessages".size() == 1
-		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyConnectResponseMessage._links.self.href
-		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
+		buddyConnectResponseMessage._links."yona:process" == null // Processing happens automatically these days
 
 		// Test whether Richard can be removed after he again established a buddy relationship with Bob
 		def newRichard = addRichard()
@@ -205,7 +193,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage.message == message
 		disconnectMessage.nickname == richard.nickname
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
-		disconnectMessage._links?."yona:process"?.href?.startsWith(YonaServer.stripQueryString(getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links.self.href))
+		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 
 		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessages.size == 1
@@ -223,12 +211,6 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		def buddyInfoChangeMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
 		buddyInfoChangeMessages.size == 0
 
-		def response = appService.postMessageActionWithPassword(buddyDisconnectMessages[0]._links."yona:process".href, [:], bob.password)
-		response.status == 200
-		response.responseData._embedded."yona:affectedMessages".size() == 1
-		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == disconnectMessage._links.self.href
-		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
-
 		def buddies = appService.getBuddies(bob)
 		buddies.size() == 0
 
@@ -245,8 +227,8 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		def message = "Goodbye friends! I deinstalled the Internet"
 		appService.deleteUser(richard, message)
 		def getResponse = appService.getMessages(bob)
-		def processUrl = (getResponse.status == 200) ? getResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links."yona:process".href : null
-		appService.postMessageActionWithPassword(processUrl, [:], bob.password)
+		assert getResponse.status == 200
+		assert getResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links."yona:process" == null // Processing happens automatically these days
 
 		when:
 		def response = analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com")

--- a/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
@@ -32,18 +32,11 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
-		buddyInfoUpdateMessages[0]._links."yona:process" != null
+		buddyInfoUpdateMessages[0]._links."yona:process" == null // Processing happens automatically these days
 		buddyInfoUpdateMessages[0]._links."yona:user".href == bob.url
 		buddyInfoUpdateMessages[0]._links."yona:buddy".href == richard.buddies[0].url
-		buddyInfoUpdateMessages[0].nickname == "BD"
+		buddyInfoUpdateMessages[0].nickname == "Bobby"
 		buddyInfoUpdateMessages[0].message == "User changed personal info"
-
-		def processResponse = appService.postMessageActionWithPassword(buddyInfoUpdateMessages[0]._links."yona:process".href, [ : ], richard.password)
-		processResponse.status == 200
-		processResponse.responseData.properties.status == "done"
-		processResponse.responseData._embedded."yona:affectedMessages".size() == 1
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyInfoUpdateMessages[0]._links.self.href
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
 		User richardAfterProcess = appService.reloadUser(richard)
 		richardAfterProcess.buddies[0].nickname == "Bobby"
@@ -72,18 +65,11 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		then:
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
-		buddyInfoUpdateMessages[0]._links."yona:process" != null
+		buddyInfoUpdateMessages[0]._links."yona:process" == null // Processing happens automatically these days
 		buddyInfoUpdateMessages[0]._links."yona:user".href == bob.url
 		buddyInfoUpdateMessages[0]._links."yona:buddy".href == richard.buddies[0].url
 		buddyInfoUpdateMessages[0].nickname == "BD"
 		buddyInfoUpdateMessages[0].message == "User changed personal info"
-
-		def processResponse = appService.postMessageActionWithPassword(buddyInfoUpdateMessages[0]._links."yona:process".href, [ : ], richard.password)
-		processResponse.status == 200
-		processResponse.responseData.properties.status == "done"
-		processResponse.responseData._embedded."yona:affectedMessages".size() == 1
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links.self.href == buddyInfoUpdateMessages[0]._links.self.href
-		processResponse.responseData._embedded."yona:affectedMessages"[0]._links."yona:process" == null
 
 		User richardAfterProcess = appService.reloadUser(richard)
 		richardAfterProcess.buddies[0].nickname == "BD"

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -106,7 +106,7 @@ public class MessageController
 	private HttpEntity<PagedResources<MessageDto>> getMessages(UUID userId, Pageable pageable,
 			PagedResourcesAssembler<MessageDto> pagedResourcesAssembler, boolean onlyUnreadMessages)
 	{
-		messageService.transferDirectMessagesToAnonymousDestination(userId);
+		messageService.prepareMessageCollection(userId);
 		Page<MessageDto> messages = messageService.getReceivedMessages(userId, onlyUnreadMessages, pageable);
 		return createOkResponse(pagedResourcesAssembler.toResource(messages,
 				new MessageResourceAssembler(curieProvider, createGoalIdMapping(userId), this)));

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
@@ -6,6 +6,7 @@ package nu.yona.server.messaging.entities;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -39,6 +40,9 @@ public interface MessageRepository extends CrudRepository<Message, Long>
 	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m.creationTime >= :earliestDateTime and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
 	Page<Message> findReceivedMessagesFromDestinationSinceDate(@Param("destinationId") UUID destinationId,
 			@Param("earliestDateTime") LocalDateTime earliestDateTime, Pageable pageable);
+
+	@Query("select m.id from Message m, MessageDestination d where d.id = :destinationId and m.isProcessed = false and m member of d.messages order by m.id desc")
+	List<Long> findUnprocessedMessagesFromDestination(@Param("destinationId") UUID destinationId);
 
 	@Modifying
 	@Query("delete from Message m where m.intervalActivity in :intervalActivities")

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -206,8 +206,9 @@ public abstract class MessageDto extends PolymorphicDto
 
 		protected SenderInfo getSenderInfoExtensionPoint(Message messageEntity)
 		{
-			throw new IllegalStateException("Cannot find buddy for message of type '" + messageEntity.getClass().getName()
-					+ "' with user anonymized ID '" + messageEntity.getRelatedUserAnonymizedId() + "'");
+			throw new IllegalStateException(
+					"Cannot find buddy for message of type '" + messageEntity.getClass().getName() + "' with user anonymized ID '"
+							+ messageEntity.getRelatedUserAnonymizedId().map(UUID::toString).orElse("UNKNOWN") + "'");
 		}
 
 		private SenderInfo createSenderInfoForSelf(UserDto actingUser)

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -273,10 +273,7 @@ class AppService extends Service
 		assert acceptResponse.status == 200
 
 		def processUrl = fetchBuddyConnectResponseMessage(requestingUser).processUrl
-
-		// Have the requesting user process the buddy connect response
-		def processResponse = postMessageActionWithPassword(processUrl, [ : ], requestingUser.password)
-		assert processResponse.status == 200
+		assert processUrl == null // Processing happens automatically these days
 	}
 
 	def sendBuddyConnectRequest(sendingUser, receivingUser)
@@ -341,7 +338,7 @@ class AppService extends Service
 		assert response.responseData._embedded
 
 		def buddyConnectResponseMessages = response.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
-		assert buddyConnectResponseMessages[0]._links."yona:process".href
+		assert buddyConnectResponseMessages[0]._links."yona:process" == null // Processing happens automatically these days
 		def selfUrl = buddyConnectResponseMessages[0]?._links?.self?.href
 		def message = buddyConnectResponseMessages[0]?.message ?: null
 		def status = buddyConnectResponseMessages[0]?.status ?: null

--- a/scripts/servers_start.cmd
+++ b/scripts/servers_start.cmd
@@ -38,6 +38,8 @@ if ERRORLEVEL 1 goto error
 curl %CURLOPT% http://localhost:8082/activityCategories/ > nul
 if ERRORLEVEL 1 goto error
 
+if "%1"=="-keepDB" goto end
+
 echo.
 echo Load the activity categories
 echo.


### PR DESCRIPTION
At the time messages are fetched, we now first check whether any messages need to be processed. If so, we do that before returning the messages. As a result, clients never need to trigger processing anymore. This prevents the issue that the first message cannot be interpreted because the second message hasn't been processed yet (the issue causing YD-419).