### PR TITLE
YD-162 Process all eligible activities

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
@@ -62,7 +62,7 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 200
 		response.responseData.writeCountPerStep?.aggregateWeekActivities == 2
-		response.responseData.writeCountPerStep?.aggregateDayActivities == 10
+		response.responseData.writeCountPerStep?.aggregateDayActivities == 6 + 4 + YonaServer.getCurrentDayOfWeek() * 2
 		assertActivityValues(richard, 1, expectedValuesRichardLastWeek, 2)
 
 		def secondAggregationResponse = batchService.triggerActivityAggregationBatchJob()

--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
@@ -12,7 +12,6 @@ import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
@@ -29,7 +28,7 @@ public class DayActivity extends IntervalActivity
 {
 	public static DayActivityRepository getRepository()
 	{
-		return (DayActivityRepository) RepositoryProvider.getRepository(DayActivity.class, UUID.class);
+		return (DayActivityRepository) RepositoryProvider.getRepository(DayActivity.class, Long.class);
 	}
 
 	@ManyToOne

--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivityRepository.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Repository;
 import nu.yona.server.goals.entities.Goal;
 
 @Repository
-public interface DayActivityRepository extends CrudRepository<DayActivity, UUID>
+public interface DayActivityRepository extends CrudRepository<DayActivity, Long>
 {
 	@Query("select a from DayActivity a"
 			+ " where a.userAnonymized.id = :userAnonymizedId and a.goal.id = :goalId order by a.startDate desc")

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
@@ -13,7 +13,6 @@ import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -28,7 +27,7 @@ public class WeekActivity extends IntervalActivity
 {
 	public static WeekActivityRepository getRepository()
 	{
-		return (WeekActivityRepository) RepositoryProvider.getRepository(WeekActivity.class, UUID.class);
+		return (WeekActivityRepository) RepositoryProvider.getRepository(WeekActivity.class, Long.class);
 	}
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "weekActivity", orphanRemoval = true)

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivityRepository.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository;
 import nu.yona.server.goals.entities.Goal;
 
 @Repository
-public interface WeekActivityRepository extends CrudRepository<WeekActivity, UUID>
+public interface WeekActivityRepository extends CrudRepository<WeekActivity, Long>
 {
 	@Query("select a from WeekActivity a"
 			+ " where a.userAnonymized.id = :userAnonymizedId and a.goal.id = :goalId and a.startDate = :startDate")


### PR DESCRIPTION
* Using the ``JpaPagingItemReader`` leads to skipped entities, see http://stackoverflow.com/questions/26509971/spring-batch-jpapagingitemreader-why-some-rows-are-not-read. Now we use ``JdbcPagingItemReader`` instead
* Increased the chunk sizes from 10 to 200. This improved the day activity performance from 67 seconds to 14 and the week activity performance from 33 to 5 in my test run.
* Corrected the CRUD repositories for ``DayActivity`` and ``WeekActivity``. They still used UUID while the ID was already switched to long.
* Corrected a test in ``ActivityAggregationBatch``. The original values were based on the wrong behavior and the fact that the tests were run on Tuesday :)