### PR TITLE
YD-468 Support different SMS sender numbers

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
 	testCompile "org.springframework.boot:spring-boot-starter-test"
 	testCompile "junit:junit:4.12"
+	testCompile "pl.pragmatists:JUnitParams:1.1.0"
 	testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
 	
 	testUtilsCompile "org.codehaus.groovy:groovy-all:2.4.6"

--- a/core/src/main/java/nu/yona/server/properties/SmsProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/SmsProperties.java
@@ -7,7 +7,9 @@ package nu.yona.server.properties;
 public class SmsProperties
 {
 	private boolean isEnabled = false;
-	private String senderNumber = "";
+	private String defaultSenderNumber = "";
+	private String alphaSenderId = "";
+	private String alphaSenderSupportingCountryCallingCodes = "";
 	private String plivoUrl = "https://api.plivo.com/v1/Account/{0}/Message/";
 	private String plivoAuthId = "";
 	private String plivoAuthToken = "";
@@ -22,14 +24,34 @@ public class SmsProperties
 		this.isEnabled = isEnabled;
 	}
 
-	public String getSenderNumber()
+	public String getDefaultSenderNumber()
 	{
-		return senderNumber;
+		return defaultSenderNumber;
 	}
 
-	public void setSenderNumber(String senderNumber)
+	public void setDefaultSenderNumber(String senderNumber)
 	{
-		this.senderNumber = senderNumber;
+		this.defaultSenderNumber = senderNumber;
+	}
+
+	public String getAlphaSenderId()
+	{
+		return alphaSenderId;
+	}
+
+	public void setAlphaSenderId(String alphaSenderId)
+	{
+		this.alphaSenderId = alphaSenderId;
+	}
+
+	public String getAlphaSenderSupportingCountryCallingCodes()
+	{
+		return alphaSenderSupportingCountryCallingCodes;
+	}
+
+	public void setAlphaSenderSupportingCountryCallingCodes(String alphaSenderSupportingPrefixes)
+	{
+		this.alphaSenderSupportingCountryCallingCodes = alphaSenderSupportingPrefixes;
 	}
 
 	public String getPlivoUrl()

--- a/core/src/main/java/nu/yona/server/sms/PlivoSmsService.java
+++ b/core/src/main/java/nu/yona/server/sms/PlivoSmsService.java
@@ -121,7 +121,7 @@ public class PlivoSmsService implements SmsService
 		try
 		{
 			Map<String, Object> requestMessage = new HashMap<>();
-			requestMessage.put("src", yonaProperties.getSms().getSenderNumber());
+			requestMessage.put("src", determineSender(phoneNumber));
 			requestMessage.put("dst", phoneNumber);
 			requestMessage.put("text", message);
 
@@ -131,6 +131,18 @@ public class PlivoSmsService implements SmsService
 		{
 			throw SmsException.smsSendingFailed(e);
 		}
+	}
+
+	String determineSender(String targetPhoneNumber)
+	{
+		for (String prefix : yonaProperties.getSms().getAlphaSenderSupportingCountryCallingCodes().split("\\s"))
+		{
+			if (targetPhoneNumber.startsWith(prefix))
+			{
+				return yonaProperties.getSms().getAlphaSenderId();
+			}
+		}
+		return yonaProperties.getSms().getDefaultSenderNumber();
 	}
 
 	private HttpPost createHttpRequest(String jsonStr)

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -94,7 +94,9 @@ yona.ldap.accessUserDn=CN=Manager,DC=yonadir1,DC=nu
 yona.ldap.accessUserPassword=Secret
 
 yona.sms.enabled = false
-yona.sms.senderNumber = 
+yona.sms.defaultSenderNumber = +17184169858
+yona.sms.alphaSenderId = Yona
+yona.sms.alphaSenderSupportingCountryCallingCodes = +31 +49 +33
 yona.sms.plivoUrl = https://api.plivo.com/v1/Account/{0}/Message/
 yona.sms.plivoAuthId = 
 yona.sms.plivoAuthToken = 

--- a/core/src/test/java/nu/yona/server/sms/PlivoSmsServiceTest.java
+++ b/core/src/test/java/nu/yona/server/sms/PlivoSmsServiceTest.java
@@ -4,25 +4,21 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import nu.yona.server.properties.SmsProperties;
 import nu.yona.server.properties.YonaProperties;
 
-@RunWith(Parameterized.class)
+@RunWith(JUnitParamsRunner.class)
 public class PlivoSmsServiceTest
 {
 	private static final String TEST_ALPHA_ID = "TestId";
@@ -31,19 +27,6 @@ public class PlivoSmsServiceTest
 
 	@Rule
 	public MockitoRule rule = MockitoJUnit.rule();
-
-	@Parameters
-	public static Collection<Object[]> data()
-	{
-		return Arrays.asList(new Object[][] { { "+31000000000", TEST_ALPHA_ID }, { "+32111111111", TEST_DEFAULT_NUMBER },
-				{ "+49222222222", TEST_ALPHA_ID } });
-	}
-
-	@Parameter // first data value (0) is default
-	public String targetPhoneNumber;
-
-	@Parameter(1)
-	public String expectedSender;
 
 	@Mock
 	private YonaProperties mockYonaProperties;
@@ -62,7 +45,8 @@ public class PlivoSmsServiceTest
 	}
 
 	@Test
-	public void test()
+	@Parameters({ "+31000000000, " + TEST_ALPHA_ID, "+32111111111, " + TEST_DEFAULT_NUMBER, "+49222222222, " + TEST_ALPHA_ID })
+	public void testDetermineSender(String targetPhoneNumber, String expectedSender)
 	{
 		assertThat(smsService.determineSender(targetPhoneNumber), equalTo(expectedSender));
 	}

--- a/core/src/test/java/nu/yona/server/sms/PlivoSmsServiceTest.java
+++ b/core/src/test/java/nu/yona/server/sms/PlivoSmsServiceTest.java
@@ -1,0 +1,70 @@
+package nu.yona.server.sms;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import nu.yona.server.properties.SmsProperties;
+import nu.yona.server.properties.YonaProperties;
+
+@RunWith(Parameterized.class)
+public class PlivoSmsServiceTest
+{
+	private static final String TEST_ALPHA_ID = "TestId";
+	private static final String TEST_DEFAULT_NUMBER = "+12345678";
+	private static final String TEST_ALPHA_SUPPORTING_COUNTRY_CALLING_CODES = "+31 +49";
+
+	@Rule
+	public MockitoRule rule = MockitoJUnit.rule();
+
+	@Parameters
+	public static Collection<Object[]> data()
+	{
+		return Arrays.asList(new Object[][] { { "+31000000000", TEST_ALPHA_ID }, { "+32111111111", TEST_DEFAULT_NUMBER },
+				{ "+49222222222", TEST_ALPHA_ID } });
+	}
+
+	@Parameter // first data value (0) is default
+	public String targetPhoneNumber;
+
+	@Parameter(1)
+	public String expectedSender;
+
+	@Mock
+	private YonaProperties mockYonaProperties;
+
+	@InjectMocks
+	private final PlivoSmsService smsService = new PlivoSmsService();
+
+	@Before
+	public void setUp()
+	{
+		SmsProperties smsProperties = new SmsProperties();
+		smsProperties.setAlphaSenderId(TEST_ALPHA_ID);
+		smsProperties.setDefaultSenderNumber(TEST_DEFAULT_NUMBER);
+		smsProperties.setAlphaSenderSupportingCountryCallingCodes(TEST_ALPHA_SUPPORTING_COUNTRY_CALLING_CODES);
+		when(mockYonaProperties.getSms()).thenReturn(smsProperties);
+	}
+
+	@Test
+	public void test()
+	{
+		assertThat(smsService.determineSender(targetPhoneNumber), equalTo(expectedSender));
+	}
+
+}

--- a/k8s/helm/yona-server/templates/01_configmap_properties.yaml
+++ b/k8s/helm/yona-server/templates/01_configmap_properties.yaml
@@ -44,7 +44,9 @@ data:
     yona.ldap.accessUserDn={{ .Values.ldap.user_dn | default "cn=admin,dc=example,dc=local" }}
     yona.ldap.accessUserPassword={{ .Values.ldap.user_password | default "password" }}
     yona.sms.enabled= {{ .Values.sms.enabled | default "false" }}
-    yona.sms.senderNumber = {{ .Values.sms.sender_number | default "Yona" }}
+    yona.sms.defaultSenderNumber = {{ .Values.sms.default_sender_number | default "+17184169858" }}
+    yona.sms.alphaSenderId = {{ .Values.sms.alpha_sender_id | default "Yona" }}
+    yona.sms.alphaSenderSupportingCountryCallingCodes = {{ .Values.sms.alpha_sender_supporting_country_calling_codes | default "+31 +49 +33" }}
     yona.sms.plivoUrl = {{ .Values.sms.plivo_url | default "https://api.plivo.com/v1/Account/{0}/Message/" }}
     yona.sms.plivoAuthId = {{ .Values.sms.plivo_auth_id | default "authidocde" }}
     yona.sms.plivoAuthToken = {{ .Values.sms.plivo_auth_token | default "authtoken" }}

--- a/k8s/helm/yona-server/values.yaml
+++ b/k8s/helm/yona-server/values.yaml
@@ -157,7 +157,9 @@ ldap:
 
 sms:
   enabled: false
-  sender_number: Yona
+  default_sender_number: +17184169858
+  alpha_sender_id: Yona
+  alpha_sender_supporting_country_calling_codes: +31 +49 +33
   plivo_url: "https://api.plivo.com/v1/Account/{0}/Message/"
   plivo_auth_id: M1234123412341234123
   plivo_auth_token: N123412341234123412341234123412341234123


### PR DESCRIPTION
New properties are introduced:

yona.sms.defaultSenderNumber = +17184169858
yona.sms.alphaSenderId = Yona
yona.sms.alphaSenderSupportingCountryCallingCodes = +31 +49 +33

If the country calling code of the target phone number is in the alpha-sender-supporting country calling codes, then the alphaSenderId will be used as sender, otherwise the defaultSenderNumber.