### PR TITLE
YD-445 Corrected error message

### DIFF
--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -71,7 +71,7 @@ error.buddy.requesting.user.buddy.is.null=The requesting user cannot be null
 error.buddy.accepting.user.is.null=The accepting user cannot be null
 error.buddy.request.must.contain.user.inside.embedded=The buddy resource must contain a ''{0}'' entity inside _embedded
 error.buddy.cannot.invite.self=Cannot yourself as a buddy
-error.buddy.cannot.invite.existing.buddy=Cannot someone who is already a buddy
+error.buddy.cannot.invite.existing.buddy=Cannot invite someone who is already a buddy
 
 error.activity.date.goal.mismatch=At {1}, user with ID ''{0}'' did not have a goal with ID ''{2}''
 error.activity.buddy.day.activity.not.found=Buddy ''{1}'' of user with ID ''{0}'' does not have activity on date ''{2}'' for goal with ID ''{3}''


### PR DESCRIPTION
Old: Cannot someone who is already a buddy
New: Cannot invite someone who is already a buddy