### PR TITLE
YD-493 Block all nonmobile numbers

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -70,7 +70,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	User addRichard(boolean reload = true)
 	{
 		User richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
-				"+$timestamp")
+				makeMobileNumber(timestamp))
 		richard = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, richard)
 		def response = appService.addGoal(richard, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
 		assert response.status == 201
@@ -80,7 +80,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	User addBob(boolean reload = true)
 	{
 		User bob = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob", "Dunn", "BD",
-				"+$timestamp")
+				makeMobileNumber(timestamp))
 		bob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bob)
 		def response = appService.addGoal(bob, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
 		assert response.status == 201
@@ -90,7 +90,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	User addBea(boolean reload = true)
 	{
 		User bea = appService.addUser(appService.&assertUserCreationResponseDetails, "Bea", "Dundee", "BDD",
-				"+$timestamp")
+				makeMobileNumber(timestamp))
 		bea = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, bea)
 		return reload? appService.reloadUser(bea) : bea
 	}
@@ -125,6 +125,11 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	{
 		int num = sequenceNumber++
 		return "$baseTimestamp$num"
+	}
+
+	static String makeMobileNumber(String timestamp)
+	{
+		"+3161" + timestamp[-7..-1]
 	}
 
 	void assertEquals(String dateTimeString, ZonedDateTime comparisonDateTime, int epsilonSeconds = 10)
@@ -478,7 +483,8 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		def activeDays = 0
 		expectedValues.each { activeDays += it.value.findAll{it.goal.activityCategoryUrl == goal.activityCategoryUrl}.size()}
 		assert response.responseData.dayActivities?.size() == activeDays
-		expectedValues.each {
+		expectedValues.each
+		{
 			def day = it.key
 			it.value.findAll{it.goal.activityCategoryUrl == goal.activityCategoryUrl}.each
 			{
@@ -493,7 +499,8 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 				assert dayActivityForGoal.date == null // Only on week level
 				assert dayActivityForGoal.timeZoneId == null // Only on week level
 				assert dayActivityForGoal._links."yona:goal" == null // Only on week level
-			}}
+			}
+		}
 	}
 
 	void assertDayDetail(User user, dayActivityOverviewResponse, Goal goal, expectedValues, weeksBack, shortDay)
@@ -513,7 +520,6 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		assert response.responseData.date =~ /\d{4}\-\d{2}\-\d{2}/
 		assert response.responseData.timeZoneId == "Europe/Amsterdam"
 		assert response.responseData._links."yona:goal"
-
 	}
 
 	void assertDayOverviewWithBuddiesBasics(response, expectedSize, expectedTotalElements, expectedPageSize = 3)
@@ -540,27 +546,32 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		int expectedUsersWithGoalInThisCategory = expectedValues.findAll{it.expectedValues[shortDay].find{it.goal.activityCategoryUrl == activityCategoryUrl}}.size()
 		assert dayActivityOverview.date =~ /\d{4}\-\d{2}\-\d{2}/
 		assert dayActivityOverview.timeZoneId == "Europe/Amsterdam"
-		if (expectedUsersWithGoalInThisCategory == 0) {
+		if (expectedUsersWithGoalInThisCategory == 0)
+		{
 			assert dayActivityOverview.dayActivities.find{ it._links."yona:activityCategory"?.href == activityCategoryUrl} == null
-		} else {
+		} else
+		{
 			assert dayActivityOverview.dayActivities.find{ it._links."yona:activityCategory"?.href == activityCategoryUrl}
 			assert dayActivityOverview._links?.self?.href
 			def dayActivitiesForCategory = dayActivityOverview.dayActivities.find{ it._links."yona:activityCategory".href == activityCategoryUrl}
 			assert dayActivitiesForCategory._links.size() == 1
 			assert dayActivitiesForCategory.dayActivitiesForUsers.size() == expectedUsersWithGoalInThisCategory
 
-			expectedValues.each {
+			expectedValues.each
+			{
 				User userToAssert = it.user
 				def expectedValuesForUser = it.expectedValues
 				def expectedValuesForDayAndActivityCategory = getExpectedDataForDayAndActivityCategory(expectedValuesForUser, shortDay, activityCategoryUrl)
-				if (expectedValuesForDayAndActivityCategory) {
-					if (expectedValuesForDayAndActivityCategory.goal instanceof TimeZoneGoal) {
+				if (expectedValuesForDayAndActivityCategory)
+				{
+					if (expectedValuesForDayAndActivityCategory.goal instanceof TimeZoneGoal)
+					{
 						assertDayOverviewWithBuddiesForTimeZoneGoal(dayActivitiesForCategory, actingUser, userToAssert, expectedValuesForDayAndActivityCategory)
-					} else {
+					} else
+					{
 						assertDayOverviewWithBuddiesForBudgetGoal(dayActivitiesForCategory, actingUser, userToAssert, expectedValuesForDayAndActivityCategory)
 					}
 				}
-
 			}
 		}
 	}
@@ -570,7 +581,8 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		def dayActivityOverviewForUser
 		def dayDetailsUrlPrefix
 		Goal goal = expectedValuesForDayAndActivityCategory.goal
-		if (userToAssert == actingUser) {
+		if (userToAssert == actingUser)
+		{
 			dayActivityOverviewForUser = dayActivitiesForCategory.dayActivitiesForUsers.find{it._links."yona:user"?.href?.startsWith(userToAssert.url)}
 			dayDetailsUrlPrefix = userToAssert.url
 			assert dayActivityOverviewForUser._links."yona:buddy" == null

--- a/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
@@ -48,7 +48,7 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		def responseWrongNewDeviceRequestPassword = appService.getNewDeviceRequest(richard.mobileNumber, "wrong temp password")
-		def responseWrongMobileNumber = appService.getNewDeviceRequest("+31690609181", "wrong temp password")
+		def responseWrongMobileNumber = appService.getNewDeviceRequest("+31610609189", "wrong temp password")
 		def responseNoNewDeviceRequestWrongPassword = appService.getNewDeviceRequest(bob.mobileNumber, "wrong temp password")
 		def responseNoNewDeviceRequestNoPassword = appService.getNewDeviceRequest(bob.mobileNumber)
 
@@ -78,7 +78,7 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		def responseWrongPassword = appService.setNewDeviceRequest(richard.mobileNumber, "foo", "Some password")
-		def responseWrongMobileNumber = appService.setNewDeviceRequest("+31690609181", "foo", "Some password")
+		def responseWrongMobileNumber = appService.setNewDeviceRequest("+31610609189", "foo", "Some password")
 
 		then:
 		responseWrongPassword.status == 400
@@ -146,7 +146,7 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		def responseWrongPassword = appService.clearNewDeviceRequest(richard.mobileNumber, "foo")
-		def responseWrongMobileNumber = appService.clearNewDeviceRequest("+31690609181", "foo")
+		def responseWrongMobileNumber = appService.clearNewDeviceRequest("+31610609189", "foo")
 
 		then:
 		responseWrongPassword.status == 400

--- a/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
@@ -20,7 +20,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def userCreationJson = """{
 				"firstName":"John",
 				"lastName":"Doe",
-				"mobileNumber":"+${timestamp}",
+				"mobileNumber":"${makeMobileNumber(timestamp)}",
 				"emailAddress":"john@doe.com"
 				}"""
 	def password = "John Doe"
@@ -28,8 +28,8 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'AddBuddy - empty first name'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.remove('firstName')
@@ -38,7 +38,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.firstname"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
@@ -46,8 +46,8 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'AddBuddy - empty last name'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.remove('lastName')
@@ -56,7 +56,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.lastname"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
@@ -64,8 +64,8 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'AddBuddy - empty mobile number'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.remove('mobileNumber')
@@ -74,7 +74,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.mobile.number"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
@@ -82,8 +82,8 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'AddBuddy - invalid mobile number'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.put('mobileNumber', '++55 5 ')
@@ -92,16 +92,16 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.mobile.number.invalid"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
-	
+
 	def 'AddBuddy - empty email address'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.remove('emailAddress')
@@ -110,7 +110,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.email.address"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
@@ -118,8 +118,8 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'AddBuddy - invalid email address'()
 	{
 		given:
-		User richard = addRichard();
-		
+		User richard = addRichard()
+
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
 		object.put('emailAddress', 'a@b')
@@ -140,11 +140,11 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		cleanup:
 		appService.deleteUser(richard)
 	}
-	
+
 	def 'Try Richard request himself as buddy'()
 	{
 		given:
-		User richard = addRichard();
+		User richard = addRichard()
 		richard.emailAddress = "richard@quinn.com"
 
 		when:
@@ -153,7 +153,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.buddy.cannot.invite.self"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 	}
@@ -161,21 +161,20 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 	def 'Try Richard request Bob as buddy twice'()
 	{
 		given:
-		User richard = addRichard();
+		User richard = addRichard()
 		User bob = addBob()
 		bob.emailAddress = "bob@dunn.com"
 		appService.sendBuddyConnectRequest(richard, bob)
-		
+
 		when:
 		def response = appService.sendBuddyConnectRequest(richard, bob, false)
 
 		then:
 		response.status == 400
 		response.responseData.code == "error.buddy.cannot.invite.existing.buddy"
-		
+
 		cleanup:
 		appService.deleteUser(richard)
 		appService.deleteUser(bob)
 	}
-
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -17,10 +17,10 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
-				"+$timestamp")
+				makeMobileNumber(timestamp))
 
 		when:
-		def response = sendBuddyRequestForBob(richard, "+$timestamp")
+		def response = sendBuddyRequestForBob(richard, makeMobileNumber(timestamp))
 
 		then:
 		response.status == 400
@@ -36,7 +36,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 
 		when:
-		def response = sendBuddyRequestForBob(richard, "+$timestamp")
+		def response = sendBuddyRequestForBob(richard, makeMobileNumber(timestamp))
 
 		then:
 		response.status == 201
@@ -53,7 +53,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 
 		when:
@@ -74,7 +74,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
@@ -116,7 +116,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
@@ -145,7 +145,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
@@ -176,7 +176,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
@@ -209,7 +209,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
@@ -253,7 +253,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
@@ -297,7 +297,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		sendBuddyRequestForBob(richard, mobileNumberBob)
 
 		when:
@@ -316,7 +316,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, "+$timestamp"))
+		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
 
 		when:
 		def response = appService.getResource(YonaServer.stripQueryString(inviteUrl), [:], ["tempPassword": "hack", "includePrivateData": "true"])
@@ -334,14 +334,14 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, "+$timestamp"))
+		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
 
 		when:
 		def response = appService.updateResource(YonaServer.stripQueryString(inviteUrl), """{
 				"firstName":"Richard",
 				"lastName":"Quin",
 				"nickname":"RQ",
-				"mobileNumber":"+$timestamp"
+				"mobileNumber":"${makeMobileNumber(timestamp)}"
 			}""", [:], ["tempPassword": "hack"])
 
 		then:
@@ -373,7 +373,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def responseAddBuddy = sendBuddyRequestForBob(richard, mobileNumberBob)
 		def bobUrl = responseAddBuddy.responseData._embedded."yona:user"._links.self.href
 
@@ -399,7 +399,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 				"firstName":"Richard",
 				"lastName":"Quin",
 				"nickname":"RQ",
-				"mobileNumber":"+$timestamp"
+				"mobileNumber":"${makeMobileNumber(timestamp)}"
 			}""", [:], ["tempPassword": "hack"])
 
 		then:
@@ -414,7 +414,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 
 		when:
@@ -463,7 +463,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def mobileNumberBob = "+$timestamp"
+		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 		appService.requestOverwriteUser(mobileNumberBob)
 		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "Bob Changed",

--- a/appservice/src/intTest/groovy/nu/yona/server/HibernateStatsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/HibernateStatsTest.groovy
@@ -319,7 +319,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 	User createBuddyUser(int index)
 	{
 		User buddyUser = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
-				"+$timestamp")
+				makeMobileNumber(timestamp))
 		buddyUser = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, buddyUser)
 		setGoals(buddyUser)
 		buddyUser.emailAddress = "bob${index}@dunn.com"

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -287,7 +287,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 	def 'Hacking attempt: Brute force overwrite user overwrite confirmation'()
 	{
 		given:
-		def userCreationMobileNumber = "+${timestamp}99"
+		def userCreationMobileNumber = makeMobileNumber("${timestamp}99")
 		def userCreationJson = """{
 						"firstName":"John",
 						"lastName":"Doe",

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -388,14 +388,14 @@ class UserTest extends AbstractAppServiceIntegrationTest
 	private User createJohnDoe(def ts)
 	{
 		appService.addUser(appService.&assertUserCreationResponseDetails, firstName, lastName, nickname,
-				"+$ts")
+				makeMobileNumber(ts))
 	}
 
 	private void testUser(User user, includePrivateData, mobileNumberConfirmed, timestamp)
 	{
 		assert user.firstName == "John"
 		assert user.lastName == "Doe"
-		assert user.mobileNumber == "+${timestamp}"
+		assert user.mobileNumber == makeMobileNumber(timestamp)
 		assertEquals(user.creationTime, YonaServer.now)
 		assertEquals(user.appLastOpenedDate, YonaServer.now.toLocalDate())
 

--- a/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
@@ -20,7 +20,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 				"firstName":"John",
 				"lastName":"Doe",
 				"nickname":"JD",
-				"mobileNumber":"+${timestamp}"
+				"mobileNumber":"${makeMobileNumber(timestamp)}"
 				}"""
 
 	def 'AddUser - empty first name'()
@@ -71,7 +71,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		response.responseData.code == "error.user.mobile.number"
 	}
 
-	def 'AddUser - invalid mobile number'()
+	def 'AddUser - invalid mobile number format'()
 	{
 		when:
 		def object = jsonSlurper.parseText(userCreationJson)
@@ -81,5 +81,17 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		then:
 		response.status == 400
 		response.responseData.code == "error.user.mobile.number.invalid"
+	}
+
+	def 'AddUser - invalid mobile number (fixed line)'()
+	{
+		when:
+		def object = jsonSlurper.parseText(userCreationJson)
+		object.put('mobileNumber', '+31356474747')
+		def response = appService.addUser(object)
+
+		then:
+		response.status == 400
+		response.responseData.code == "error.user.mobile.number.not.mobile"
 	}
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compile "org.springframework.security:spring-security-web:4.0.3.RELEASE"
 	compile "com.google.guava:guava:18.0"
 	compile "com.hazelcast:hazelcast-spring"
+	compile "com.googlecode.libphonenumber:libphonenumber:8.8.4"
 	
 	compile "org.codehaus.groovy:groovy-all:2.4.7"
 	compile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -50,6 +50,11 @@ public class InvalidDataException extends YonaException
 		return new InvalidDataException("error.user.mobile.number.invalid", mobileNumber);
 	}
 
+	public static InvalidDataException notAMobileNumber(String number, String classification)
+	{
+		return new InvalidDataException("error.user.mobile.number.not.mobile", number, classification);
+	}
+
 	public static InvalidDataException emptyUserId()
 	{
 		return new InvalidDataException("error.missing.user.id");

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -28,6 +28,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
+
 import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.crypto.CryptoUtil;
 import nu.yona.server.crypto.seckey.CryptoSession;
@@ -824,6 +828,24 @@ public class UserService
 		if (!REGEX_PHONE.matcher(mobileNumber).matches())
 		{
 			throw InvalidDataException.invalidMobileNumber(mobileNumber);
+		}
+		assertNumberIsMobile(mobileNumber);
+	}
+
+	private void assertNumberIsMobile(String mobileNumber)
+	{
+		try
+		{
+			PhoneNumberUtil util = PhoneNumberUtil.getInstance();
+			PhoneNumberType numberType = util.getNumberType(util.parse(mobileNumber, null));
+			if ((numberType != PhoneNumberType.MOBILE) && (numberType != PhoneNumberType.FIXED_LINE_OR_MOBILE))
+			{
+				throw InvalidDataException.notAMobileNumber(mobileNumber, numberType.toString());
+			}
+		}
+		catch (NumberParseException e)
+		{
+			throw YonaException.unexpected(e);
 		}
 	}
 

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -24,6 +24,7 @@ error.user.email.address=The email address of the user must be set
 error.user.email.address.invalid=The email address ''{0}'' is invalid.
 error.user.mobile.number=The mobile number of the user must be set
 error.user.mobile.number.invalid=The mobile number ''{0}'' is invalid. It must start with a + sign, with no spaces between the digits
+error.user.mobile.number.not.mobile=The number ''{0}'' is not a mobile number (classified as {1}). Only mobile numbers are allowed.
 error.user.email.address=The email address of the user must be set
 error.user.email.address.invalid=The email address ''{0}'' is invalid. It must follow the pattern a@b.c
 error.user.email.address.not.supported=E-mail address not supported in this context (only when sending a buddy connect request)

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -24,6 +24,7 @@ error.user.email.address=Het e-mail adres van de gebruiker moet worden ingevuld
 error.user.email.address.invalid=Het e-mail adres ''{0}'' is onjuist
 error.user.mobile.number=Het mobiele nummer van de gebruiker moet worden ingevuld
 error.user.mobile.number.invalid=Het mobiele nummer ''{0}'' is ongeldig. Het moet beginnen met een +-teken, zonder spaties tussen de tekens
+error.user.mobile.number.not.mobile=Het nummer ''{0}'' geen mobiel nummer (geclassificeerd als {1}). Alleen mobiele nummers zijn toegestaan.
 error.user.email.address=Het e-mail addres van de gebruiker moet worden ingevuld
 error.user.email.address.invalid=Het e-mail adres ''{0}'' is ongeldig. Het moet voldoen aan het patroon a@b.c
 error.user.email.address.not.supported=E-mail adres wordt niet ondersteund in deze context (alleen bij het verzenden van een vriendschapsverzoek)


### PR DESCRIPTION
Added a dependency on Google's libphonenumber to verify the numbers. Only numbers of the types MOBILE and FIXED_LINE_OR_MOBILE are accepted. The tests are updated to produce numbers that match Google's definition of mobile numbers.

Extended UserValidationTest with a test that verifies that fixed line numbers are rejected.