### PR TITLE
YD-464 Added base-64 encoded Mobile Config

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import java.util.Base64
+
 import groovy.json.*
 import nu.yona.server.test.User
 
@@ -292,12 +294,18 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		when:
 		assert richard.appleMobileConfig
 		def responseAppleMobileConfig = appService.yonaServer.restClient.get(path: richard.appleMobileConfig, headers: ["Yona-Password":richard.password])
+		def responseAppleMobileConfigBase64 = appService.yonaServer.restClient.get(path: richard.appleMobileConfigBase64, headers: ["Yona-Password":richard.password])
 
 		then:
 		responseAppleMobileConfig.status == 200
 		responseAppleMobileConfig.contentType == "application/x-apple-aspen-config"
-		def appleMobileConfig = responseAppleMobileConfig.responseData.text
-		appleMobileConfig.contains("<string>${richard.vpnProfile.vpnLoginId}\\n${richard.vpnProfile.vpnPassword}</string>")
+		def appleMobileConfig = responseAppleMobileConfig.responseData.bytes
+		new String(appleMobileConfig, "UTF-8").contains("<string>${richard.vpnProfile.vpnLoginId}\\n${richard.vpnProfile.vpnPassword}</string>")
+		
+		responseAppleMobileConfigBase64.status == 200
+		responseAppleMobileConfigBase64.contentType == "application/base64"
+		def appleMobileConfigBase64 = responseAppleMobileConfigBase64.responseData.text
+		appleMobileConfig == Base64.getDecoder().decode(appleMobileConfigBase64)
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1736,6 +1736,14 @@ definitions:
                       href:
                         type: string
                         description: Link to user-specific Apple .mobileconfig file (available after confirming mobile number)
+                  "yona:appleMobileConfigBase64":
+                    type: object
+                    required:
+                      - href
+                    properties:
+                      href:
+                        type: string
+                        description: Link to user-specific base-64 encoded Apple .mobileconfig file (available after confirming mobile number). This is link is added to work around the issue that the iOS Yona app currently cannot handle binary responses (which occur when the mobile config is signed)
         required:
           - _embedded
           - _links

--- a/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
@@ -46,6 +46,7 @@ class User
 	final String clearPinResetUrl
 	final String sslRootCertUrl
 	final String appleMobileConfig
+	final String appleMobileConfigBase64
 	final String sslRootCertCn
 	final String password
 
@@ -87,6 +88,7 @@ class User
 		this.clearPinResetUrl = json._links?."yona:clearPinReset"?.href
 		this.sslRootCertUrl = json._links?."yona:sslRootCert"?.href
 		this.appleMobileConfig = json._links?."yona:appleMobileConfig"?.href
+		this.appleMobileConfigBase64 = json._links?."yona:appleMobileConfigBase64"?.href
 		this.sslRootCertCn = json.sslRootCertCN
 	}
 


### PR DESCRIPTION
To work around the issue that the iOS app currently does not support binary responses (which occur when the mobile config is signed).