### PR TITLE
Fix the URL endpoints for internal communication for dev standup

### DIFF
--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -41,7 +41,7 @@ spec:
             {{- if .Values.batch.url_override }}
               value: {{ .Values.batch.url_override | quote }}
             {{- else }}
-              value: "http://batch.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "http://batch.{{ .Release.Namespace }}.svc.cluster.local:8080"
             {{- end }}
           ports:
             - containerPort: 8080

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -41,13 +41,13 @@ spec:
             {{- if hasKey .Values.analysis "url_override" }}
               value: {{ .Values.analysis.url_override | quote }}
             {{- else }}
-              value: "http://analysis.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "http://analysis.{{ .Release.Namespace }}.svc.cluster.local:8080"
             {{- end }}
             - name: YONA_BATCH_SERVICE_SERVICE_URL
             {{- if .Values.batch.url_override }}
               value: {{ .Values.batch.url_override | quote }}
             {{- else }}
-              value: "http://batch.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "http://batch.{{ .Release.Namespace }}.svc.cluster.local:8080"
             {{- end }}
           ports:
             - containerPort: 8080


### PR DESCRIPTION
When running on a local development standup, using no external load balancer, the pods communicate directly against the defined service IPs - This also means they need to talk to the exposed ports.  Either direct againt 8080 for springboot apps, or perhaps against defined node ports.   Not going through the kube-proxy (used in node ports) is more efficient, so I just added :8080 to the default urls.

```
app# curl http://analysis.yona.svc.cluster.local     
curl: (7) Failed to connect to analysis.yona.svc.cluster.local port 80: Network is unreachable
```
vs...
```
app# curl http://analysis.yona.svc.cluster.local:8080     
{
  "timestamp" : "2017-06-21T18:11:44.640+0000",
  "status" : 404,
  "error" : "Not Found",
  "message" : "No message available",
  "path" : "/"
}
```