### PR TITLE
YD-461 Test to generate data for query analysis

### DIFF
--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -103,7 +103,8 @@ task intTest(type:Test){
 	systemProperties = [
 		"yona.adminservice.url": project.ext.yona_adminservice_url,
 		"yona.analysisservice.url": project.ext.yona_analysisservice_url,
-		"yona.appservice.url": project.ext.yona_appservice_url
+		"yona.appservice.url": project.ext.yona_appservice_url,
+		"yona.test.gen.data": project.ext.yona_test_gen_data
 	]
 }
 

--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -17,6 +17,7 @@ import nu.yona.server.test.AdminService
 import nu.yona.server.test.AnalysisService
 import nu.yona.server.test.AppActivity
 import nu.yona.server.test.AppService
+import nu.yona.server.test.BatchService
 import nu.yona.server.test.Buddy
 import nu.yona.server.test.BudgetGoal
 import nu.yona.server.test.Goal
@@ -35,6 +36,9 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	@Shared
 	def AdminService adminService = new AdminService()
+
+	@Shared
+	def BatchService batchService = new BatchService()
 
 	@Shared
 	private String baseTimestamp = createBaseTimestamp()

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
@@ -7,16 +7,11 @@
 package nu.yona.server
 
 import groovy.json.*
-import nu.yona.server.test.BatchService
 import nu.yona.server.test.Goal
 import nu.yona.server.test.User
-import spock.lang.Shared
 
 class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 {
-	@Shared
-	def BatchService batchService = new BatchService()
-
 	def 'Days and weeks in the past are aggregated once'()
 	{
 		given:

--- a/appservice/src/intTest/groovy/nu/yona/server/PerformanceSetupTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PerformanceSetupTest.groovy
@@ -49,23 +49,14 @@ class PerformanceSetupTest extends AbstractAppServiceIntegrationTest
 		return buddyUsers
 	}
 
-	User createMainUser()
-	{
-		User richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
-				"+$timestamp")
-		richard = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, richard)
-		setGoals(richard)
-		return richard
-	}
-
 	User createBuddyUser(int index)
 	{
-		User bob = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
+		User buddyUser = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
 				"+$timestamp")
-		bob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bob)
-		setGoals(bob)
-		bob.emailAddress = "bob${index}@dunn.com"
-		return bob
+		buddyUser = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, buddyUser)
+		setGoals(buddyUser)
+		buddyUser.emailAddress = "bob${index}@dunn.com"
+		return buddyUser
 	}
 
 	void setGoals(User user)

--- a/appservice/src/intTest/groovy/nu/yona/server/PerformanceSetupTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PerformanceSetupTest.groovy
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server
+
+import java.time.LocalDate
+import java.time.format.TextStyle
+
+import groovy.json.*
+import nu.yona.server.test.BudgetGoal
+import nu.yona.server.test.User
+import spock.lang.IgnoreIf
+
+class PerformanceSetupTest extends AbstractAppServiceIntegrationTest
+{
+	@IgnoreIf({ !Boolean.valueOf(properties['yona.test.gen.data']) })
+	def 'Setup query optimization benchmark scenario'()
+	{
+		given:
+		int numBuddies = 3
+		User richard = addRichard()
+
+		when:
+		def buddyUsers = createBuddies(richard, numBuddies)
+		generateActivities(richard)
+		buddyUsers.each { generateActivities(it) }
+		richard = appService.reloadUser(richard)
+		generateCommentThreadOnYesterdaysNewsActivity(richard, buddyUsers)
+		assert batchService.triggerActivityAggregationBatchJob().status == 200
+
+
+		then:
+		richard.getBuddies().size() == numBuddies
+		println "Test user URL: $richard.url, password: $richard.password"
+	}
+
+	List<User> createBuddies(User user, int numBuddies)
+	{
+		def buddyUsers = []
+		(1..numBuddies).each
+		{
+			User buddyUser = createBuddyUser(it)
+			appService.makeBuddies(user, buddyUser)
+			buddyUsers.add(appService.reloadUser(buddyUser))
+		}
+		return buddyUsers
+	}
+
+	User createMainUser()
+	{
+		User richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
+				"+$timestamp")
+		richard = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, richard)
+		setGoals(richard)
+		return richard
+	}
+
+	User createBuddyUser(int index)
+	{
+		User bob = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
+				"+$timestamp")
+		bob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bob)
+		setGoals(bob)
+		bob.emailAddress = "bob${index}@dunn.com"
+		return bob
+	}
+
+	void setGoals(User user)
+	{
+		setGoalCreationTime(user, GAMBLING_ACT_CAT_URL, "W-2 Sun 01:00")
+		addBudgetGoals(user,  [NEWS_ACT_CAT_URL, MULTIMEDIA_ACT_CAT_URL])
+		addTimeZoneGoals(user,  [ADULT_CONTENT_ACT_CAT_URL])
+		createGoalHistoryItems(user, NEWS_ACT_CAT_URL)
+		createGoalHistoryItems(user, MULTIMEDIA_ACT_CAT_URL)
+	}
+	void addBudgetGoals(User user, def goalUrls)
+	{
+		goalUrls.each {addBudgetGoal(user, it, 0, "W-2 Sun 01:00")}
+	}
+
+	void addTimeZoneGoals(User user, def goalUrls)
+	{
+		goalUrls.each {addTimeZoneGoal(user, it, ["11:00-12:00"], "W-2 Sun 01:00")}
+	}
+
+	void createGoalHistoryItems(User user, def goalUrl)
+	{
+		user = appService.reloadUser(user)
+		BudgetGoal goal = user.findActiveGoal(goalUrl)
+		updateBudgetGoal(user, goal, 10, "W-2 Tue 01:00")
+		updateBudgetGoal(user, goal, 20, "W-2 Wed 01:00")
+		updateBudgetGoal(user, goal, 30, "W-2 Thu 01:00")
+	}
+
+	void generateActivities(User user)
+	{
+		def apps = ["Bad app", "com.whatsapp", "Poker App", "nl.uitzendinggemist", "nl.sanomamedia.android.nu", "com.facebook.katana"]
+		apps.each { generateAppActivityForEveryDay(user, it) }
+	}
+
+	void generateAppActivityForEveryDay(User user, def app)
+	{
+		(-2..-1).each {generateAppActivityForDaysOfWeek(user, app, "W$it", 7) }
+		generateAppActivityForDaysOfWeek(user, app, "W0", YonaServer.getCurrentDayOfWeek() + 1)
+	}
+
+	void generateAppActivityForDaysOfWeek(User user, def app, def week, def numDays)
+	{
+		def days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+		days[0..numDays-1].each { generateAppActivityForDay(user, app, "$week $it") }
+	}
+
+	void generateAppActivityForDay(User user, def app, def day)
+	{
+		def hoursBegin = ["00:05", "00:30", "00:55", "01:20"]
+		def hoursEnd   = ["00:10", "00:35", "01:00", "01:25"]
+		hoursBegin.eachWithIndex
+		{ begin, idx ->
+			reportAppActivity(user, app, "$day $begin", "$day " + hoursEnd[idx])
+		}
+	}
+	void generateCommentThreadOnYesterdaysNewsActivity(User user, def buddyUsers)
+	{
+		User buddyUser = buddyUsers.find { it.nickname == user.buddies[0].nickname }
+		def yesterdayShortDay = LocalDate.now().getDayOfWeek().minus(1).getDisplayName(TextStyle.SHORT, Locale.US)
+		ActivityCommentTest.assertCommentingWorks(appService, user, buddyUser, NEWS_ACT_CAT_URL, false, {u -> appService.getDayActivityOverviews(u, ["size": 14])},
+		{u -> appService.getDayActivityOverviews(u, u.buddies[0], ["size": 14])},
+		{responseOverviews, u, goal -> appService.getDayDetailsFromOverview(responseOverviews, u, goal, 0, yesterdayShortDay)},
+		{ u, message -> assertMarkReadUnread(u, message)})
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ subprojects {
 		yona_batchservice_mgmt_port     = project.properties["yona_batchservice_mgmt_port"]    ?: "9083"
 		yona_batchservice_debug_port    = project.properties["yona_batchservice_debug_port"]   ?: "8843"
 		yona_batchservice_url           = project.properties["yona_batchservice_url"]          ?: "${yona_batchservice_scheme}://${yona_batchservice_host}:${yona_batchservice_port}"
+		yona_test_gen_data              = project.properties["yona_test_gen_data"]             ?: "false"
 	}
 
 	repositories {

--- a/dbinit/data/activityCategories.json
+++ b/dbinit/data/activityCategories.json
@@ -14,7 +14,7 @@
          "Sexuality Sites"
       ],
       "applications": [
-
+         "Bad app"
       ],
       "localizableDescription": {
          "en-US": "This challenge includes apps and sites with adult and porn",


### PR DESCRIPTION
The test creates:

* A user with 3 buddies
* Each of the 4 users gets 4 goals, three budget goals and a timezone goal
* Two if the timezone goals are updated 3 times, to create history items
* Over a period of the current week and the two preceding weeks, each user does 4 activities for each goal, in the early hours of the day
* The "main user" and one of his buddies is having a conversation (multiple activity comment messages) on an activity of yesterday

As the test is rather time consuming (2.5 minutes), it is skipped by default. To run it, do this:

```
gradlew :appservice:cleanIntTest :appservice:intTest -Pyona_test_gen_data=true -DintTest.single=PerformanceSetupTest
```

The user and his password are printed to stdout, like this (in the test output):

```
Test user URL: http://localhost:8082/users/26d92f7f-1a63-41af-8791-df8166f0e3ac, password: AES:128:KHoAy+XTPcKeiE/pfdDAXg==
```