### PR TITLE
YD-502 Now use Google Play testing link

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -89,7 +89,7 @@ yona.email.smtp.username=yona@localhost
 yona.email.smtp.password=
 yona.email.includedMediaBaseUrl=https://app.prd.yona.nu/media/
 yona.email.appleAppStoreUrl=https://itunes.apple.com/us/app/keynote/id361285480?mt=8
-yona.email.googlePlayStoreUrl=https://play.google.com/store/apps/details?id=nu.yona
+yona.email.googlePlayStoreUrl=https://play.google.com/apps/testing/nu.yona.app
 
 yona.ldap.enabled = false
 yona.ldap.url=ldap://localhost:389

--- a/core/src/main/resources/templates/email/buddy-invitation-body.html
+++ b/core/src/main/resources/templates/email/buddy-invitation-body.html
@@ -353,8 +353,7 @@
                         	</p>
 <ol class="smallertext" style="font-family: 'Open Sans', Arial, sans-serif; color: #707070; font-size: 12px; line-height: 2.8; font-weight: normal; padding-left: 20px; margin: 0 0 20px;">
                         		<li style="margin-left: 5px; font-weight: bold; list-style-position: inside;"><span style="font-weight: normal; padding-left: 15px;" th:utext="#{buddy-invitation-body.step1(${appleAppStoreUrl}, ${googlePlayStoreUrl})}">Ga naar de <a href="#" style="color: #2678bf; text-decoration: none;">Apple App Store</a> of de <a href="#" style="color: #2678bf; text-decoration: none;">Google Play Store</a> en download Yona.</span></li>
-                                <li style="margin-left: 5px; font-weight: bold; list-style-position: inside;"><span style="font-weight: normal; padding-left: 15px;" th:utext="#{buddy-invitation-body.step2}">Open de app en &bdquo;doe mee&ldquo;.</span></li>
-                                <li style="margin-left: 5px; font-weight: bold; list-style-position: inside;"><span style="font-weight: normal; padding-left: 15px;" th:utext="#{buddy-invitation-body.step3(${inviteUrl})}">Ga terug naar deze mail en klik op <a href="https://app.prd.yona.nu/users/a-b-c?includePrivateData=true" style="color: #2678bf; text-decoration: none;">deze link</a> om vriend te worden.</span></li>
+                                <li style="margin-left: 5px; font-weight: bold; list-style-position: inside;"><span style="font-weight: normal; padding-left: 15px;" th:utext="#{buddy-invitation-body.step2(${inviteUrl})}">Ga terug naar deze mail en klik op <a href="https://app.prd.yona.nu/users/a-b-c?includePrivateData=true" style="color: #2678bf; text-decoration: none;">deze link</a> om vriend te worden.</span></li>
                         	</ol>
 
 

--- a/core/src/main/resources/templates/email/messages.properties
+++ b/core/src/main/resources/templates/email/messages.properties
@@ -9,8 +9,7 @@ buddy-invitation-subject=Become my friend on Yona!
 buddy-invitation-body.header=Become friends on Yona!
 buddy-invitation-body.p1={0} has invited you to become friends on Yona. With Yona, you together ensure Internet stays fun. Follow the steps below and see which goals have been set by {0}. After that, set your own goals.
 buddy-invitation-body.step1=Go to the <a href="{0}" style="color: #2678bf; text-decoration: none;">Apple App Store</a> or the <a href="{1}" style="color: #2678bf; text-decoration: none;">Google Play Store</a> and download Yona.
-buddy-invitation-body.step2=Open the app and &ldquo;join&rdquo;.
-buddy-invitation-body.step3=Return to this mail and click <a href="{0}" style="color: #2678bf; text-decoration: none;">this link</a> to become a friend.
+buddy-invitation-body.step2=Return to this mail and click <a href="{0}" style="color: #2678bf; text-decoration: none;">this link</a> to become a friend.
 buddy-invitation-body.warning=<strong>Important</strong>: Verify if the invitation is really from {0} {1} and check the mobile number: <a href="tel:{2}" style="color: #2678bf; text-decoration: none;">{2}</a>.
 buddy-invitation-body.footerHeader=YONA | Challenge your online life.
 buddy-invitation-body.footerText=How long do you want to be online at most? Set your own challenges per app or per activity type. How much time do you want to spend on Instagram or WhatsApp? How much time do you want to spend on gaming or shopping? On what do you want to spend no time at all?

--- a/core/src/main/resources/templates/email/messages_nl.properties
+++ b/core/src/main/resources/templates/email/messages_nl.properties
@@ -9,8 +9,7 @@ buddy-invitation-subject=Word vriend op Yona!
 buddy-invitation-body.header=Word vrienden op Yona!
 buddy-invitation-body.p1={0} heeft je uitgenodigd om Yona-vrienden te worden bij Yona. Met Yona zorg je er samen voor dat internet leuk blijft. Volg onderstaande stappen en kijk welke doelen {0} heeft ingesteld. Vervolgens stel jij jouw doelen in.
 buddy-invitation-body.step1=Ga naar de <a href="{0}" style="color: #2678bf; text-decoration: none;">Apple App Store</a> of de <a href="{1}" style="color: #2678bf; text-decoration: none;">Google Play Store</a> en download Yona.
-buddy-invitation-body.step2=Open de app en &bdquo;doe mee&rdquo;.
-buddy-invitation-body.step3=Ga terug naar deze mail en klik op <a href="{0}" style="color: #2678bf; text-decoration: none;">deze link</a> om vriend te worden.
+buddy-invitation-body.step2=Ga terug naar deze mail en klik op <a href="{0}" style="color: #2678bf; text-decoration: none;">deze link</a> om vriend te worden.
 buddy-invitation-body.warning=<strong>Belangrijk</strong>: Let op of de uitnodiging werkelijk van {0} {1} komt en check het mobiele nummer: <a href="tel:{2}" style="color: #2678bf; text-decoration: none;">{2}</a>.
 buddy-invitation-body.footerHeader=YONA | Challenge je online tijdsbesteding.
 buddy-invitation-body.footerText=Hoeveel tijd wil je maximaal online zijn? Leg je eigen challenges vast per app of type activiteit. Hoeveel tijd wil je bijvoorbeeld maximaal bezig zijn met Instagram of WhatsApp? Hoeveel tijd wil je maximaal besteden aan gaming of shopping? Waaraan wil je helemaal geen tijd besteden?


### PR DESCRIPTION
As the app is still in closed beta. Next, corrected the instructions. There used to be a step that said you should first join in the app and then open the URL, but that was wrong. You should after installation immediately open the URL that was provided in the mail.

Once we end closed beta, we should update application.properties and set this property:

yona.email.googlePlayStoreUrl=https://play.google.com/store/apps/details?id=nu.yona.app