### PR TITLE
YD-423 PIN reset code was sent too early

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
@@ -128,7 +128,8 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def responsePost = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.responseData.delay)
 
 		when:
 		def response = appService.yonaServer.postJson(richard.url + "/pinResetRequest/verify", """{"code" : "1234"}""", ["Yona-Password" : richard.password])
@@ -139,6 +140,14 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 
 		cleanup:
 		appService.deleteUser(richard)
+	}
+
+	private void sleepTillMidOfPinResetCodeGenerationInterval(User user, def delayString)
+	{
+		long millis = Duration.parse(delayString).toMillis() / 2
+		println("$YonaServer.now: sleepTillMidOfPinResetCodeGenerationInterval: delayString=$delayString, user.url=$user.url, millis: $millis. Entering sleep")
+		sleep(millis)
+		println("$YonaServer.now: sleepTillMidOfPinResetCodeGenerationInterval: sleep completed")
 	}
 
 	def 'Clear pin reset request before verification'()

--- a/core/src/main/java/nu/yona/server/batch/client/PinResetConfirmationCodeSendRequestDto.java
+++ b/core/src/main/java/nu/yona/server/batch/client/PinResetConfirmationCodeSendRequestDto.java
@@ -28,7 +28,7 @@ public class PinResetConfirmationCodeSendRequestDto
 
 	@JsonCreator
 	public PinResetConfirmationCodeSendRequestDto(@JsonProperty("userId") UUID userId,
-			@JsonFormat(pattern = Constants.ISO_DATE_PATTERN) @JsonProperty("executionTime") Date executionTime,
+			@JsonFormat(pattern = Constants.ISO_DATE_TIME_PATTERN) @JsonProperty("executionTime") Date executionTime,
 			@JsonProperty("localeString") String localeString)
 	{
 		this(userId, TimeUtil.toUtcLocalDateTime(executionTime), localeString);
@@ -52,9 +52,9 @@ public class PinResetConfirmationCodeSendRequestDto
 	}
 
 	// Jackson fails on LocalDateTime, so use Date to serialize
-	@JsonFormat(pattern = Constants.ISO_DATE_PATTERN)
+	@JsonFormat(pattern = Constants.ISO_DATE_TIME_PATTERN)
 	@JsonProperty("executionTime")
-	public Date getExecutionTimeAsUtilDate()
+	public Date getExecutionTimeAsDate()
 	{
 		return TimeUtil.toDate(executionTime);
 	}


### PR DESCRIPTION
Cause: Use of ``ISO_DATE_PATTERN`` for the ``executionTime`` property of ``PinResetConfirmationCodeSendRequestDto`` instead of ``ISO_DATE_TIME_PATTERN``
This was going unnoticed because the test "Hacking attempt: Try to verify pin reset confirmation code before end of delay period" was checking the PIN too early, before the batch job had a chance to generate it. Now it's tested in the middle of the interval. That failed with the old bug but passes now.