### PR TITLE
YD-456 Using a proper batch size for activity fetching

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
@@ -20,6 +20,8 @@ import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import org.hibernate.annotations.BatchSize;
+
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
@@ -36,6 +38,8 @@ public class DayActivity extends IntervalActivity
 	private WeekActivity weekActivity;
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "dayActivity", fetch = FetchType.LAZY)
+	@BatchSize(size = 25) // When e.g. fetching a day or week overview, it is expected that only the last day is not aggregated,
+							// so you get 4 goals * 1 day = 4 activity collections to be joined
 	private List<Activity> activities;
 
 	private boolean goalAccomplished;

--- a/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/WeekActivity.java
@@ -18,6 +18,8 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 
+import org.hibernate.annotations.BatchSize;
+
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
@@ -31,6 +33,8 @@ public class WeekActivity extends IntervalActivity
 	}
 
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "weekActivity", orphanRemoval = true)
+	@BatchSize(size = 25) // When e.g. fetching a week overview with 3 weeks * 4 goals you already get 12 day collections to be
+							// joined
 	private final List<DayActivity> dayActivities = new ArrayList<>();
 
 	// Default constructor is required for JPA


### PR DESCRIPTION
This reduces the amount of select queries to only one per type instead
of one per day activity in the week overview