### PR TITLE
YD-408 Overlapping activity is merged

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -272,7 +272,7 @@ public class AnalysisEngineService
 
 	private boolean isInterruptedAppActivity(ActivityPayload payload, ActivityDto lastRegisteredActivity)
 	{
-		return payload.application.isPresent() && !payload.startTime.equals(lastRegisteredActivity.getEndTime());
+		return payload.application.isPresent() && payload.startTime.isAfter(lastRegisteredActivity.getEndTime());
 	}
 
 	private boolean isRelatedToDifferentApp(ActivityPayload payload, ActivityDto lastRegisteredActivity)

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -693,6 +693,24 @@ public class AnalysisEngineServiceTest
 	}
 
 	@Test
+	public void analyze_appActivityOverlappingSameApp_activityRecordMergedAndNoNewGoalConflictMessageCreated()
+	{
+		ZonedDateTime now = now();
+		ZonedDateTime existingActivityEndTime = now.minusMinutes(5);
+		DayActivity existingDayActivity = mockExistingActivity(gamblingGoal, now.minusMinutes(10), existingActivityEndTime,
+				"Lotto App");
+
+		service.analyze(userAnonId,
+				createSingleAppActivity("Lotto App", existingActivityEndTime.minusSeconds(30), now.minusMinutes(2)));
+
+		verifyNoGoalConflictMessagesCreated();
+		List<Activity> activities = existingDayActivity.getActivities();
+		assertThat(activities.size(), equalTo(1));
+		assertThat(activities.get(0).getApp(), equalTo(Optional.of("Lotto App")));
+		assertThat(activities.get(0).getDurationMinutes(), equalTo(8));
+	}
+
+	@Test
 	public void analyze_appActivitySameAppWithinConflictIntervalButNotContinuous_activityRecordNotMergedButNoNewGoalConflictMessageCreated()
 	{
 		ZonedDateTime now = now();
@@ -712,7 +730,7 @@ public class AnalysisEngineServiceTest
 
 	private NetworkActivityDto createNetworkActivityForCategories(String... conflictCategories)
 	{
-		return new NetworkActivityDto(new HashSet<String>(Arrays.asList(conflictCategories)),
+		return new NetworkActivityDto(new HashSet<>(Arrays.asList(conflictCategories)),
 				"http://localhost/test" + new Random().nextInt(), Optional.empty());
 	}
 
@@ -733,7 +751,7 @@ public class AnalysisEngineServiceTest
 
 	private List<Activity> verifyActivityUpdate(Goal... forGoals)
 	{
-		List<Activity> resultActivities = new ArrayList<Activity>();
+		List<Activity> resultActivities = new ArrayList<>();
 		// Verify there is a an activity in a day activity inside a week activity
 		verify(mockUserAnonymizedService, atLeastOnce()).updateUserAnonymized(userAnonEntity);
 		for (Goal forGoal : forGoals)


### PR DESCRIPTION
The analysis engine scales each activity up to at least one minute. So this is what could happen:
* User opens app for 20 seconds
* Analysis engine scales this up to 1 minute
* In 20 seconds, the user opens the app again, now for 3 minutes

This should result in an activity of 3 minutes and 40 seconds. In the past, a new activity was created, because start time of the new activity was not equal to the end time of the previous one. Now a new activity is created when the start time is after the end time of the last activity, not when it is equal or before it.