### PR TITLE
YD-424 Implemented signing of the mobile config

### DIFF
--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -23,6 +23,8 @@ configurations {
 
 dependencies {
 	compile project(":core")
+	compile "org.bouncycastle:bcprov-jdk15on:1.56"
+	compile "org.bouncycastle:bcpkix-jdk15on:1.56"
 	runtime "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
 	runtime "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$project.ext.version_jackson"
 	runtime "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$project.ext.version_jackson"

--- a/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
+++ b/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
@@ -4,6 +4,11 @@
  *******************************************************************************/
 package nu.yona.server;
 
+import java.security.Security;
+
+import javax.annotation.PostConstruct;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -27,6 +32,12 @@ public class AppServiceApplication
 	{
 		PropertyInitializer.initializePropertiesFromEnvironment();
 		SpringApplication.run(AppServiceApplication.class, args);
+	}
+
+	@PostConstruct
+	public void initialize()
+	{
+		Security.addProvider(new BouncyCastleProvider());
 	}
 
 	@Bean

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/Signer.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/Signer.java
@@ -1,0 +1,145 @@
+package nu.yona.server.subscriptions.rest;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cms.CMSException;
+import org.bouncycastle.cms.CMSProcessableByteArray;
+import org.bouncycastle.cms.CMSSignedDataGenerator;
+import org.bouncycastle.cms.SignerInfoGenerator;
+import org.bouncycastle.cms.jcajce.JcaSignerInfoGeneratorBuilder;
+import org.bouncycastle.openssl.PEMDecryptorProvider;
+import org.bouncycastle.openssl.PEMEncryptedKeyPair;
+import org.bouncycastle.openssl.PEMException;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.X509TrustedCertificateBlock;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
+
+import nu.yona.server.exceptions.YonaException;
+
+public class Signer
+{
+	private final String signingCertificateFile;
+	private final String signingKeyFile;
+	private final String password;
+
+	public Signer(String signingCertificateFile, String signingKeyFile, String password)
+	{
+		this.signingCertificateFile = signingCertificateFile;
+		this.signingKeyFile = signingKeyFile;
+		this.password = password;
+	}
+
+	public byte[] sign(byte[] unsignedMobileconfig)
+	{
+		try
+		{
+			CMSSignedDataGenerator generator = createSignedDataGenerator(signingCertificateFile, signingKeyFile, password);
+			return generator.generate(new CMSProcessableByteArray(unsignedMobileconfig), true).getEncoded();
+		}
+		catch (IOException | CMSException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private CMSSignedDataGenerator createSignedDataGenerator(String signingCertificateFile, String signingKeyFile,
+			String password)
+	{
+		try
+		{
+			X509Certificate signerCertificate = createSignerCertificate(signingCertificateFile);
+			SignerInfoGenerator signerInfoGenerator = createSignerInfoGenerator(signerCertificate, signingKeyFile, password);
+			CMSSignedDataGenerator signedDataGenerator = new CMSSignedDataGenerator();
+			signedDataGenerator.addSignerInfoGenerator(signerInfoGenerator);
+			signedDataGenerator.addCertificate(new X509CertificateHolder(signerCertificate.getEncoded()));
+			return signedDataGenerator;
+		}
+		catch (CertificateException | IOException | CMSException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private X509Certificate createSignerCertificate(String signingCertificateFile)
+	{
+		try
+		{
+			return new JcaX509CertificateConverter().getCertificate(loadSignerCertificate(signingCertificateFile));
+		}
+		catch (CertificateException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private SignerInfoGenerator createSignerInfoGenerator(X509Certificate signerCertificate, String signingKeyFile,
+			String password)
+	{
+		try
+		{
+			ContentSigner sha1Signer = createContentSigner(signingKeyFile, password);
+
+			JcaDigestCalculatorProviderBuilder digestProviderBuilder = new JcaDigestCalculatorProviderBuilder().setProvider("BC");
+			JcaSignerInfoGeneratorBuilder signerInfoGeneratorBuilder = new JcaSignerInfoGeneratorBuilder(
+					digestProviderBuilder.build());
+
+			SignerInfoGenerator signerInfoGenerator = signerInfoGeneratorBuilder.build(sha1Signer, signerCertificate);
+			return signerInfoGenerator;
+		}
+		catch (CertificateException | OperatorCreationException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private ContentSigner createContentSigner(String signingKeyFile, String password)
+	{
+		try
+		{
+			PrivateKey signerKey = new JcaPEMKeyConverter().getPrivateKey(loadPrivateKey(signingKeyFile, password));
+			return new JcaContentSignerBuilder("SHA1withRSA").setProvider("BC").build(signerKey);
+		}
+		catch (OperatorCreationException | PEMException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+
+	}
+
+	private X509CertificateHolder loadSignerCertificate(String fileName)
+	{
+		try (PEMParser parser = new PEMParser(new FileReader(fileName)))
+		{
+			return ((X509TrustedCertificateBlock) parser.readObject()).getCertificateHolder();
+		}
+		catch (IOException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private PrivateKeyInfo loadPrivateKey(String fileName, String password)
+	{
+		try (PEMParser parser = new PEMParser(new FileReader(fileName)))
+		{
+			PEMDecryptorProvider decryptionProv = new JcePEMDecryptorProviderBuilder().build(password.toCharArray());
+			return ((PEMEncryptedKeyPair) parser.readObject()).decryptKeyPair(decryptionProv).getPrivateKeyInfo();
+		}
+		catch (IOException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+}

--- a/core/src/main/java/nu/yona/server/properties/AppleMobileConfigSigningProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/AppleMobileConfigSigningProperties.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.properties;
+
+public class AppleMobileConfigSigningProperties
+{
+	private boolean isSigningEnabled;
+	private String signingCertificateFile;
+	private String signingKeyFile;
+	private String password;
+
+	public void setSigningEnabled(boolean isSigningEnabled)
+	{
+		this.isSigningEnabled = isSigningEnabled;
+	}
+
+	public boolean isSigningEnabled()
+	{
+		return isSigningEnabled;
+	}
+
+	public String getSigningCertificateFile()
+	{
+		return signingCertificateFile;
+	}
+
+	public void setSigningCertificateFile(String signingCertificateFile)
+	{
+		this.signingCertificateFile = signingCertificateFile;
+	}
+
+	public String getSigningKeyFile()
+	{
+		return signingKeyFile;
+	}
+
+	public void setSigningKeyFile(String signingKeyFile)
+	{
+		this.signingKeyFile = signingKeyFile;
+	}
+
+	public String getPassword()
+	{
+		return password;
+	}
+
+	public void setPassword(String password)
+	{
+		this.password = password;
+	}
+
+}

--- a/core/src/main/java/nu/yona/server/properties/SecurityProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/SecurityProperties.java
@@ -6,8 +6,13 @@ package nu.yona.server.properties;
 
 import java.time.Duration;
 
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
 public class SecurityProperties
 {
+	@NestedConfigurationProperty
+	private final AppleMobileConfigSigningProperties appleMobileConfigSigning = new AppleMobileConfigSigningProperties();
+
 	private int confirmationCodeDigits = 4;
 	private int confirmationCodeMaxAttempts = 5;
 	private Duration newDeviceRequestExpirationTime = Duration.ofDays(1);
@@ -23,6 +28,11 @@ public class SecurityProperties
 	 * If true, Cross Origin Resource Sharing is allowed. This is necessary for Swagger UI.
 	 */
 	private boolean isCorsAllowed;
+
+	public AppleMobileConfigSigningProperties getAppleMobileConfigSigning()
+	{
+		return appleMobileConfigSigning;
+	}
 
 	public int getConfirmationCodeDigits()
 	{

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -22,11 +22,6 @@ liquibase.enabled=false
 spring.batch.initializer.enabled=false
 spring.batch.job.enabled=false
 
-# Spring Batch Admin
-server.servletPath=/*
-spring.freemarker.checkTemplateLocation=false
-ENVIRONMENT=mysql
-
 # JSON
 # See https://docs.spring.io/spring-boot/docs/current/reference/html/howto-spring-mvc.html#howto-customize-the-jackson-objectmapper
 spring.jackson.deserialization.fail-on-unknown-properties=true
@@ -40,11 +35,6 @@ spring.jackson.serialization.indent_output=true
 # Management (Spring Boot Actuator)
 # As the Actuator end points are ports that are not accessible outside, security is disabled
 management.security.enabled=false
-
-# Quartz scheduler
-org.quartz.scheduler.instanceName=spring-boot-quartz-demo
-org.quartz.scheduler.instanceId=AUTO
-org.quartz.threadPool.threadCount=5
 
 # Yona properties
 yona.defaultLocale=en-US
@@ -65,6 +55,11 @@ yona.security.dosProtectionWindow = PT5M
 yona.security.maxCreateUserAttemptsPerTimeWindow = 2
 yona.security.maxUpdateUserAttemptsPerTimeWindow = 2
 yona.security.corsAllowed = true
+
+yona.security.appleMobileConfigSigning.isSigningEnabled = true
+yona.security.appleMobileConfigSigning.signingCertificateFile = smime.crt
+yona.security.appleMobileConfigSigning.signingKeyFile = smime.key
+yona.security.appleMobileConfigSigning.password = Yona1
 
 yona.analysisservice.conflictInterval = PT15M
 yona.analysisservice.updateSkipWindow = PT5S


### PR DESCRIPTION
The current implementation only signs when explicitly requested to do so through a query parameter. When the iOS team is happy with the result, we'll make signing the default.

Along with this, cleaned up some old properties.