### PR TITLE
YD-485 Ignore too large sets of app activities

### DIFF
--- a/core/src/main/java/nu/yona/server/properties/AnalysisServiceProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/AnalysisServiceProperties.java
@@ -13,6 +13,7 @@ public class AnalysisServiceProperties
 	private Duration activityMemory = Duration.ofDays(490);
 	private String serviceUrl = "http://localhost:8081";
 	private int appActivityCountLoggingThreshold = 10;
+	private final int appActivityCountIgnoreThreshold = 100;
 
 	public Duration getActivityMemory()
 	{
@@ -62,5 +63,10 @@ public class AnalysisServiceProperties
 	public void setAppActivityCountLoggingThreshold(int appActivityCountLoggingThreshold)
 	{
 		this.appActivityCountLoggingThreshold = appActivityCountLoggingThreshold;
+	}
+
+	public int getAppActivityCountIgnoreThreshold()
+	{
+		return appActivityCountIgnoreThreshold;
 	}
 }

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -72,6 +72,7 @@ yona.analysisservice.conflictInterval = PT15M
 yona.analysisservice.updateSkipWindow = PT5S
 yona.analysisservice.activityMemory = P490D
 yona.analysisservice.appActivityCountLoggingThreshold = 10
+yona.analysisservice.appActivityCountIgnoreThreshold = 100
 
 yona.email.enabled = false
 yona.email.senderAddress=noreply@yona.nu


### PR DESCRIPTION
When a user posts more app activities than the configured threshold, the set of app activities is ignored. This is a workaround for APPDEV-1022: the app accumulates all app activities and posts all historical app activities along with each new one, thus accumulating collections of app activities as large as 745,846 items. By ignoring large sets in the app service, the analysis engine service doesn't get overloaded. Once the issue in the app is fixed, we can remove these provisions again.