### PR TITLE
YD-476 Define BuddyAnonymized.owningUserAnonymized as entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Yona Server
 ==================================
 
-The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging.
+The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging. 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Yona Server
 ==================================
 
-The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging. 
+The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging.

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
@@ -85,7 +85,11 @@ public class Buddy extends EntityWithUuid
 
 	public BuddyAnonymized getBuddyAnonymized()
 	{
-		return BuddyAnonymized.getRepository().findOne(buddyAnonymizedId);
+		BuddyAnonymized buddyAnonymized = BuddyAnonymized.getRepository().findOne(buddyAnonymizedId);
+		assert buddyAnonymized != null : "Buddy with ID " + getId() + " cannot find buddy anonymized with ID "
+				+ buddyAnonymizedId;
+
+		return buddyAnonymized;
 	}
 
 	public String getNickname()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymized.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.hibernate.annotations.Type;
@@ -27,11 +28,18 @@ public class BuddyAnonymized extends EntityWithUuid
 		NOT_REQUESTED, REQUESTED, ACCEPTED, REJECTED
 	}
 
-	@Type(type = "uuid-char")
-	@Column(name = "owning_user_anonymized_id")
-	private UUID owningUserAnonymizedId;
+	/**
+	 * The anonymized user owning this buddy anonymized entity.
+	 */
+	@ManyToOne
+	private UserAnonymized owningUserAnonymized;
 
+	/**
+	 * The anonymized user of the buddy. This is kept as UUID rather than an entity, as the ID is still needed even if the entity
+	 * has been deleted, to clean up the messages sent by this user.
+	 */
 	@Type(type = "uuid-char")
+	@Column(name = "user_anonymized_id")
 	private UUID userAnonymizedId;
 
 	/*
@@ -112,6 +120,16 @@ public class BuddyAnonymized extends EntityWithUuid
 	public void setReceivingStatus(Status receivingStatus)
 	{
 		this.receivingStatus = receivingStatus;
+	}
+
+	public void setOwningUserAnonymized(UserAnonymized owningUserAnonymized)
+	{
+		this.owningUserAnonymized = owningUserAnonymized;
+	}
+
+	public void clearOwningUserAnonymized()
+	{
+		this.owningUserAnonymized = null;
 	}
 
 	public Optional<UUID> getUserAnonymizedId()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -43,8 +42,10 @@ public class UserAnonymized extends EntityWithUuid
 	@BatchSize(size = 20)
 	private Set<Goal> goals;
 
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JoinColumn(name = "owning_user_anonymized_id", referencedColumnName = "id")
+	/**
+	 * The BuddyAnonymized entities owned by this user
+	 */
+	@OneToMany(mappedBy = "owningUserAnonymized", cascade = CascadeType.ALL, orphanRemoval = true)
 	private Set<BuddyAnonymized> buddiesAnonymized;
 
 	// Default constructor is required for JPA
@@ -100,12 +101,14 @@ public class UserAnonymized extends EntityWithUuid
 	public void addBuddyAnonymized(BuddyAnonymized buddyAnonimized)
 	{
 		buddiesAnonymized.add(buddyAnonimized);
+		buddyAnonimized.setOwningUserAnonymized(this);
 	}
 
 	public void removeBuddyAnonymized(BuddyAnonymized buddyAnonimized)
 	{
 		boolean removed = buddiesAnonymized.remove(buddyAnonimized);
 		assert removed;
+		buddyAnonimized.clearOwningUserAnonymized();
 	}
 
 	public UUID getVpnLoginId()


### PR DESCRIPTION
Rather than a UUID, to create a regular and clean JPA model.

Along with this added extra assert to Buddy.java