### PR TITLE
YD-506 Use assertResponseStatus...

### DIFF
--- a/adminservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
+++ b/adminservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
@@ -9,6 +9,7 @@ package nu.yona.server
 
 import groovy.json.*
 import nu.yona.server.test.AppService
+import static nu.yona.server.test.CommonAssertions.*
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -28,7 +29,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.getAllActivityCategories()
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._links.self.href == adminService.url + AdminService.ACTIVITY_CATEGORIES_PATH
 		response.responseData._embedded."yona:activityCategories".size() > 0
 		def gamblingCategory = response.responseData._embedded."yona:activityCategories".find
@@ -62,7 +63,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._links.self.href.startsWith(adminService.url)
 		response.responseData.localizableName["en-US"] == englishName
 		response.responseData.localizableName["nl-NL"] == dutchName
@@ -73,7 +74,7 @@ class ActivityCategoriesTest extends Specification
 		response.responseData.localizableDescription["nl-NL"] == dutchDescription
 
 		def getResponse = adminService.yonaServer.getResource(response.responseData._links.self.href)
-		getResponse.status == 200
+		assertResponseStatusOk(getResponse)
 		getResponse.responseData._links.self.href.startsWith(adminService.url)
 		getResponse.responseData.localizableName["en-US"] == englishName
 		getResponse.responseData.localizableName["nl-NL"] == dutchName
@@ -101,7 +102,7 @@ class ActivityCategoriesTest extends Specification
 		given:
 		String programmingActivityCategoryJson = createActivityCategoryJson(["nl-NL": "Programmeren", "en-US" : "Programming"], false, ["programming", "scripting"], ["Eclipse", "Visual Studio"], ["nl-NL": "Programmeren van computers", "en-US" : "Programming computers"])
 		def createResponse = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
-		assert createResponse.status == 200
+		assertResponseStatusOk(createResponse)
 		String englishName = "Chess"
 		String dutchName = "Schaken"
 		boolean isNoGo = true
@@ -116,7 +117,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.yonaServer.updateResource(createResponse.responseData._links.self.href, chessActivityCategoryJson)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._links.self.href == createResponse.responseData._links.self.href
 		response.responseData.localizableName["en-US"] == englishName
 		response.responseData.localizableName["nl-NL"] == dutchName
@@ -127,7 +128,7 @@ class ActivityCategoriesTest extends Specification
 		response.responseData.localizableDescription["nl-NL"] == dutchDescription
 
 		def getResponse = adminService.yonaServer.getResource(createResponse.responseData._links.self.href)
-		getResponse.status == 200
+		assertResponseStatusOk(getResponse)
 		getResponse.responseData._links.self.href == createResponse.responseData._links.self.href
 		getResponse.responseData.localizableName["en-US"] == englishName
 		getResponse.responseData.localizableName["nl-NL"] == dutchName
@@ -154,7 +155,7 @@ class ActivityCategoriesTest extends Specification
 		given:
 		String programmingActivityCategoryJson = createActivityCategoryJson(["nl-NL": "Programmeren", "en-US" : "Programming"], false, ["programming", "scripting"], ["Eclipse", "Visual Studio"], ["nl-NL": "Programmeren van computers", "en-US" : "Programming computers"])
 		def createResponse = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
-		assert createResponse.status == 200
+		assertResponseStatusOk(createResponse)
 		def numActivityCategories = adminService.getAllActivityCategories().responseData._embedded."yona:activityCategories".size()
 		int numOfCategoriesInAppServiceBeforeDelete = appService.getAllActivityCategories().responseData._embedded."yona:activityCategories".size()
 
@@ -162,7 +163,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.yonaServer.deleteResource(createResponse.responseData._links.self.href)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		adminService.getAllActivityCategories().responseData._embedded."yona:activityCategories".size() == numActivityCategories - 1
 
 		def appServiceGetResponse = appService.getAllActivityCategories()
@@ -178,7 +179,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.activitycategory.duplicate.name"
 	}
 
@@ -186,7 +187,7 @@ class ActivityCategoriesTest extends Specification
 	{
 		String programmingActivityCategoryJson = createActivityCategoryJson(["nl-NL": "Programmeren", "en-US" : "Programming"], false, ["programming", "scripting"], ["Eclipse", "Visual Studio"], ["nl-NL": "Programmeren van computers", "en-US" : "Programming computers"])
 		def createResponse = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
-		assert createResponse.status == 200
+		assertResponseStatusOk(createResponse)
 		String englishName = "Just something"
 		String dutchName = "Gokken"
 		boolean isNoGo = true
@@ -199,7 +200,7 @@ class ActivityCategoriesTest extends Specification
 		def response = adminService.yonaServer.updateResource(createResponse.responseData._links.self.href, chessActivityCategoryJson)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.activitycategory.duplicate.name"
 
 		cleanup:

--- a/analysisservice/src/intTest/groovy/nu/yona/server/RelevantSmoothwallCategoriesTest.groovy
+++ b/analysisservice/src/intTest/groovy/nu/yona/server/RelevantSmoothwallCategoriesTest.groovy
@@ -8,6 +8,7 @@ package nu.yona.server
 
 import groovy.json.*
 import nu.yona.server.test.AnalysisService
+import static nu.yona.server.test.CommonAssertions.*
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -24,7 +25,7 @@ class RelevantSmoothwallCategoriesTest extends Specification
 		def response = analysisService.getRelevantSmoothwallCategories()
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.categories.size() > 10
 		response.responseData.categories.contains("Gambling")
 		response.responseData.categories.contains("lotto")

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 import nu.yona.server.test.Goal
 import nu.yona.server.test.User
@@ -20,7 +22,7 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		setCreationTimeOfMandatoryGoalsToNow(richard)
 		User bob = richardAndBob.bob
 		// Trigger aggregation for any already existing activities
-		assert batchService.triggerActivityAggregationBatchJob().status == 200
+		assertResponseStatusOk(batchService.triggerActivityAggregationBatchJob())
 
 		setGoalCreationTime(richard, NEWS_ACT_CAT_URL, "W-1 Mon 02:18")
 		reportAppActivity(richard, "NU.nl", "W-1 Mon 03:15", "W-1 Mon 03:35")
@@ -56,13 +58,13 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		def response = batchService.triggerActivityAggregationBatchJob()
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.writeCountPerStep?.aggregateWeekActivities == 2
 		response.responseData.writeCountPerStep?.aggregateDayActivities == 6 + 4 + YonaServer.getCurrentDayOfWeek() * 2
 		assertActivityValues(richard, 1, expectedValuesRichardLastWeek, 2)
 
 		def secondAggregationResponse = batchService.triggerActivityAggregationBatchJob()
-		secondAggregationResponse.status == 200
+		assertResponseStatusOk(secondAggregationResponse)
 		secondAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 0
 		// Do not assert aggregateDayActivities; inactivity for past days of current week is suddenly added on second retrieval of week overview, one per loaded goal.
 
@@ -79,12 +81,12 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		setCreationTimeOfMandatoryGoalsToNow(richard)
 		User bob = richardAndBob.bob
 		// Trigger aggregation for any already existing activities
-		assert batchService.triggerActivityAggregationBatchJob().status == 200
+		assertResponseStatusOk(batchService.triggerActivityAggregationBatchJob())
 
 		setGoalCreationTime(richard, NEWS_ACT_CAT_URL, "W-1 Mon 02:18")
 		reportAppActivity(richard, "NU.nl", "W-1 Mon 23:00", "W-1 Mon 23:49")
 		def firstAggregationResponse = batchService.triggerActivityAggregationBatchJob()
-		assert firstAggregationResponse.status == 200
+		assertResponseStatusOk(firstAggregationResponse)
 		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 1
 		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateDayActivities == 1
 
@@ -113,7 +115,7 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)
 
 		def response = batchService.triggerActivityAggregationBatchJob()
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.writeCountPerStep?.aggregateWeekActivities == 1
 		response.responseData.writeCountPerStep?.aggregateDayActivities == 1 + 5 + YonaServer.getCurrentDayOfWeek() //days are initialized with inactivity, side effect of retrieving and asserting activity
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)
@@ -131,12 +133,12 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		setCreationTimeOfMandatoryGoalsToNow(richard)
 		User bob = richardAndBob.bob
 		// Trigger aggregation for any already existing activities
-		assert batchService.triggerActivityAggregationBatchJob().status == 200
+		assertResponseStatusOk(batchService.triggerActivityAggregationBatchJob())
 
 		setGoalCreationTime(richard, NEWS_ACT_CAT_URL, "W-1 Mon 02:18")
 		reportAppActivity(richard, "NU.nl", "W-1 Mon 23:00", "W-1 Mon 23:05")
 		def firstAggregationResponse = batchService.triggerActivityAggregationBatchJob()
-		assert firstAggregationResponse.status == 200
+		assertResponseStatusOk(firstAggregationResponse)
 		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 1
 		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateDayActivities == 1
 
@@ -165,7 +167,7 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)
 
 		def response = batchService.triggerActivityAggregationBatchJob()
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.writeCountPerStep?.aggregateWeekActivities == 1
 		response.responseData.writeCountPerStep?.aggregateDayActivities == 1 + 5 + YonaServer.getCurrentDayOfWeek() //days are initialized with inactivity, side effect of retrieving and asserting activity
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 
 class ActivityCategoriesTest extends AbstractAppServiceIntegrationTest
@@ -18,7 +20,7 @@ class ActivityCategoriesTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getAllActivityCategories()
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._links.self.href == appService.url + appService.ACTIVITY_CATEGORIES_PATH
 		response.responseData._embedded."yona:activityCategories".size() > 0
 		def gamblingCategory = response.responseData._embedded."yona:activityCategories".find

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityCommentTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityCommentTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 import nu.yona.server.test.AppService
 import nu.yona.server.test.Buddy
@@ -172,7 +174,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		Goal budgetGoalNewsBuddyBob = richard.buddies[0].findActiveGoal(NEWS_ACT_CAT_URL)
 
 		def responseDayOverviewsBobAsBuddyAll = appService.getDayActivityOverviews(richard, richard.buddies[0])
-		assert responseDayOverviewsBobAsBuddyAll.status == 200
+		assertResponseStatusOk(responseDayOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = appService.getDayDetailsFromOverview(responseDayOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob, 0, getCurrentShortDay(YonaServer.now))
 		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
@@ -183,7 +185,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def responseAddMessage = appService.yonaServer.createResourceWithPassword(responseDetailsBobAsBuddy.responseData._links."yona:addComment".href, message, richard.password)
 
 		then:
-		responseAddMessage.status == 200
+		assertResponseStatusOk(responseAddMessage)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -200,7 +202,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		Goal budgetGoalNewsBuddyBob = richard.buddies[0].findActiveGoal(NEWS_ACT_CAT_URL)
 
 		def responseWeekOverviewsBobAsBuddyAll = appService.getWeekActivityOverviews(richard, richard.buddies[0])
-		assert responseWeekOverviewsBobAsBuddyAll.status == 200
+		assertResponseStatusOk(responseWeekOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = appService.getWeekDetailsFromOverview(responseWeekOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob, 0)
 		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
@@ -211,7 +213,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def responseAddMessage = appService.yonaServer.createResourceWithPassword(responseDetailsBobAsBuddy.responseData._links."yona:addComment".href, message, richard.password)
 
 		then:
-		responseAddMessage.status == 200
+		assertResponseStatusOk(responseAddMessage)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -257,7 +259,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def response = appService.deleteResourceWithPassword(richardMessagesRevisited[0]._links.edit.href, richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		getActivityDetailMessages(richardResponseDetails, richard, [], 10)
 		getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, [], 10)
 
@@ -305,7 +307,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def response = appService.deleteResourceWithPassword(richardMessagesRevisited[1]._links.edit.href, richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		getActivityDetailMessages(richardResponseDetails, richard, expectedData1, 10)
 		getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData1, 10)
 
@@ -353,7 +355,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def response = appService.deleteResourceWithPassword(richardMessagesRevisited[2]._links.edit.href, richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		getActivityDetailMessages(richardResponseDetails, richard, expectedData2, 10)
 		getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2, 10)
@@ -382,7 +384,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		assert budgetGoalNewsBob
 
 		def responseOverviewsBobAsBuddyAll = buddyOverviewRetriever(richard)
-		assert responseOverviewsBobAsBuddyAll.status == 200
+		assertResponseStatusOk(responseOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = detailsRetriever(responseOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob)
 		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
@@ -391,7 +393,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def message = """{"message": "You're quiet!"}"""
 		def responseAddMessage = appService.yonaServer.createResourceWithPassword(responseDetailsBobAsBuddy.responseData._links."yona:addComment".href, message, richard.password)
 
-		assert responseAddMessage.status == 200
+		assertResponseStatusOk(responseAddMessage)
 		def addedMessage = responseAddMessage.responseData
 		assertCommentMessageDetails(addedMessage, richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "You're quiet!", addedMessage)
 
@@ -403,7 +405,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		assertCommentMessageDetails(initialMessagesSeenByRichard[0], richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "You're quiet!", initialMessagesSeenByRichard[0])
 
 		def responseOverviewsBobAll = userOverviewRetriever(bob)
-		assert responseOverviewsBobAll.status == 200
+		assertResponseStatusOk(responseOverviewsBobAll)
 
 		def responseDetailsBob = detailsRetriever(responseOverviewsBobAll, bob, budgetGoalNewsBob)
 		assert responseDetailsBob.responseData._links."yona:addComment" == null
@@ -471,7 +473,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 	private static void replyToMessage(AppService appService, messageToReply, User senderUser, messageToSend, boolean isWeek, responseGetActivityDetails, threadHeadMessage)
 	{
 		def responseReplyFromBob = appService.postMessageActionWithPassword(messageToReply._links."yona:reply".href, ["message" : messageToSend], senderUser.password)
-		assert responseReplyFromBob.status == 200
+		assertResponseStatusOk(responseReplyFromBob)
 		assert responseReplyFromBob.responseData.properties["status"] == "done"
 		assert responseReplyFromBob.responseData._embedded?."yona:affectedMessages"?.size() == 1
 		def replyMessage = responseReplyFromBob.responseData._embedded."yona:affectedMessages"[0]
@@ -484,7 +486,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		int expectedNumMessagesInPage = Math.min(expectedNumMessages, pageSize)
 		def response = appService.yonaServer.getResourceWithPassword(responseGetActivityDetails.responseData._links."yona:messages".href, user.password, ["size":pageSize])
 
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		def messages = response.responseData?._embedded?."yona:messages"
 		if (expectedNumMessagesInPage == 0)
 		{
@@ -518,7 +520,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		int defaultPageSize = 4
 		def response = appService.yonaServer.getResourceWithPassword(responseGetActivityDetails.responseData._links.next.href, user.password)
 
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		assert response.responseData?._embedded?."yona:messages"?.size() == 1
 		assert response.responseData.page.size == defaultPageSize
 		assert response.responseData.page.totalElements == 5

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -59,14 +61,14 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assert weekActivityForGoal?._links?."yona:weekDetails"?.href
 		def weekActivityDetailUrl = weekActivityForGoal?._links?."yona:weekDetails"?.href
 		def response = appService.getResourceWithPassword(weekActivityDetailUrl, richard.password)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 
 		def dayActivityOverview = responseDayOverviews.responseData._embedded."yona:dayActivityOverviews"[0]
 		def dayActivityForGoal = dayActivityOverview.dayActivities.find{ it._links."yona:goal".href == goal.url}
 		assert dayActivityForGoal?._links?."yona:dayDetails"?.href
 		def dayActivityDetailUrl =  dayActivityForGoal?._links?."yona:dayDetails"?.href
 		def responseDayDetail = appService.getResourceWithPassword(dayActivityDetailUrl, richard.password)
-		assert responseDayDetail.status == 200
+		assertResponseStatusOk(responseDayDetail)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -274,30 +276,30 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		// Assert self-links of day and week overviews
 		def weekOverviewLink = weekOverviewLastWeek._links.self.href
 		def weekOverviewResponse = appService.getResourceWithPassword(weekOverviewLink, richard.password)
-		assert weekOverviewResponse.status == 200
+		assertResponseStatusOk(weekOverviewResponse)
 		assert weekOverviewResponse.data.date == weekOverviewLastWeek.date
 
 		def dayOverviewOffset = YonaServer.relativeDateStringToDaysOffset(1, "Thu")
 		def dayOverviewLink = responseDayOverviewsAll.responseData._embedded."yona:dayActivityOverviews"[dayOverviewOffset]._links.self.href
 		def dayOverviewResponse = appService.getResourceWithPassword(dayOverviewLink, richard.password)
-		assert dayOverviewResponse.status == 200
+		assertResponseStatusOk(dayOverviewResponse)
 		assert dayOverviewResponse.data.date == responseDayOverviewsAll.responseData._embedded."yona:dayActivityOverviews"[dayOverviewOffset].date
 
 		def dayOverviewWithBuddiesOffset = YonaServer.relativeDateStringToDaysOffset(1, "Fri")
 		def dayOverviewWithBuddiesLink = responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset]._links.self.href
 		def dayOverviewWithBuddiesResponse = appService.getResourceWithPassword(dayOverviewWithBuddiesLink, richard.password)
-		assert dayOverviewWithBuddiesResponse.status == 200
+		assertResponseStatusOk(dayOverviewWithBuddiesResponse)
 		assert dayOverviewWithBuddiesResponse.data.date == responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset].date
 
 		def buddyWeekOverviewLink = buddyWeekOverviewLastWeek._links.self.href
 		def responseBuddyWeekOverview = appService.getResourceWithPassword(buddyWeekOverviewLink, richard.password)
-		assert responseBuddyWeekOverview.status == 200
+		assertResponseStatusOk(responseBuddyWeekOverview)
 		assert responseBuddyWeekOverview.data.date == buddyWeekOverviewLastWeek.date
 
 		def buddyDayOverviewOffset = YonaServer.relativeDateStringToDaysOffset(1, "Sat")
 		def buddyDayOverviewLink = responseBuddyDayOverviews.responseData._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset]._links.self.href
 		def responseBuddyDayOverview = appService.getResourceWithPassword(buddyDayOverviewLink, richard.password)
-		assert responseBuddyDayOverview.status == 200
+		assertResponseStatusOk(responseBuddyDayOverview)
 		assert responseBuddyDayOverview.data.date == responseBuddyDayOverviews.responseData._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset].date
 
 		cleanup:
@@ -359,7 +361,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 			(currentShortDay) : [[goal:budgetGoalNews, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]], [goal:budgetGoalGambling, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]]]
 		def initialResponseWeekOverviews = appService.getWeekActivityOverviews(richard)
 		def initialResponseDayOverviews = appService.getDayActivityOverviews(richard)
-		assert initialResponseWeekOverviews.status == 200
+		assertResponseStatusOk(initialResponseWeekOverviews)
 		def initialCurrentWeekOverview = initialResponseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0]
 		assertDayInWeekOverviewForGoal(initialCurrentWeekOverview, budgetGoalNews, initialExpectedValues, currentShortDay)
 		assertWeekDetailForGoal(richard, initialCurrentWeekOverview, budgetGoalNews, initialExpectedValues)
@@ -404,7 +406,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		]
 		def initialResponseWeekOverviews = appService.getWeekActivityOverviews(richard)
 		def initialResponseDayOverviews = appService.getDayActivityOverviews(richard, ["size": 14])
-		assert initialResponseWeekOverviews.status == 200
+		assertResponseStatusOk(initialResponseWeekOverviews)
 		def initialCurrentWeekOverviewLastWeek = initialResponseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
 		assertDayInWeekOverviewForGoal(initialCurrentWeekOverviewLastWeek, budgetGoalNews, initialExpectedValuesRichardLastWeek, "Wed")
 		assertWeekDetailForGoal(richard, initialCurrentWeekOverviewLastWeek, budgetGoalNews, initialExpectedValuesRichardLastWeek)
@@ -505,7 +507,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def response = appService.removeGoal(richard, budgetGoalNews)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def expectedTotalDaysAfterDelete = expectedTotalDaysBeforeDelete - 2
 		def expectedTotalWeeksAfterDelete = expectedTotalWeeksBeforeDelete
 		def expectedValuesRichardLastWeekAfterDelete = [
@@ -555,14 +557,14 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		addTimeZoneGoal(richard, MULTIMEDIA_ACT_CAT_URL, ["11:00-12:00"])
-		assert appService.getDayActivityOverviews(richard).status == 200
-		assert appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		when:
 		addBudgetGoal(richard, COMMUNICATION_ACT_CAT_URL, 60)
 		then:
-		appService.getDayActivityOverviews(richard).status == 200
-		appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -573,15 +575,15 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		Goal timeZoneGoalMultimedia = addTimeZoneGoal(richard, MULTIMEDIA_ACT_CAT_URL, ["11:00-12:00"])
-		assert appService.getDayActivityOverviews(richard).status == 200
-		assert appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		when:
 		updateTimeZoneGoal(richard, timeZoneGoalMultimedia, ["13:00-14:00"])
 
 		then:
-		appService.getDayActivityOverviews(richard).status == 200
-		appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -592,15 +594,15 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		Goal budgetGoalMultimedia = addBudgetGoal(richard, MULTIMEDIA_ACT_CAT_URL, 60)
-		assert appService.getDayActivityOverviews(richard).status == 200
-		assert appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		when:
 		updateBudgetGoal(richard, budgetGoalMultimedia, 81)
 
 		then:
-		appService.getDayActivityOverviews(richard).status == 200
-		appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -1019,7 +1021,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		updateBudgetGoal(bob, budgetGoalSocialBobBeforeUpdate, 120, "W-1 Sat 20:51")
 		reportAppActivity(bob, "Facebook", "W-1 Sat 20:55", "W-1 Sat 22:00")
 
-		assert appService.removeGoal(richard, budgetGoalNewsRichardAfterUpdate).status == 200
+		assertResponseStatusOk(appService.removeGoal(richard, budgetGoalNewsRichardAfterUpdate))
 
 		richard = appService.reloadUser(richard)
 		timeZoneGoalSocialRichardBeforeUpdate = richard.goals.find{ it.activityCategoryUrl == SOCIAL_ACT_CAT_URL && it.historyItem }
@@ -1184,7 +1186,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		richard.buddies[0].dailyActivityReportsUrl == null
 		richard.buddies[0].weeklyActivityReportsUrl == null
-		responseDayOverviewsWithBuddies.status == 200
+		assertResponseStatusOk(responseDayOverviewsWithBuddies)
 		responseDayOverviewsWithBuddies.responseData?._embedded == null // Richard doesn't know Bob's goals yet
 
 		cleanup:
@@ -1201,7 +1203,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		appService.sendBuddyConnectRequest(richard, bob)
 		def connectRequestMessage = appService.fetchBuddyConnectRequestMessage(bob)
 		def acceptUrl = connectRequestMessage.acceptUrl
-		assert appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password).status == 200
+		assertResponseStatusOk(appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password))
 		richard = appService.reloadUser(richard)
 
 		when:
@@ -1210,7 +1212,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		richard.buddies[0].dailyActivityReportsUrl == null
 		richard.buddies[0].weeklyActivityReportsUrl == null
-		responseDayOverviewsWithBuddies.status == 200
+		assertResponseStatusOk(responseDayOverviewsWithBuddies)
 		responseDayOverviewsWithBuddies.responseData?._embedded == null // Richard doesn't know Bob's goals yet
 
 		cleanup:
@@ -1227,7 +1229,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		appService.sendBuddyConnectRequest(richard, bob)
 		def connectRequestMessage = appService.fetchBuddyConnectRequestMessage(bob)
 		def acceptUrl = connectRequestMessage.acceptUrl
-		assert appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password).status == 200
+		assertResponseStatusOk(appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password))
 		richard = appService.reloadUser(richard)
 		bob = appService.reloadUser(bob)
 		Goal budgetGoalGamblingRichard = bob.buddies[0].findActiveGoal(GAMBLING_ACT_CAT_URL)
@@ -1236,10 +1238,10 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseDayOverviewsWithBuddies = appService.getDayActivityOverviewsWithBuddies(bob, ["size": 14])
 
 		then:
-		responseDayOverviewsWithBuddies.status == 200
+		assertResponseStatusOk(responseDayOverviewsWithBuddies)
 		responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[0].dayActivities.find{ it._links."yona:activityCategory"?.href == GAMBLING_ACT_CAT_URL}.dayActivitiesForUsers.size() == 2
 		def responseWeekOverviews = appService.getWeekActivityOverviews(bob, bob.buddies[0])
-		responseWeekOverviews.status == 200
+		assertResponseStatusOk(responseWeekOverviews)
 		responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find{ it._links."yona:goal".href == budgetGoalGamblingRichard.url}
 		def weekActivityForGoal = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find{ it._links."yona:goal".href == budgetGoalGamblingRichard.url}
 		def dayActivityInWeekForGoal = weekActivityForGoal.dayActivities[YonaServer.now.dayOfWeek.toString()]
@@ -1270,13 +1272,13 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def goalId = richard.findActiveGoal(NEWS_ACT_CAT_URL).getId()
 		def lastWednesdayDate = YonaServer.toIsoDateString(YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Wed 09:00"))
 		def detailsUrl = YonaServer.stripQueryString(richard.url) + "/activity/days/$lastWednesdayDate/details/$goalId"
-		assert appService.getResourceWithPassword(detailsUrl, richard.password).status == 200
+		assertResponseStatusOk(appService.getResourceWithPassword(detailsUrl, richard.password))
 
 		when:
 		def response = appService.getResourceWithPassword(detailsUrl + "/raw/", richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._embedded."yona:activities".size == 2
 		response.responseData._embedded."yona:activities"[0].startTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActStartTime))
 		response.responseData._embedded."yona:activities"[0].endTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActEndTime))
@@ -1407,13 +1409,13 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		User richard = richardAndBob.richard
 		User bob = richardAndBob.bob
 		def responseRemoveBuddy = appService.removeBuddy(bob, appService.getBuddies(bob)[0], "Sorry, I regret having asked you")
-		assert responseRemoveBuddy.status == 200
+		assertResponseStatusOk(responseRemoveBuddy)
 
 		when:
 		def responseDayOverviewsWithBuddies = appService.getDayActivityOverviewsWithBuddies(richard, ["size": 14])
 
 		then:
-		responseDayOverviewsWithBuddies.status == 200
+		assertResponseStatusOk(responseDayOverviewsWithBuddies)
 		responseDayOverviewsWithBuddies.responseData?._embedded == null // Richard doesn't know Bob's goals anymore
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AddDeviceTest.groovy
@@ -7,6 +7,8 @@
 package nu.yona.server
 
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 import nu.yona.server.test.User
 
@@ -22,12 +24,12 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def response = appService.setNewDeviceRequest(richard.mobileNumber, richard.password, newDeviceRequestPassword)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
-		getResponseAfter.status == 200
+		assertResponseStatusOk(getResponseAfter)
 
 		def getWithPasswordResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
-		getWithPasswordResponseAfter.status == 200
+		assertResponseStatusOk(getWithPasswordResponseAfter)
 		getWithPasswordResponseAfter.responseData.yonaPassword == richard.password
 		getWithPasswordResponseAfter.responseData._links.self.href == richard.newDeviceRequestUrl
 		getWithPasswordResponseAfter.responseData._links.edit.href == richard.newDeviceRequestUrl
@@ -53,13 +55,13 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def responseNoNewDeviceRequestNoPassword = appService.getNewDeviceRequest(bob.mobileNumber)
 
 		then:
-		responseWrongNewDeviceRequestPassword.status == 400
+		assertResponseStatus(responseWrongNewDeviceRequestPassword, 400)
 		responseWrongNewDeviceRequestPassword.responseData.code == "error.device.request.invalid.password"
-		responseWrongMobileNumber.status == 400
+		assertResponseStatus(responseWrongMobileNumber, 400)
 		responseWrongMobileNumber.responseData.code == "error.no.device.request.present"
-		responseNoNewDeviceRequestWrongPassword.status == 400
+		assertResponseStatus(responseNoNewDeviceRequestWrongPassword, 400)
 		responseNoNewDeviceRequestWrongPassword.responseData.code == "error.no.device.request.present"
-		responseNoNewDeviceRequestNoPassword.status == 400
+		assertResponseStatus(responseNoNewDeviceRequestNoPassword, 400)
 		responseNoNewDeviceRequestNoPassword.responseData.code == "error.no.device.request.present"
 
 		cleanup:
@@ -74,19 +76,19 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def newDeviceRequestPassword = "Temp password"
 		appService.setNewDeviceRequest(richard.mobileNumber, richard.password, newDeviceRequestPassword)
 		def getResponseImmmediately = appService.getNewDeviceRequest(richard.mobileNumber)
-		assert getResponseImmmediately.status == 200
+		assertResponseStatusOk(getResponseImmmediately)
 
 		when:
 		def responseWrongPassword = appService.setNewDeviceRequest(richard.mobileNumber, "foo", "Some password")
 		def responseWrongMobileNumber = appService.setNewDeviceRequest("+31610609189", "foo", "Some password")
 
 		then:
-		responseWrongPassword.status == 400
+		assertResponseStatus(responseWrongPassword, 400)
 		responseWrongPassword.responseData.code == "error.decrypting.data"
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
-		getResponseAfter.status == 200
+		assertResponseStatusOk(getResponseAfter)
 		getResponseAfter.responseData.yonaPassword == richard.password
-		responseWrongMobileNumber.status == 400
+		assertResponseStatus(responseWrongMobileNumber, 400)
 		responseWrongMobileNumber.responseData.code == "error.decrypting.data"
 
 		cleanup:
@@ -104,9 +106,9 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def response = appService.setNewDeviceRequest(richard.mobileNumber, richard.password, newDeviceRequestPassword)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
-		getResponseAfter.status == 200
+		assertResponseStatusOk(getResponseAfter)
 		getResponseAfter.responseData.yonaPassword == richard.password
 
 		cleanup:
@@ -124,13 +126,13 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def response = appService.clearNewDeviceRequest(richard.mobileNumber, richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
-		getResponseAfter.status == 400
+		assertResponseStatus(getResponseAfter, 400)
 		getResponseAfter.responseData.code == "error.no.device.request.present"
 
 		def getWithPasswordResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
-		getWithPasswordResponseAfter.status == 400
+		assertResponseStatus(getWithPasswordResponseAfter, 400)
 		getWithPasswordResponseAfter.responseData.code == "error.no.device.request.present"
 
 		cleanup:
@@ -149,12 +151,12 @@ class AddDeviceTest extends AbstractAppServiceIntegrationTest
 		def responseWrongMobileNumber = appService.clearNewDeviceRequest("+31610609189", "foo")
 
 		then:
-		responseWrongPassword.status == 400
+		assertResponseStatus(responseWrongPassword, 400)
 		responseWrongPassword.responseData.code == "error.decrypting.data"
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
-		getResponseAfter.status == 200
+		assertResponseStatusOk(getResponseAfter)
 		getResponseAfter.responseData.yonaPassword == richard.password
-		responseWrongMobileNumber.status == 400
+		assertResponseStatus(responseWrongMobileNumber, 400)
 		responseWrongMobileNumber.responseData.code == "error.decrypting.data"
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -6,12 +6,13 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import java.time.Duration
 import java.time.ZonedDateTime
 
 import groovy.json.*
 import nu.yona.server.test.AppActivity
-import nu.yona.server.test.AppService
 
 class AppActivityTest extends AbstractAppServiceIntegrationTest
 {
@@ -36,7 +37,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				}]}""", "Hack")
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.decrypting.data"
 
 		cleanup:
@@ -58,26 +59,26 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def response = appService.postAppActivityToAnalysisEngine(richard, AppActivity.singleActivity("Poker App", startTime, endTime))
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
 		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll
 		{ it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesRichard.size() == 1
 		goalConflictMessagesRichard[0].nickname == "RQ (me)"
-		AppService.assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
 		goalConflictMessagesRichard[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 
 		def getMessagesBobResponse = appService.getMessages(bob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll
 		{ it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesBob.size() == 1
 		goalConflictMessagesBob[0].nickname == richard.nickname
-		AppService.assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
-		AppService.assertEquals(goalConflictMessagesBob[0].activityStartTime, startTime)
-		AppService.assertEquals(goalConflictMessagesBob[0].activityEndTime, endTime)
+		assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesBob[0].activityStartTime, startTime)
+		assertEquals(goalConflictMessagesBob[0].activityEndTime, endTime)
 		goalConflictMessagesBob[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 
 		cleanup:
@@ -104,24 +105,24 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def response = appService.postAppActivityToAnalysisEngine(richard, AppActivity.singleActivity(testStartTimeWrong, "Poker App", startTimeWrong, endTimeWrong))
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
 		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesRichard.size() == 1
 		goalConflictMessagesRichard[0].nickname == "RQ (me)"
-		AppService.assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
 		goalConflictMessagesRichard[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 
 		def getMessagesBobResponse = appService.getMessages(bob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesBob.size() == 1
 		goalConflictMessagesBob[0].nickname == richard.nickname
-		AppService.assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
-		AppService.assertEquals(goalConflictMessagesBob[0].activityStartTime, startTime)
-		AppService.assertEquals(goalConflictMessagesBob[0].activityEndTime, endTime)
+		assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesBob[0].activityStartTime, startTime)
+		assertEquals(goalConflictMessagesBob[0].activityEndTime, endTime)
 		goalConflictMessagesBob[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 
 		cleanup:
@@ -149,12 +150,12 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesRichard.size() == 1
 
 		def getMessagesBobResponse = appService.getMessages(bob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesBob.size() == 1
 
@@ -181,23 +182,23 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime), new AppActivity.Activity("Lotto App", , startTime1, endTime1)].toArray()))
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
 		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesRichard.size() == 1
-		AppService.assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
-		AppService.assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
-		AppService.assertEquals(goalConflictMessagesRichard[0].activityEndTime, endTime)
+		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
+		assertEquals(goalConflictMessagesRichard[0].activityEndTime, endTime)
 
 		def getMessagesBobResponse = appService.getMessages(bob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessagesBob.size() == 1
-		AppService.assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
-		AppService.assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
-		AppService.assertEquals(goalConflictMessagesRichard[0].activityEndTime, endTime)
+		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
+		assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
+		assertEquals(goalConflictMessagesRichard[0].activityEndTime, endTime)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -218,9 +219,9 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
 		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"} == null
 
@@ -242,7 +243,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.analysis.invalid.app.activity.data.end.before.start"
 
 		cleanup:
@@ -263,7 +264,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.analysis.invalid.app.activity.data.ends.in.future"
 
 		cleanup:
@@ -284,7 +285,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.analysis.invalid.app.activity.data.starts.in.future"
 
 		cleanup:
@@ -308,10 +309,10 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 				new AppActivity([new AppActivity.Activity("Poker App", startTime, endTime)].toArray()))
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll{ it."@type" == "GoalConflictMessage"}?.size()
 		// Don't poke into the messages. The app activity spans many days and we only support activities spanning at most two days
 
@@ -333,11 +334,11 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		analysisService.postToAnalysisEngine(richard, ["Gambling"], "http://www.poker.com", netActStartTime)
-		assert appService.postAppActivityToAnalysisEngine(richard, new AppActivity([appActivity].toArray())).status == 200
+		assertResponseStatusOk(appService.postAppActivityToAnalysisEngine(richard, new AppActivity([appActivity].toArray())))
 
 		then:
 		def response = appService.getDayDetails(richard, GAMBLING_ACT_CAT_URL, appActStartTime)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		assert response.responseData.totalActivityDurationMinutes == Duration.between(appActStartTime, appActEndTime).toMinutes()
 
 		cleanup:
@@ -362,11 +363,11 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		analysisService.postToAnalysisEngine(richard, ["Gambling"], "http://www.poker.com", netActStartTime)
-		assert appService.postAppActivityToAnalysisEngine(richard, new AppActivity([appActOne, appActTwo, appActOne].toArray())).status == 200
+		assertResponseStatusOk(appService.postAppActivityToAnalysisEngine(richard, new AppActivity([appActOne, appActTwo, appActOne].toArray())))
 
 		then:
 		def response = appService.getDayDetails(richard, GAMBLING_ACT_CAT_URL, appActOneStartTime)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		assert response.responseData.totalActivityDurationMinutes == Duration.between(appActOneStartTime, appActTwoEndTime).toMinutes() + netActDuration
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 import nu.yona.server.test.User
 
@@ -36,7 +38,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.firstname"
 
 		cleanup:
@@ -54,7 +56,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.lastname"
 
 		cleanup:
@@ -72,7 +74,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.mobile.number"
 
 		cleanup:
@@ -90,7 +92,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.mobile.number.invalid"
 
 		cleanup:
@@ -108,7 +110,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.email.address"
 
 		cleanup:
@@ -130,11 +132,11 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response3 = appService.sendBuddyConnectRequest(richard, object, false)
 
 		then:
-		response1.status == 400
+		assertResponseStatus(response1, 400)
 		response1.responseData.code == "error.user.email.address.invalid"
-		response2.status == 400
+		assertResponseStatus(response2, 400)
 		response2.responseData.code == "error.user.email.address.invalid"
-		response3.status == 400
+		assertResponseStatus(response3, 400)
 		response3.responseData.code == "error.user.email.address.invalid"
 
 		cleanup:
@@ -151,7 +153,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, richard, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.buddy.cannot.invite.self"
 
 		cleanup:
@@ -170,7 +172,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.sendBuddyConnectRequest(richard, bob, false)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.buddy.cannot.invite.existing.buddy"
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -6,8 +6,10 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
-import nu.yona.server.test.AppService
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 
 class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
@@ -17,14 +19,14 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	def 'Richard cannot create a buddy request before confirming his own mobile number'()
 	{
 		given:
-		def richard = appService.addUser(appService.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
+		def richard = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
 				makeMobileNumber(timestamp))
 
 		when:
 		def response = sendBuddyRequestForBob(richard, makeMobileNumber(timestamp))
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.mobile.number.not.confirmed"
 
 		cleanup:
@@ -40,7 +42,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = sendBuddyRequestForBob(richard, makeMobileNumber(timestamp))
 
 		then:
-		response.status == 201
+		assertResponseStatus(response, 201)
 		response.responseData._embedded."yona:user".firstName == "Bob"
 		response.responseData._links."yona:user" == null
 		response.responseData._links.self.href.startsWith(YonaServer.stripQueryString(richard.url))
@@ -58,7 +60,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
 
 		when:
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
 		then:
 		bob.firstName == "Bob"
@@ -77,13 +79,13 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
 		when:
 		def newNickname = "Bobby"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 
 		then:
 		updatedBob.firstName == bob.firstName
@@ -93,7 +95,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		!(updatedBob.url ==~ /tempPassword/)
 
 		def getUserResponse = appService.getUser(inviteUrl, true, null)
-		getUserResponse.status == 400
+		assertResponseStatus(getUserResponse, 400)
 		getUserResponse.responseData.code == "error.decrypting.data"
 
 		User bobFromGetAfterUpdate = appService.reloadUser(updatedBob)
@@ -106,7 +108,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		bobFromGetAfterUpdate.url
 
 		def getMessagesResponse = appService.yonaServer.getResourceWithPassword(YonaServer.stripQueryString(bobFromGetAfterUpdate.url) + "/messages/", bobFromGetAfterUpdate.password)
-		getMessagesResponse.status == 400
+		assertResponseStatus(getMessagesResponse, 400)
 		getMessagesResponse.responseData.code == "error.mobile.number.not.confirmed"
 
 		cleanup:
@@ -120,7 +122,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
 		when:
 		def updatedBobJson = bob.convertToJson()
@@ -128,12 +130,12 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		User bobToBeUpdated = new User(updatedBobJson)
 		bobToBeUpdated.deviceName = "My S8"
 		bobToBeUpdated.deviceOperatingSystem = "ANDROID"
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, bobToBeUpdated, inviteUrl)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, bobToBeUpdated, inviteUrl)
 
 		then:
 		updatedBob.devices == null // Mobile number not confirmed yet
 
-		def bobWithConfirmedNumber = appService.confirmMobileNumber({ AppService.assertResponseStatusSuccess(it)}, updatedBob)
+		def bobWithConfirmedNumber = appService.confirmMobileNumber({ assertResponseStatusSuccess(it)}, updatedBob)
 		bobWithConfirmedNumber.devices.size() == 1
 		bobWithConfirmedNumber.devices[0].name == "My S8"
 		bobWithConfirmedNumber.devices[0].operatingSystem == "ANDROID"
@@ -149,20 +151,20 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
-		def bobFromGetAfterUpdate = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateData, bob.url, true, updatedBob.password)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		def bobFromGetAfterUpdate = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateData, bob.url, true, updatedBob.password)
 
 		when:
 		def againChangedNickname = "Robert"
 		def againUpdatedBobJson = bobFromGetAfterUpdate.convertToJson()
 		againUpdatedBobJson.nickname = againChangedNickname
-		def againUpdatedBob = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(againUpdatedBobJson))
+		def againUpdatedBob = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(againUpdatedBobJson))
 
 		then:
 		againUpdatedBob.nickname == againChangedNickname
@@ -178,24 +180,24 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
 
 		when:
-		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
+		updatedBob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, updatedBob)
 
 		then:
 		def getUserResponse = appService.getUser(updatedBob.url, true, updatedBob.password)
-		getUserResponse.status == 200
+		assertResponseStatusOk(getUserResponse)
 		getUserResponse.responseData._embedded."yona:goals"._embedded."yona:goals"
 		getUserResponse.responseData._embedded."yona:goals"._embedded."yona:goals".size() == 1 //mandatory goal
 		def getMessagesResponse = appService.getMessages(updatedBob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded."yona:messages".size() == 1 // The buddy request from Richard
 
 		cleanup:
@@ -209,21 +211,21 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
-		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		updatedBob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 
 		when:
 		def response = appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], updatedBob.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def bobWithBuddy = appService.reloadUser(updatedBob)
 		bobWithBuddy.buddies != null
 		bobWithBuddy.buddies.size() == 1
@@ -242,14 +244,14 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
-		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		updatedBob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], updatedBob.password)
 
@@ -257,13 +259,13 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getMessages(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll
 		{ it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages[0]._links?."yona:user"?.href.startsWith(YonaServer.stripQueryString(bob.url))
 		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
 		buddyConnectResponseMessages[0].nickname == newNickname
-		AppService.assertEquals(buddyConnectResponseMessages[0].creationTime, YonaServer.now)
+		assertEquals(buddyConnectResponseMessages[0].creationTime, YonaServer.now)
 		buddyConnectResponseMessages[0].status == "ACCEPTED"
 		buddyConnectResponseMessages[0]._links.self.href.startsWith(YonaServer.stripQueryString(richard.messagesUrl))
 		buddyConnectResponseMessages[0]._links."yona:process" == null // Processing happens automatically these days
@@ -286,14 +288,14 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
 		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
-		def bob = appService.getUser(appService.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
+		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.yonaPassword = newPassword
 		updatedBobJson.nickname = newNickname
-		User updatedBob = appService.updateUserCreatedOnBuddyRequest(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
-		updatedBob = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, updatedBob)
+		User updatedBob = appService.updateUserCreatedOnBuddyRequest(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson), inviteUrl)
+		updatedBob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, updatedBob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(updatedBob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], updatedBob.password)
 		def processUrl = appService.fetchBuddyConnectResponseMessage(richard).processUrl
@@ -304,7 +306,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
@@ -312,7 +314,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		richardGoalConflictMessages[0].url == "http://www.refdag.nl"
 
 		def getMessagesBobResponse = appService.getMessages(updatedBob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == richard.nickname
@@ -353,7 +355,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getResource(YonaServer.stripQueryString(inviteUrl), [:], ["tempPassword": "hack", "requestingUserId": richard.getId()])
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.decrypting.data"
 
 		cleanup:
@@ -376,7 +378,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 			}""", [:], ["tempPassword": "hack"])
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.decrypting.data"
 
 		cleanup:
@@ -393,7 +395,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getResource(richard.url, [:], ["tempPassword": richard.password, "requestingUserId": richard.getId()])
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.not.created.on.buddy.request"
 
 		cleanup:
@@ -412,7 +414,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getUser(bobUrl, true, dummyTempPassword)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.created.on.buddy.request"
 
 		cleanup:
@@ -434,7 +436,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 			}""", [:], ["tempPassword": "hack"])
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.not.created.on.buddy.request"
 
 		cleanup:
@@ -452,7 +454,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.requestOverwriteUser(mobileNumberBob)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "Bob Changed",
 				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
@@ -471,7 +473,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		buddiesBob.size() == 0
 
 		def getMessagesResponse = appService.getMessages(richard)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded
 		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
 
@@ -516,7 +518,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		buddiesBob[0].user.firstName == "Richard"
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
-		getMessagesRichardResponse.status == 200
+		assertResponseStatusOk(getMessagesRichardResponse)
 		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
@@ -524,7 +526,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		richardGoalConflictMessages[0].url == "http://www.refdag.nl"
 
 		def getMessagesBobResponse = appService.getMessages(bob)
-		getMessagesBobResponse.status == 200
+		assertResponseStatusOk(getMessagesBobResponse)
 		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == richard.nickname
@@ -538,14 +540,14 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 	def assertUserCreationFailedBecauseOfDuplicate(response)
 	{
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.exists.created.on.buddy.request"
 	}
 
 	def assertUserOverwriteResponseDetails(def response)
 	{
-		appService.assertResponseStatusCreated(response)
-		appService.assertUserWithPrivateData(response.responseData)
+		assertResponseStatusCreated(response)
+		assertUserWithPrivateData(response.responseData)
 	}
 
 	def sendBuddyRequestForBob(User user, String mobileNumber)

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -8,6 +8,8 @@ package nu.yona.server
 
 import groovy.json.*
 import nu.yona.server.test.AppService
+import static nu.yona.server.test.CommonAssertions.*
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 
 class DeviceTest extends AbstractAppServiceIntegrationTest
@@ -21,7 +23,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		def johnAsCreated = createJohnDoe(ts, "My S8", "ANDROID")
 
 		then:
-		def johnAfterNumberConfirmation = appService.confirmMobileNumber(AppService.&assertResponseStatusSuccess, johnAsCreated)
+		def johnAfterNumberConfirmation = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, johnAsCreated)
 
 		johnAfterNumberConfirmation.devices.size == 1
 		johnAfterNumberConfirmation.devices[0].name == "My S8"
@@ -40,7 +42,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		def johnAsCreated = createJohnDoe(ts, "My iPhone X", "IOS")
 
 		then:
-		def johnAfterNumberConfirmation = appService.confirmMobileNumber(AppService.&assertResponseStatusSuccess, johnAsCreated)
+		def johnAfterNumberConfirmation = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, johnAsCreated)
 
 		johnAfterNumberConfirmation.devices.size == 1
 		johnAfterNumberConfirmation.devices[0].name == "My iPhone X"
@@ -59,7 +61,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		def johnAsCreated = createJohnDoe(ts, "01234567890123456789", "IOS")
 
 		then:
-		def johnAfterNumberConfirmation = appService.confirmMobileNumber(AppService.&assertResponseStatusSuccess, johnAsCreated)
+		def johnAfterNumberConfirmation = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, johnAsCreated)
 
 		johnAfterNumberConfirmation.devices.size == 1
 		johnAfterNumberConfirmation.devices[0].name == "01234567890123456789"
@@ -77,7 +79,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		def johnAsCreated = appService.addUser(
 				{
-					AppService.assertResponseStatus(it, 400)
+					assertResponseStatus(it, 400)
 					assert it.responseData.code == "error.device.unknown.operating.system"
 				}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "My Raspberry", "RASPBIAN")
@@ -94,7 +96,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		def johnAsCreated = appService.addUser(
 				{
-					AppService.assertResponseStatus(it, 400)
+					assertResponseStatus(it, 400)
 					assert it.responseData.code == "error.device.unknown.operating.system"
 				}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "First device", "UNKNOWN")
@@ -111,7 +113,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		def johnAsCreated = appService.addUser(
 				{
-					AppService.assertResponseStatus(it, 400)
+					assertResponseStatus(it, 400)
 					assert it.responseData.code == "error.device.invalid.device.name"
 				}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "012345678901234567891", "IOS")
@@ -128,7 +130,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		def johnAsCreated = appService.addUser(
 				{
-					AppService.assertResponseStatus(it, 400)
+					assertResponseStatus(it, 400)
 					assert it.responseData.code == "error.device.invalid.device.name"
 				}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "some:thing", "IOS")
@@ -139,7 +141,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 	private User createJohnDoe(ts, deviceName, deviceOperatingSystem)
 	{
-		appService.addUser(appService.&assertUserCreationResponseDetails, "John", "Doe", "JD",
+		appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "John", "Doe", "JD",
 				makeMobileNumber(ts), deviceName, deviceOperatingSystem)
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DisclosureTest.groovy
@@ -6,8 +6,9 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
-import nu.yona.server.test.AppService
 import nu.yona.server.test.Goal
 
 class DisclosureTest extends AbstractAppServiceIntegrationTest
@@ -25,7 +26,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def responseBob = appService.getMessages(bob)
 
 		then:
-		responseRichard.status == 200
+		assertResponseStatusOk(responseRichard)
 		def messagesRichard = responseRichard.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		messagesRichard.size() == 1
 		messagesRichard[0].nickname == "RQ (me)"
@@ -33,7 +34,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		messagesRichard[0].url != null
 		messagesRichard[0]._links."yona:requestDisclosure" == null
 
-		responseBob.status == 200
+		assertResponseStatusOk(responseBob)
 		def messagesBob = responseBob.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		messagesBob.size() == 1
 		messagesBob[0].nickname == richard.nickname
@@ -62,7 +63,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def response = appService.postMessageActionWithPassword(disclosureRequestUrl, [ "message" : requestMessageText], bob.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.properties.status == "done"
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == goalConflictMessage._links.self.href
@@ -70,12 +71,12 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages"[0]._links.requestDisclosure == null
 
 		def getRichardMessagesResponse = appService.getMessages(richard)
-		getRichardMessagesResponse.status == 200
+		assertResponseStatusOk(getRichardMessagesResponse)
 		def disclosureRequestMessages = getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "DisclosureRequestMessage"}
 		disclosureRequestMessages.size() == 1
 		disclosureRequestMessages[0].status == "DISCLOSURE_REQUESTED"
 		disclosureRequestMessages[0].message == requestMessageText
-		AppService.assertEquals(disclosureRequestMessages[0].creationTime, YonaServer.now)
+		assertEquals(disclosureRequestMessages[0].creationTime, YonaServer.now)
 		disclosureRequestMessages[0]._links?."yona:user"?.href.startsWith(YonaServer.stripQueryString(bob.url))
 		disclosureRequestMessages[0]._links?.related?.href == getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links.self.href
 		disclosureRequestMessages[0]._links."yona:accept"?.href
@@ -84,7 +85,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def dayDetailsUrlRichard = disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 		dayDetailsUrlRichard
 		def dayActivityDetailRichard = appService.getResourceWithPassword(dayDetailsUrlRichard, richard.password)
-		dayActivityDetailRichard.status == 200
+		assertResponseStatusOk(dayActivityDetailRichard)
 		dayActivityDetailRichard.responseData.date == YonaServer.toIsoDateString(YonaServer.now)
 		dayActivityDetailRichard.responseData._links."yona:goal".href == goalRichard.url
 
@@ -103,11 +104,11 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def bob = richardAndBob.bob
 		analysisService.postToAnalysisEngine(richard, ["Gambling"], "http://www.poker.com")
 		def getMessagesResponse = appService.getMessages(bob)
-		assert getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		def disclosureRequestUrl = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links."yona:requestDisclosure".href
-		assert appService.postMessageActionWithPassword(disclosureRequestUrl, [ : ], bob.password).status == 200
+		assertResponseStatusOk(appService.postMessageActionWithPassword(disclosureRequestUrl, [ : ], bob.password))
 		getMessagesResponse = appService.getMessages(richard)
-		assert getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		def disclosureRequestMessage = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "DisclosureRequestMessage"}[0]
 		def disclosureRequestAcceptUrl = disclosureRequestMessage._links."yona:accept".href
 		bob = appService.reloadUser(bob)
@@ -118,7 +119,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def response = appService.postMessageActionWithPassword(disclosureRequestAcceptUrl, [ "message" : responseMessageText ], richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == disclosureRequestMessage._links.self.href
 		response.responseData._embedded."yona:affectedMessages"[0].status == "DISCLOSURE_ACCEPTED"
@@ -126,7 +127,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:reject" == null
 
 		def getRichardMessagesResponse = appService.getMessages(richard)
-		getRichardMessagesResponse.status == 200
+		assertResponseStatusOk(getRichardMessagesResponse)
 		def disclosureRequestMessages = getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "DisclosureRequestMessage"}
 		disclosureRequestMessages.size() == 1
 		disclosureRequestMessages[0].status == "DISCLOSURE_ACCEPTED"
@@ -135,7 +136,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 
 		def getBobMessagesResponse = appService.getMessages(bob)
-		getBobMessagesResponse.status == 200
+		assertResponseStatusOk(getBobMessagesResponse)
 		def goalConflictMessages = getBobMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessages.size() == 1
 		goalConflictMessages[0].url == "http://www.poker.com"
@@ -146,7 +147,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureResponseMessage.status == "DISCLOSURE_ACCEPTED"
 		disclosureResponseMessage.message == responseMessageText
 		disclosureResponseMessage.nickname == richard.nickname
-		AppService.assertEquals(disclosureResponseMessage.creationTime, YonaServer.now)
+		assertEquals(disclosureResponseMessage.creationTime, YonaServer.now)
 		disclosureResponseMessage._links?.related?.href == goalConflictMessages[0]._links.self.href
 		disclosureResponseMessage._links?."yona:user"?.href.startsWith(YonaServer.stripQueryString(richard.url))
 		disclosureResponseMessage._embedded?."yona:user" == null
@@ -154,7 +155,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def dayDetailsUrl = disclosureResponseMessage._links."yona:dayDetails"?.href
 		dayDetailsUrl
 		def dayActivityDetail = appService.getResourceWithPassword(dayDetailsUrl, bob.password)
-		dayActivityDetail.status == 200
+		assertResponseStatusOk(dayActivityDetail)
 		dayActivityDetail.responseData.date == YonaServer.toIsoDateString(YonaServer.now)
 		dayActivityDetail.responseData._links."yona:goal".href == goalBuddyRichard.url
 
@@ -163,7 +164,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		//check delete
 		disclosureResponseMessage._links.edit
 		def deleteResponse = appService.deleteResourceWithPassword(disclosureResponseMessage._links.edit.href, bob.password)
-		deleteResponse.status == 200
+		assertResponseStatusOk(deleteResponse)
 		def getBobMessagesResponseAfterDelete = appService.getMessages(bob)
 		!getBobMessagesResponseAfterDelete.responseData._embedded."yona:disclosureResponseMessages"
 
@@ -180,11 +181,11 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def bob = richardAndBob.bob
 		analysisService.postToAnalysisEngine(richard, ["Gambling"], "http://www.poker.com")
 		def getMessagesResponse = appService.getMessages(bob)
-		assert getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		def disclosureRequestUrl = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}[0]._links."yona:requestDisclosure".href
-		assert appService.postMessageActionWithPassword(disclosureRequestUrl, [ : ], bob.password).status == 200
+		assertResponseStatusOk(appService.postMessageActionWithPassword(disclosureRequestUrl, [ : ], bob.password))
 		getMessagesResponse = appService.getMessages(richard)
-		assert getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		def disclosureRequestMessage = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "DisclosureRequestMessage"}[0]
 		def disclosureRequestRejectUrl = disclosureRequestMessage._links."yona:reject".href
 
@@ -193,7 +194,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		def response = appService.postMessageActionWithPassword(disclosureRequestRejectUrl, [ "message" : responseMessageText ], richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData._embedded."yona:affectedMessages".size() == 1
 		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == disclosureRequestMessage._links.self.href
 		response.responseData._embedded."yona:affectedMessages"[0].status == "DISCLOSURE_REJECTED"
@@ -201,7 +202,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		response.responseData._embedded."yona:affectedMessages"[0]._links."yona:reject" == null
 
 		def getRichardMessagesResponse = appService.getMessages(richard)
-		getRichardMessagesResponse.status == 200
+		assertResponseStatusOk(getRichardMessagesResponse)
 		def disclosureRequestMessages = getRichardMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "DisclosureRequestMessage"}
 		disclosureRequestMessages.size() == 1
 		disclosureRequestMessages[0].status == "DISCLOSURE_REJECTED"
@@ -210,7 +211,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		disclosureRequestMessages[0]._links."yona:dayDetails"?.href
 
 		def getBobMessagesResponse = appService.getMessages(bob)
-		getBobMessagesResponse.status == 200
+		assertResponseStatusOk(getBobMessagesResponse)
 		def goalConflictMessages = getBobMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "GoalConflictMessage"}
 		goalConflictMessages.size() == 1
 		goalConflictMessages[0].url == null
@@ -229,7 +230,7 @@ class DisclosureTest extends AbstractAppServiceIntegrationTest
 		//check delete
 		disclosureResponseMessage._links.edit
 		def deleteResponse = appService.deleteResourceWithPassword(disclosureResponseMessage._links.edit.href, bob.password)
-		deleteResponse.status == 200
+		assertResponseStatusOk(deleteResponse)
 		def getBobMessagesResponseAfterDelete = appService.getMessages(bob)
 		getBobMessagesResponseAfterDelete.responseData._embedded."yona:messages".findAll{ it."@type" == "DiscloseResponseMessage"}.size() == 0
 

--- a/appservice/src/intTest/groovy/nu/yona/server/HibernateStatsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/HibernateStatsTest.groovy
@@ -6,11 +6,14 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import java.time.LocalDate
 import java.time.format.TextStyle
 
 import groovy.json.*
 import nu.yona.server.test.BudgetGoal
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 import spock.lang.IgnoreIf
 import spock.lang.Shared
@@ -41,7 +44,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		buddyUsers.each { generateActivities(it) }
 		richard = appService.reloadUser(richard)
 		generateCommentThreadOnYesterdaysNewsActivity(richard, buddyUsers)
-		assert batchService.triggerActivityAggregationBatchJob().status == 200
+		assertResponseStatusOk(batchService.triggerActivityAggregationBatchJob())
 		assert richard.getBuddies().size() == numBuddies
 		println "Test user URL: $richard.url, password: $richard.password"
 
@@ -63,7 +66,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		appService.clearCaches()
 
 		when:
-		appService.getUser(appService.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
+		appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
 
 		then:
 		captureStatistics("GetUserWithoutPrivateDataFirst")
@@ -73,11 +76,11 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		appService.clearCaches()
-		appService.getUser(appService.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
+		appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
 		appService.resetStatistics()
 
 		when:
-		appService.getUser(appService.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
+		appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithoutPrivateData, richard.url, false, null)
 
 		then:
 		captureStatistics("GetUserWithoutPrivateDataSecond")
@@ -121,7 +124,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getMessages(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetMessagesFirst")
 	}
 
@@ -130,14 +133,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		given:
 		appService.clearCaches()
 		appService.reloadUser(richard)
-		assert appService.getMessages(richard).status == 200
+		assertResponseStatusOk(appService.getMessages(richard))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getMessages(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetMessagesSecond")
 	}
 
@@ -152,7 +155,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getDayActivityOverviews(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityOverviewsFirst")
 	}
 
@@ -161,14 +164,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		given:
 		appService.clearCaches()
 		appService.reloadUser(richard)
-		assert appService.getDayActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviews(richard))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getDayActivityOverviews(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityOverviewsSecond")
 	}
 
@@ -183,7 +186,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getWeekActivityOverviews(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetWeekActivityOverviewsFirst")
 	}
 
@@ -192,14 +195,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		given:
 		appService.clearCaches()
 		appService.reloadUser(richard)
-		assert appService.getWeekActivityOverviews(richard).status == 200
+		assertResponseStatusOk(appService.getWeekActivityOverviews(richard))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getWeekActivityOverviews(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetWeekActivityOverviewsSecond")
 	}
 
@@ -214,7 +217,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getDayActivityOverviewsWithBuddies(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityOverviewsWithBuddiesFirst")
 	}
 
@@ -223,14 +226,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		given:
 		appService.clearCaches()
 		appService.reloadUser(richard)
-		assert appService.getDayActivityOverviewsWithBuddies(richard).status == 200
+		assertResponseStatusOk(appService.getDayActivityOverviewsWithBuddies(richard))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getDayActivityOverviewsWithBuddies(richard)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityOverviewsWithBuddiesSecond")
 	}
 
@@ -247,7 +250,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getResourceWithPassword(richard.url + "/activity/days/$lastFridayDate/details/$goalId", richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityDetailsLastFridayFirst")
 	}
 
@@ -258,14 +261,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		appService.reloadUser(richard)
 		def goalId = richard.findActiveGoal(GAMBLING_ACT_CAT_URL).getId()
 		def lastFridayDate = YonaServer.toIsoDateString(YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Fri 09:00"))
-		assert appService.getResourceWithPassword(richard.url + "/activity/days/$lastFridayDate/details/$goalId", richard.password).status == 200
+		assertResponseStatusOk(appService.getResourceWithPassword(richard.url + "/activity/days/$lastFridayDate/details/$goalId", richard.password))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getResourceWithPassword(richard.url + "/activity/days/$lastFridayDate/details/$goalId", richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityDetailsLastFridaySecond")
 	}
 
@@ -282,7 +285,7 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getResourceWithPassword(richard.url + "/activity/weeks/$lastWeek/details/$goalId", richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityDetailsLastFridayFirst")
 	}
 
@@ -293,14 +296,14 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 		appService.reloadUser(richard)
 		def goalId = richard.findActiveGoal(GAMBLING_ACT_CAT_URL).getId()
 		def lastWeek = YonaServer.toIsoWeekDateString(YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Fri 09:00"))
-		assert appService.getResourceWithPassword(richard.url + "/activity/weeks/$lastWeek/details/$goalId", richard.password).status == 200
+		assertResponseStatusOk(appService.getResourceWithPassword(richard.url + "/activity/weeks/$lastWeek/details/$goalId", richard.password))
 		appService.resetStatistics()
 
 		when:
 		def response = appService.getResourceWithPassword(richard.url + "/activity/weeks/$lastWeek/details/$goalId", richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		captureStatistics("GetDayActivityDetailsLastFridaySecond")
 	}
 
@@ -318,9 +321,9 @@ class HibernateStatsTest extends AbstractAppServiceIntegrationTest
 
 	User createBuddyUser(int index)
 	{
-		User buddyUser = appService.addUser(appService.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
+		User buddyUser = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Bob" + index, "Dunn" + index, "BD" + index,
 				makeMobileNumber(timestamp))
-		buddyUser = appService.confirmMobileNumber(appService.&assertResponseStatusSuccess, buddyUser)
+		buddyUser = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, buddyUser)
 		setGoals(buddyUser)
 		buddyUser.emailAddress = "bob${index}@dunn.com"
 		return buddyUser

--- a/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 
 class LocalizationTest extends AbstractAppServiceIntegrationTest
@@ -19,11 +21,11 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Yona-NewDeviceRequestPassword" : ""])
 
 		then:
-		successResponse.status == 200
+		assertResponseStatusOk(successResponse)
 		successResponse.responseData.name == "Gambling"
 		successResponse.responseData.description == "This challenge includes apps and sites like Poker and Blackjack"
 		successResponse.headers."Content-Language" == "en-US"
-		errorResponse.status == 400
+		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
 		errorResponse.headers."Content-Language" == "en-US"
@@ -38,11 +40,11 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Accept-Language" : "nl-NL", "Yona-NewDeviceRequestPassword" : ""])
 
 		then:
-		successResponse.status == 200
+		assertResponseStatusOk(successResponse)
 		successResponse.responseData.name == "Gokken"
 		successResponse.responseData.description == "Deze challenge bevat apps en sites zoals Poker en Blackjack"
 		successResponse.headers."Content-Language" == "nl-NL"
-		errorResponse.status == 400
+		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "Het mobiele nummer '$wrongNumber' is ongeldig. Het moet beginnen met een +-teken, zonder spaties tussen de tekens"
 		errorResponse.headers."Content-Language" == "nl-NL"
@@ -57,11 +59,11 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Accept-Language" : "la", "Yona-NewDeviceRequestPassword" : ""])
 
 		then:
-		successResponse.status == 200
+		assertResponseStatusOk(successResponse)
 		successResponse.responseData.name == "Gambling"
 		successResponse.responseData.description == "This challenge includes apps and sites like Poker and Blackjack"
 		successResponse.headers."Content-Language" == "en-US"
-		errorResponse.status == 400
+		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
 		errorResponse.headers."Content-Language" == "en-US"

--- a/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
@@ -7,9 +7,12 @@
 package nu.yona.server
 
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import java.time.Duration
 
 import groovy.json.*
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 
 class PinResetRequestTest extends AbstractAppServiceIntegrationTest
@@ -40,16 +43,16 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.delay == "PT10S"
-		User  richardAfterGet = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated)
+		User  richardAfterGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated)
 		!richardAfterGet.pinResetRequestUrl
 
 		!richardAfterGet.verifyPinResetUrl
 		!richardAfterGet.clearPinResetUrl
 
 		sleepTillPinResetCodeIsGenerated(richard, response.responseData.delay)
-		User  richardAfterDelayedGet = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		User  richardAfterDelayedGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		richardAfterDelayedGet.verifyPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify"
 		richardAfterDelayedGet.clearPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/clear"
@@ -63,11 +66,11 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def firstResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
-		assert firstResponse.status == 200
+		assertResponseStatusOk(firstResponse)
 		sleepTillPinResetCodeIsGenerated(richard, firstResponse.responseData.delay)
-		richard = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 		assert richard.clearPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/clear"
-		assert appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password]).status == 200
+		assertResponseStatusOk(appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password]))
 		richard = appService.reloadUser(richard)
 		assert richard.pinResetRequestUrl != null
 
@@ -75,16 +78,16 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData.delay == "PT10S"
-		User  richardAfterGet = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated)
+		User  richardAfterGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated)
 		!richardAfterGet.pinResetRequestUrl
 
 		!richardAfterGet.verifyPinResetUrl
 		!richardAfterGet.clearPinResetUrl
 
 		sleepTillPinResetCodeIsGenerated(richard, response.responseData.delay)
-		User  richardAfterDelayedGet = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		User  richardAfterDelayedGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		richardAfterDelayedGet.verifyPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify"
 		richardAfterDelayedGet.clearPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/clear"
@@ -108,14 +111,14 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
-		richard = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 
 		when:
 		def response = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
 
 		then:
-		response.status == 200
-		User  richardAfterGet = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		assertResponseStatusOk(response)
+		User  richardAfterGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 		!richardAfterGet.pinResetRequestUrl
 		richardAfterGet.verifyPinResetUrl
 		richardAfterGet.clearPinResetUrl
@@ -135,7 +138,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.postJson(YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify", """{"code" : "1234"}""", ["Yona-Password" : richard.password])
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
 
 		cleanup:
@@ -156,19 +159,19 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
-		richard = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 
 		when:
 		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password])
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		User  richardAfterGet = appService.reloadUser(richard)
 		richardAfterGet.pinResetRequestUrl
 		!richardAfterGet.verifyPinResetUrl
 		!richardAfterGet.clearPinResetUrl
 		def verifyPinResetAttemptResponse = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
-		verifyPinResetAttemptResponse.status == 400
+		assertResponseStatus(verifyPinResetAttemptResponse, 400)
 		verifyPinResetAttemptResponse.responseData.code == "error.pin.reset.request.confirmation.code.not.set"
 
 		cleanup:
@@ -182,13 +185,13 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
 		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
-		richard = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 
 		when:
 		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password])
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		User  richardAfterGet = appService.reloadUser(richard)
 		richardAfterGet.pinResetRequestUrl
 		!richardAfterGet.verifyPinResetUrl
@@ -204,7 +207,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
-		richard = appService.reloadUser(richard, appService.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated)
 
 		when:
 		def response1TimeWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12341"}""", ["Yona-Password" : richard.password])
@@ -217,19 +220,19 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		def response7thTimeRight = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
 
 		then:
-		response1TimeWrong.status == 400
+		assertResponseStatus(response1TimeWrong, 400)
 		response1TimeWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
 		response1TimeWrong.responseData.remainingAttempts == 4
-		response4TimesWrong.status == 400
+		assertResponseStatus(response4TimesWrong, 400)
 		response4TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
 		response4TimesWrong.responseData.remainingAttempts == 1
-		response5TimesWrong.status == 400
+		assertResponseStatus(response5TimesWrong, 400)
 		response5TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
 		response5TimesWrong.responseData.remainingAttempts == 0
-		response6TimesWrong.status == 400
+		assertResponseStatus(response6TimesWrong, 400)
 		response6TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
 		response6TimesWrong.responseData.remainingAttempts == null
-		response7thTimeRight.status == 400
+		assertResponseStatus(response7thTimeRight, 400)
 		response7thTimeRight.responseData.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 
 class RejectBuddyTest extends AbstractAppServiceIntegrationTest
@@ -25,7 +27,7 @@ class RejectBuddyTest extends AbstractAppServiceIntegrationTest
 		def rejectResponse = appService.postMessageActionWithPassword(rejectUrl, ["message" : rejectMessage], bob.password)
 
 		then:
-		rejectResponse.status == 200
+		assertResponseStatusOk(rejectResponse)
 		rejectResponse.responseData._embedded."yona:affectedMessages".size() == 1
 		rejectResponse.responseData._embedded."yona:affectedMessages"[0]._links.self.href == connectRequestMessage.selfUrl
 		rejectResponse.responseData._embedded."yona:affectedMessages"[0].status == "REJECTED"

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -6,7 +6,10 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.Goal
 import nu.yona.server.test.TimeZoneGoal
 import nu.yona.server.test.User
@@ -22,7 +25,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		def response = appService.deleteUser(richard, "Goodbye friends! I deinstalled the Internet")
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 	}
 
 	def 'Delete and recreate account'()
@@ -32,7 +35,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richard, "Goodbye friends! I deinstalled the Internet")
 
 		when:
-		def newRichard = appService.addUser(appService.&assertUserCreationResponseDetails, richard.firstName, richard.lastName,
+		def newRichard = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, richard.firstName, richard.lastName,
 				richard.nickname, richard.mobileNumber)
 
 		then:
@@ -48,8 +51,8 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
-		assert analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com").status == 200
-		assert analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl").status == 200
+		assertResponseStatusOk(analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com"))
+		assertResponseStatusOk(analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl"))
 
 		when:
 		def message = "Goodbye friends! I deinstalled the Internet"
@@ -60,7 +63,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		buddies.size() == 0
 
 		def getMessagesResponse = appService.getMessages(bob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded
 		getMessagesResponse.responseData._embedded."yona:messages".size() == 2
 
@@ -101,7 +104,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		buddies.size() == 0
 
 		def getMessagesResponse = appService.getMessages(bob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded
 		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
 
@@ -120,7 +123,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		appService.makeBuddies(newRichard, bob)
 
 		then:
-		appService.deleteUser(newRichard, "Sorry, going again").status == 200
+		assertResponseStatusOk(appService.deleteUser(newRichard, "Sorry, going again"))
 
 		cleanup:
 		appService.deleteUser(bob)
@@ -140,7 +143,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def getMessagesResponse = appService.getMessages(bob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded == null
 
 		def buddies = appService.getBuddies(bob)
@@ -164,9 +167,9 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		Goal budgetGoalNewsBuddyBob = richard.buddies[0].findActiveGoal(NEWS_ACT_CAT_URL)
 		//insert some messages
 		//goal conflict
-		assert analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl").status == 200
+		assertResponseStatusOk(analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl"))
 		//goal change
-		appService.addGoal(appService.&assertResponseStatusCreated, richard, TimeZoneGoal.createInstance(SOCIAL_ACT_CAT_URL, ["11:00-12:00"].toArray()), "Going to restrict my social time!")
+		appService.addGoal(CommonAssertions.&assertResponseStatusCreated, richard, TimeZoneGoal.createInstance(SOCIAL_ACT_CAT_URL, ["11:00-12:00"].toArray()), "Going to restrict my social time!")
 		//activity comment at activity of Richard
 		def bobResponseDetailsRichard = appService.getDayActivityDetails(bob, bob.buddies[0], budgetGoalNewsBuddyRichard, 1, "Tue")
 		appService.yonaServer.createResourceWithPassword(bobResponseDetailsRichard.responseData._links."yona:addComment".href, """{"message": "Hi Richard, everything OK?"}""", bob.password)
@@ -176,18 +179,18 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		//buddy info change
 		def updatedRichardJson = richard.convertToJson()
 		updatedRichardJson.nickname = "Richardo"
-		richard = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedRichardJson))
+		richard = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedRichardJson))
 
 		when:
 		def message = "Goodbye friends! I deinstalled the Internet"
 		appService.deleteUser(richard, message)
 
 		then:
-		assert analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com").status == 200
-		assert analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl").status == 400 // User deleted
+		assertResponseStatusOk(analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com"))
+		assertResponseStatus(analysisService.postToAnalysisEngine(richard, "news/media", "http://www.refdag.nl"), 400) // User deleted
 
 		def getMessagesResponse = appService.getMessages(bob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded
 		getMessagesResponse.responseData._embedded."yona:messages".size() == 2 // User removal + own goal conflict
 
@@ -233,16 +236,16 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		def message = "Goodbye friends! I deinstalled the Internet"
 		appService.deleteUser(richard, message)
 		def getResponse = appService.getMessages(bob)
-		assert getResponse.status == 200
+		assertResponseStatusOk(getResponse)
 		assert getResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}[0]._links."yona:process" == null // Processing happens automatically these days
 
 		when:
 		def response = analysisService.postToAnalysisEngine(bob, ["Gambling"], "http://www.poker.com")
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		def getMessagesResponse = appService.getMessages(bob)
-		getMessagesResponse.status == 200
+		assertResponseStatusOk(getMessagesResponse)
 		getMessagesResponse.responseData._embedded
 		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyDisconnectMessage"}
 		buddyDisconnectMessages[0].reason == "USER_ACCOUNT_DELETED"

--- a/appservice/src/intTest/groovy/nu/yona/server/SystemMessageTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/SystemMessageTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 
 class SystemMessageTest extends AbstractAppServiceIntegrationTest
@@ -23,7 +25,7 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 		def messagesBob = appService.getMessages(bob)
 
 		then:
-		messagesRichard.status == 200
+		assertResponseStatusOk(messagesRichard)
 		def systemMessagesRichard = messagesRichard.responseData._embedded."yona:messages".findAll{ it."@type" == "SystemMessage"}
 		systemMessagesRichard.size() == 1
 		systemMessagesRichard[0].message == "Hi there!"
@@ -59,7 +61,7 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 		def response = appService.deleteResourceWithPassword(messageDeleteUrl, bob.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		appService.getMessages(richard).responseData._embedded."yona:messages".findAll{ it."@type" == "SystemMessage"}.size() == 1
 		appService.getMessages(bob).responseData._embedded == null
 

--- a/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
@@ -8,6 +8,8 @@ package nu.yona.server
 
 import groovy.json.*
 import nu.yona.server.test.User
+import static nu.yona.server.test.CommonAssertions.*
+import nu.yona.server.test.CommonAssertions
 
 class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 {
@@ -21,9 +23,9 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		when:
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.nickname = "Bobby"
-		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson))
+		User bobAfterUpdate = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
-		assert richardMessagesAfterUpdate.status == 200
+		assertResponseStatusOk(richardMessagesAfterUpdate)
 		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
 
 		then:
@@ -57,9 +59,9 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.firstName = "Robert"
 		updatedBobJson.lastName = "Dunstan"
-		User bobAfterUpdate = appService.updateUser(appService.&assertUserUpdateResponseDetails, new User(updatedBobJson))
+		User bobAfterUpdate = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
-		assert richardMessagesAfterUpdate.status == 200
+		assertResponseStatusOk(richardMessagesAfterUpdate)
 		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
 
 		then:

--- a/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import org.apache.http.HttpEntity
 import org.apache.http.entity.mime.MultipartEntityBuilder
 import org.apache.http.entity.mime.content.InputStreamBody
@@ -38,7 +40,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.contentType == "application/json"
 		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
@@ -62,13 +64,13 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.contentType == "application/json"
 		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
 
 		def downloadResponse = appService.yonaServer.restClient.get(path: newUserPhotoUrl)
-		downloadResponse.status == 200
+		assertResponseStatusOk(downloadResponse)
 		downloadResponse.contentType == "image/png"
 
 		cleanup:
@@ -87,13 +89,13 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.contentType == "application/json"
 		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
 
 		def downloadResponse = appService.yonaServer.restClient.get(path: newUserPhotoUrl)
-		downloadResponse.status == 200
+		assertResponseStatusOk(downloadResponse)
 		downloadResponse.contentType == "image/png"
 
 		cleanup:
@@ -112,7 +114,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == null // As the app should take care for uploading a resized photo, this is not a user error, so it does not need to have a code
 
 		cleanup:
@@ -129,7 +131,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.get(path: userPhotoUrl)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 		response.contentType == "image/png"
 
 		cleanup:
@@ -152,10 +154,10 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		richardAfterUpdate.userPhotoUrl == newUserPhotoUrl
 
 		def retrievePhotoBeforeResponse = appService.yonaServer.restClient.get(path: userPhotoUrlBefore)
-		retrievePhotoBeforeResponse.status == 200
+		assertResponseStatusOk(retrievePhotoBeforeResponse)
 
 		def retrieveNewPhotoResponse = appService.yonaServer.restClient.get(path: newUserPhotoUrl)
-		retrieveNewPhotoResponse.status == 200
+		assertResponseStatusOk(retrieveNewPhotoResponse)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -171,13 +173,13 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.deleteResourceWithPassword(richard.editUserPhotoUrl, richard.password)
 
 		then:
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		def richardAfterUpdate = appService.reloadUser(richard)
 		richardAfterUpdate.userPhotoUrl == null
 
 		def retrievePhotoBeforeResponse = appService.yonaServer.restClient.get(path: userPhotoUrlBefore)
-		retrievePhotoBeforeResponse.status == 200
+		assertResponseStatusOk(retrievePhotoBeforeResponse)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -225,7 +227,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
 		def response = appService.yonaServer.restClient.get(path: richardPhotoUrl)
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -252,7 +254,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
 		def response = appService.yonaServer.restClient.get(path: richardPhotoUrl)
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -278,7 +280,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
 		def response = appService.yonaServer.restClient.get(path: richardPhotoUrl)
-		response.status == 200
+		assertResponseStatusOk(response)
 
 		cleanup:
 		appService.deleteUser(bob)
@@ -296,7 +298,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
-		assert bobMessagesAfterUpdate.status == 200
+		assertResponseStatusOk(bobMessagesAfterUpdate)
 		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
@@ -330,7 +332,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
-		assert bobMessagesAfterUpdate.status == 200
+		assertResponseStatusOk(bobMessagesAfterUpdate)
 		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyInfoChangeMessage"}
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
@@ -361,7 +363,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": "Wrong password"], body: multipartEntity)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.decrypting.data"
 
 		def richardAfterUpdate = appService.reloadUser(richard)
@@ -381,7 +383,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.deleteResourceWithPassword(richard.editUserPhotoUrl, "Wrong password")
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.decrypting.data"
 
 		def richardAfterUpdate = appService.reloadUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import groovy.json.*
 
 /**
@@ -31,7 +33,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.firstname"
 	}
 
@@ -43,7 +45,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.lastname"
 	}
 
@@ -55,7 +57,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.nickname"
 	}
 
@@ -67,7 +69,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.mobile.number"
 	}
 
@@ -79,7 +81,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.mobile.number.invalid"
 	}
 
@@ -91,7 +93,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 		def response = appService.addUser(object)
 
 		then:
-		response.status == 400
+		assertResponseStatus(response, 400)
 		response.responseData.code == "error.user.mobile.number.not.mobile"
 	}
 }

--- a/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
@@ -142,31 +142,6 @@ class YonaServer
 		}
 	}
 
-	void setEnableStatistics(def enable)
-	{
-		def response = createResource("/hibernateStatistics/enable/", "{}", [:], ["enable" : enable])
-		assert response.status == 200 : "Ensure the server stats are enabled (run with -Dyona.enableHibernateStatsAllowed=true)"
-	}
-
-	void resetStatistics()
-	{
-		def response = getResource("/hibernateStatistics/", [:], ["reset" : "true"])
-		assert response.status == 200
-	}
-
-	void clearCaches()
-	{
-		def response = createResource("/hibernateStatistics/clearCaches/", "{}", [:], [:])
-		assert response.status == 200
-	}
-
-	def getStatistics()
-	{
-		def response = getResource("/hibernateStatistics/", [:], ["reset" : "false"])
-		assert response.status == 200
-		response.responseData
-	}
-
 	static void storeStatistics(def statistics, def heading)
 	{
 		def file = new File("build/reports/tests/intTest/" + heading + ".md")

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -6,8 +6,8 @@
  *******************************************************************************/
 package nu.yona.server.test
 
-import java.time.Duration
-import java.time.LocalDate
+import static nu.yona.server.test.CommonAssertions.*
+
 import java.time.ZonedDateTime
 
 import groovy.json.*
@@ -19,28 +19,6 @@ class AppService extends Service
 	static final NEW_DEVICE_REQUESTS_PATH = "/newDeviceRequests/"
 	static final USERS_PATH = "/users/"
 	static final OVERWRITE_USER_REQUEST_PATH = "/admin/requestUserOverwrite/"
-
-	static final UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
-
-
-	static final PUBLIC_USER_PROPERTIES_APP_NOT_OPENED = ["firstName", "lastName", "mobileNumber", "creationTime", "_links"] as Set
-	static final PUBLIC_USER_PROPERTIES_APP_OPENED = PUBLIC_USER_PROPERTIES_APP_NOT_OPENED + ["appLastOpenedDate"] as Set
-	static final PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST = PUBLIC_USER_PROPERTIES_APP_NOT_OPENED + ["nickname", "yonaPassword"] as Set
-	static final PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED = PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST + ["appLastOpenedDate"] as Set
-	static final PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY = PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED + ["vpnProfile", "sslRootCertCN", "_embedded"] as Set
-	static final PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_AFTER_ACTIVITY = PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY + ["lastMonitoredActivityDate"] as Set
-	static final BUDDY_USER_PROPERTIES = PUBLIC_USER_PROPERTIES_APP_OPENED + ["nickname"] as Set
-	static final BUDDY_USER_PROPERTIES_VARYING = ["_embedded"] as Set
-	static final PRIVATE_USER_COMMON_LINKS = ["self", "curies"] as Set
-	static final PRIVATE_USER_LINKS_NUM_TO_BE_CONFIRMED = PRIVATE_USER_COMMON_LINKS + ["yona:confirmMobileNumber", "yona:resendMobileNumberConfirmationCode", "edit"] as Set
-	static final PRIVATE_USER_LINKS_NUM_CONFIRMED = PRIVATE_USER_COMMON_LINKS + ["edit", "yona:postOpenAppEvent", "yona:messages", "yona:dailyActivityReports", "yona:weeklyActivityReports", "yona:dailyActivityReportsWithBuddies", "yona:newDeviceRequest", "yona:appActivity", "yona:sslRootCert", "yona:appleMobileConfig", "yona:editUserPhoto"] as Set
-	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_NOT_REQUESTED = PRIVATE_USER_LINKS_NUM_CONFIRMED + ["yona:requestPinReset"] as Set
-	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED = PRIVATE_USER_LINKS_NUM_CONFIRMED
-	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED = PRIVATE_USER_LINKS_NUM_CONFIRMED + ["yona:verifyPinReset", "yona:resendPinResetConfirmationCode", "yona:clearPinReset"] as Set
-	static final BUDDY_USER_LINKS =  ["self"] as Set
-	static final PRIVATE_USER_EMBEDDED = ["yona:devices", "yona:goals", "yona:buddies"] as Set
-	static final BUDDY_USER_EMBEDDED = ["yona:goals", "yona:devices"] as Set
-	static final USER_LINKS_VARYING = ["yona:userPhoto"]
 
 	JsonSlurper jsonSlurper = new JsonSlurper()
 
@@ -182,7 +160,7 @@ class AppService extends Service
 			return null
 		}
 		def response = yonaServer.deleteResourceWithPassword(user.editUrl, user.password, ["message":message])
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		return response
 	}
 
@@ -191,241 +169,12 @@ class AppService extends Service
 		yonaServer.deleteResourceWithPassword(userEditUrl, password, ["message":message])
 	}
 
-	def assertUserCreationResponseDetails(def response)
-	{
-		assertResponseStatusCreated(response)
-		assertUserWithPrivateData(response.responseData, false)
-	}
-
-	def assertUserUpdateResponseDetails(def response)
-	{
-		assert response.status == 200
-		assertUserWithPrivateData(response.responseData, false)
-	}
-
-	def assertUserGetResponseDetailsWithPrivateData(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertUserWithPrivateData(response.responseData, false)
-	}
-
-	def assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertUserWithPrivateData(response.responseData, true)
-		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
-		assert response.responseData._links.keySet() == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED
-		assert response.responseData._embedded.keySet() == PRIVATE_USER_EMBEDDED
-	}
-
-	def assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertUserWithPrivateData(response.responseData, true)
-		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
-		assert response.responseData._links.keySet() == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED
-		assert response.responseData._embedded.keySet() == PRIVATE_USER_EMBEDDED
-	}
-
-	def assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertUserWithPrivateData(response.responseData, true, true)
-		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST
-	}
-
-	def assertUserGetResponseDetailsWithoutPrivateData(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertPublicUserData(response.responseData, false, false)
-	}
-
-	def assertUserWithPrivateData(user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest = false)
-	{
-		assertPublicUserData(user, true, userCreatedOnBuddyRequest)
-		assertPrivateUserData(user, skipPropertySetAssertion, userCreatedOnBuddyRequest)
-	}
-
-	def assertUserGetResponseDetailsWithBuddyData(def response)
-	{
-		assertResponseStatusSuccess(response)
-		assertBuddyUser(response.responseData)
-	}
-
-	def assertPublicUserData(def user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest)
-	{
-		if (user instanceof User)
-		{
-			assert user.url != null
-		}
-		else
-		{
-			assert user._links.self.href != null
-			assert skipPropertySetAssertion || user.keySet() == PUBLIC_USER_PROPERTIES_APP_NOT_OPENED || user.keySet() == PUBLIC_USER_PROPERTIES_APP_OPENED
-		}
-		assert user.creationTime != null
-		assert userCreatedOnBuddyRequest || user.appLastOpenedDate != null
-		assert user.firstName != null
-		assert user.lastName != null
-		assert user.mobileNumber ==~/^\+[0-9]+$/
-	}
-
-	def assertPrivateUserData(def user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest)
-	{
-		assert userCreatedOnBuddyRequest || user.nickname != null
-		boolean mobileNumberToBeConfirmed
-
-		/*
-		 * The below asserts use exclusive or operators. Either there should be a mobile number confirmation URL, or the other URL.
-		 * The URLs shouldn't be both missing or both present.
-		 */
-		if (user instanceof User)
-		{
-			mobileNumberToBeConfirmed = ((boolean) user.mobileNumberConfirmationUrl)
-			assert user.password.startsWith("AES:128:")
-			assert mobileNumberToBeConfirmed ^ ((boolean) user.buddiesUrl)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user.messagesUrl)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user.newDeviceRequestUrl)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user.appActivityUrl)
-		}
-		else
-		{
-			mobileNumberToBeConfirmed = ((boolean) user._links?."yona:confirmMobileNumber"?.href)
-			assert user.yonaPassword.startsWith("AES:128:")
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:buddies"?._links?.self?.href)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:goals"?._links?.self?.href)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:devices"?._links?.self?.href)
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:messages")
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:newDeviceRequest")
-			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:appActivity")
-			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user.keySet() == PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED : (user.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY || user.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_AFTER_ACTIVITY))
-			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user._links.keySet() - USER_LINKS_VARYING == PRIVATE_USER_LINKS_NUM_TO_BE_CONFIRMED : user._links.keySet() - USER_LINKS_VARYING == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_NOT_REQUESTED)
-			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user._embedded == null : user._embedded.keySet() == PRIVATE_USER_EMBEDDED)
-			assert skipPropertySetAssertion || user._links.self.href ==~/(?i)^.*\/$UUID_PATTERN\?requestingUserId=$UUID_PATTERN$/
-			if (!mobileNumberToBeConfirmed)
-			{
-				assertDefaultOwnDevice(user._embedded."yona:devices"._embedded."yona:devices"[0])
-			}
-		}
-
-		if (!mobileNumberToBeConfirmed)
-		{
-			assertVpnProfile(user)
-		}
-	}
-
-	def assertVpnProfile(def user)
-	{
-		if (user instanceof User)
-		{
-			// The User Groovy object follows the new camel casing pattern: Id with lowercase d
-			assert user.vpnProfile.vpnLoginId ==~ /(?i)^$UUID_PATTERN$/
-		}
-		else
-		{
-			// For backward compatibility, the JSON still has the old camel casing pattern: ID with uppercase D
-			assert user.vpnProfile.vpnLoginID ==~ /(?i)^$UUID_PATTERN$/
-		}
-		assert user.vpnProfile.vpnPassword.length() == 32
-		if (user instanceof User)
-		{
-			assert user.vpnProfile.ovpnProfileUrl
-		}
-		else
-		{
-			assert user.vpnProfile._links."yona:ovpnProfile".href
-		}
-	}
-
-	void assertDefaultOwnDevice(def device)
-	{
-		if (device instanceof Device)
-		{
-			assert device.name == "First device"
-			assert device.operatingSystem == "UNKNOWN"
-		}
-		else
-		{
-			assert device.keySet() == ["name", "operatingSystem", "registrationTime", "appLastOpenedDate", "vpnConnected", "_links"] as Set
-			assert device._links.keySet() == ["self", "edit"] as Set
-			assert device.name == "First device"
-			assert device.operatingSystem == "UNKNOWN"
-			assertDateTimeFormat(device.registrationTime)
-			assertDateFormat(device.appLastOpenedDate)
-			assert device.vpnConnected == true || device.vpnConnected == false
-		}
-	}
-
-	static void assertEquals(String dateTimeString, ZonedDateTime comparisonDateTime, int epsilonSeconds = 10)
-	{
-		// Example date/time string: 2016-02-23T21:28:58.556+0000
-		ZonedDateTime dateTime = YonaServer.parseIsoDateTimeString(dateTimeString)
-		assertEquals(dateTime, comparisonDateTime, epsilonSeconds)
-	}
-
-	static void assertEquals(ZonedDateTime dateTime, ZonedDateTime comparisonDateTime, int epsilonSeconds = 10)
-	{
-		int epsilonMilliseconds = epsilonSeconds * 1000
-
-		assert dateTime.isAfter(comparisonDateTime.minus(Duration.ofMillis(epsilonMilliseconds)))
-		assert dateTime.isBefore(comparisonDateTime.plus(Duration.ofMillis(epsilonMilliseconds)))
-	}
-
-	static void assertDateTimeFormat(dateTimeString)
-	{
-		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+\d{4}/
-	}
-
-	static void assertEquals(String dateTimeString, LocalDate comparisonDate)
-	{
-		// Example date string: 2016-02-23
-		ZonedDateTime date = YonaServer.parseIsoDateString(dateTimeString)
-		assertEquals(date, comparisonDate)
-	}
-
-	static void assertEquals(LocalDate date, LocalDate comparisonDate)
-	{
-		assert date == comparisonDate
-	}
-
-	static void assertDateFormat(dateTimeString)
-	{
-		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}/
-	}
-
-	static void assertResponseStatusCreated(def response)
-	{
-		assertResponseStatus(response, 201)
-	}
-
-	static void assertResponseStatus(def response, int status)
-	{
-		assert response.status == status, "Invalid status: $response.status (expecting $status). Response: $response.data"
-	}
-
-	static void assertResponseStatusSuccess(def response)
-	{
-		assert response.status >= 200 && response.status < 300, "Invalid status: $response.status (expecting 2xx). Response: $response.data"
-	}
-
-	private assertBuddyUsers(response)
-	{
-		response.responseData._embedded?."yona:buddies"?._embedded?."yona:buddies".each{assertBuddyUser(it._embedded."yona:user")}
-	}
-
-	def assertBuddyUser(def buddyUser)
-	{
-		assert buddyUser.keySet() -BUDDY_USER_PROPERTIES_VARYING == BUDDY_USER_PROPERTIES
-		assert buddyUser._links.keySet() - USER_LINKS_VARYING == BUDDY_USER_LINKS
-		assert buddyUser._embedded == null || buddyUser._embedded.keySet() == BUDDY_USER_EMBEDDED
-	}
-
 	void makeBuddies(User requestingUser, User respondingUser)
 	{
 		sendBuddyConnectRequest(requestingUser, respondingUser)
 		def acceptUrl = fetchBuddyConnectRequestMessage(respondingUser).acceptUrl
 		def acceptResponse = postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], respondingUser.password)
-		assert acceptResponse.status == 200
+		assertResponseStatusOk(acceptResponse)
 
 		def processUrl = fetchBuddyConnectResponseMessage(requestingUser).processUrl
 		assert processUrl == null // Processing happens automatically these days
@@ -457,7 +206,7 @@ class AppService extends Service
 	{
 		// Have the other user fetch the buddy connect request
 		def response = getMessages(user)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		assert response.responseData._embedded
 
 		def buddyConnectRequestMessages = response.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}
@@ -491,7 +240,7 @@ class AppService extends Service
 	{
 		// Have the requesting user fetch the buddy connect response
 		def response = getMessages(user)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		assert response.responseData._embedded
 
 		def buddyConnectResponseMessages = response.responseData._embedded?."yona:messages".findAll{ it."@type" == "BuddyConnectResponseMessage"}
@@ -559,7 +308,7 @@ class AppService extends Service
 	List<Buddy> getBuddies(User user)
 	{
 		def response = yonaServer.getResourceWithPassword(user.buddiesUrl, user.password)
-		assertResponseStatus(response, 200)
+		assertResponseStatusOk(response)
 		assert response.responseData._links?.self?.href == user.buddiesUrl
 
 		if (!response.responseData._embedded?."yona:buddies")
@@ -597,14 +346,14 @@ class AppService extends Service
 	def getDayActivityDetails(User user, Goal goal, int weeksBack, String shortDay)
 	{
 		def responseDayOverviewsAll = getDayActivityOverviews(user, ["size": (weeksBack+1)*7])
-		assert responseDayOverviewsAll.status == 200
+		assertResponseStatusOk(responseDayOverviewsAll)
 		getDayDetailsFromOverview(responseDayOverviewsAll, user, goal, weeksBack, shortDay)
 	}
 
 	def getDayActivityDetails(User user, Buddy buddy, Goal goal, int weeksBack, String shortDay)
 	{
 		def responseDayOverviewsAll = getDayActivityOverviews(user, buddy, ["size": (weeksBack+1)*7])
-		assert responseDayOverviewsAll.status == 200
+		assertResponseStatusOk(responseDayOverviewsAll)
 		getDayDetailsFromOverview(responseDayOverviewsAll, user, goal, weeksBack, shortDay)
 	}
 
@@ -631,7 +380,7 @@ class AppService extends Service
 		assert dayActivityForGoal?._links?."yona:dayDetails"?.href
 		def dayActivityDetailUrl =  dayActivityForGoal?._links?."yona:dayDetails"?.href
 		def response = getResourceWithPassword(dayActivityDetailUrl, user.password)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		return response
 	}
 
@@ -639,7 +388,7 @@ class AppService extends Service
 		assert weekActivityForGoal?._links?."yona:weekDetails"?.href
 		def weekActivityDetailUrl =  weekActivityForGoal?._links?."yona:weekDetails"?.href
 		def response = getResourceWithPassword(weekActivityDetailUrl, user.password)
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		return response
 	}
 

--- a/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.test
+
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+import groovy.json.*
+import nu.yona.server.YonaServer
+
+class CommonAssertions extends Service
+{
+	static final UUID_PATTERN = '[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+
+	static final PUBLIC_USER_PROPERTIES_APP_NOT_OPENED = ["firstName", "lastName", "mobileNumber", "creationTime", "_links"] as Set
+	static final PUBLIC_USER_PROPERTIES_APP_OPENED = PUBLIC_USER_PROPERTIES_APP_NOT_OPENED + ["appLastOpenedDate"] as Set
+	static final PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST = PUBLIC_USER_PROPERTIES_APP_NOT_OPENED + ["nickname", "yonaPassword"] as Set
+	static final PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED = PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST + ["appLastOpenedDate"] as Set
+	static final PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY = PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED + ["vpnProfile", "sslRootCertCN", "_embedded"] as Set
+	static final PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_AFTER_ACTIVITY = PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY + ["lastMonitoredActivityDate"] as Set
+	static final BUDDY_USER_PROPERTIES = PUBLIC_USER_PROPERTIES_APP_OPENED + ["nickname"] as Set
+	static final BUDDY_USER_PROPERTIES_VARYING = ["_embedded"] as Set
+	static final PRIVATE_USER_COMMON_LINKS = ["self", "curies"] as Set
+	static final PRIVATE_USER_LINKS_NUM_TO_BE_CONFIRMED = PRIVATE_USER_COMMON_LINKS + ["yona:confirmMobileNumber", "yona:resendMobileNumberConfirmationCode", "edit"] as Set
+	static final PRIVATE_USER_LINKS_NUM_CONFIRMED = PRIVATE_USER_COMMON_LINKS + ["edit", "yona:postOpenAppEvent", "yona:messages", "yona:dailyActivityReports", "yona:weeklyActivityReports", "yona:dailyActivityReportsWithBuddies", "yona:newDeviceRequest", "yona:appActivity", "yona:sslRootCert", "yona:appleMobileConfig", "yona:editUserPhoto"] as Set
+	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_NOT_REQUESTED = PRIVATE_USER_LINKS_NUM_CONFIRMED + ["yona:requestPinReset"] as Set
+	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED = PRIVATE_USER_LINKS_NUM_CONFIRMED
+	static final PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED = PRIVATE_USER_LINKS_NUM_CONFIRMED + ["yona:verifyPinReset", "yona:resendPinResetConfirmationCode", "yona:clearPinReset"] as Set
+	static final BUDDY_USER_LINKS =  ["self"] as Set
+	static final PRIVATE_USER_EMBEDDED = ["yona:devices", "yona:goals", "yona:buddies"] as Set
+	static final BUDDY_USER_EMBEDDED = ["yona:goals", "yona:devices"] as Set
+	static final USER_LINKS_VARYING = ["yona:userPhoto"]
+
+	static def assertUserCreationResponseDetails(def response)
+	{
+		assertResponseStatusCreated(response)
+		assertUserWithPrivateData(response.responseData, false)
+	}
+
+	static def assertUserUpdateResponseDetails(def response)
+	{
+		assert response.status == 200
+		assertUserWithPrivateData(response.responseData, false)
+	}
+
+	static def assertUserGetResponseDetailsWithPrivateData(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertUserWithPrivateData(response.responseData, false)
+	}
+
+	static def assertUserGetResponseDetailsWithPrivateDataPinResetRequestedNotGenerated(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertUserWithPrivateData(response.responseData, true)
+		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
+		assert response.responseData._links.keySet() == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED
+		assert response.responseData._embedded.keySet() == PRIVATE_USER_EMBEDDED
+	}
+
+	static def assertUserGetResponseDetailsWithPrivateDataPinResetRequestedAndGenerated(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertUserWithPrivateData(response.responseData, true)
+		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
+		assert response.responseData._links.keySet() == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED
+		assert response.responseData._embedded.keySet() == PRIVATE_USER_EMBEDDED
+	}
+
+	static def assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertUserWithPrivateData(response.responseData, true, true)
+		assert response.responseData.keySet() == PRIVATE_USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST
+	}
+
+	static def assertUserGetResponseDetailsWithoutPrivateData(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertPublicUserData(response.responseData, false, false)
+	}
+
+	static def assertUserWithPrivateData(user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest = false)
+	{
+		assertPublicUserData(user, true, userCreatedOnBuddyRequest)
+		assertPrivateUserData(user, skipPropertySetAssertion, userCreatedOnBuddyRequest)
+	}
+
+	static def assertUserGetResponseDetailsWithBuddyData(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertBuddyUser(response.responseData)
+	}
+
+	static def assertPublicUserData(def user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest)
+	{
+		if (user instanceof User)
+		{
+			assert user.url != null
+		}
+		else
+		{
+			assert user._links.self.href != null
+			assert skipPropertySetAssertion || user.keySet() == PUBLIC_USER_PROPERTIES_APP_NOT_OPENED || user.keySet() == PUBLIC_USER_PROPERTIES_APP_OPENED
+		}
+		assert user.creationTime != null
+		assert userCreatedOnBuddyRequest || user.appLastOpenedDate != null
+		assert user.firstName != null
+		assert user.lastName != null
+		assert user.mobileNumber ==~/^\+[0-9]+$/
+	}
+
+	static def assertPrivateUserData(def user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest)
+	{
+		assert userCreatedOnBuddyRequest || user.nickname != null
+		boolean mobileNumberToBeConfirmed
+
+		/*
+		 * The below asserts use exclusive or operators. Either there should be a mobile number confirmation URL, or the other URL.
+		 * The URLs shouldn't be both missing or both present.
+		 */
+		if (user instanceof User)
+		{
+			mobileNumberToBeConfirmed = ((boolean) user.mobileNumberConfirmationUrl)
+			assert user.password.startsWith("AES:128:")
+			assert mobileNumberToBeConfirmed ^ ((boolean) user.buddiesUrl)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user.messagesUrl)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user.newDeviceRequestUrl)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user.appActivityUrl)
+		}
+		else
+		{
+			mobileNumberToBeConfirmed = ((boolean) user._links?."yona:confirmMobileNumber"?.href)
+			assert user.yonaPassword.startsWith("AES:128:")
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:buddies"?._links?.self?.href)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:goals"?._links?.self?.href)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:devices"?._links?.self?.href)
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:messages")
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:newDeviceRequest")
+			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:appActivity")
+			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user.keySet() == PRIVATE_USER_PROPERTIES_NUM_TO_BE_CONFIRMED : (user.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY || user.keySet() == PRIVATE_USER_PROPERTIES_NUM_CONFIRMED_AFTER_ACTIVITY))
+			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user._links.keySet() - USER_LINKS_VARYING == PRIVATE_USER_LINKS_NUM_TO_BE_CONFIRMED : user._links.keySet() - USER_LINKS_VARYING == PRIVATE_USER_LINKS_NUM_CONFIRMED_PIN_RESET_NOT_REQUESTED)
+			assert skipPropertySetAssertion || (mobileNumberToBeConfirmed ? user._embedded == null : user._embedded.keySet() == PRIVATE_USER_EMBEDDED)
+			assert skipPropertySetAssertion || user._links.self.href ==~/(?i)^.*\/$UUID_PATTERN\?requestingUserId=$UUID_PATTERN$/
+			if (!mobileNumberToBeConfirmed)
+			{
+				assertDefaultOwnDevice(user._embedded."yona:devices"._embedded."yona:devices"[0])
+			}
+		}
+
+		if (!mobileNumberToBeConfirmed)
+		{
+			assertVpnProfile(user)
+		}
+	}
+
+	static def assertVpnProfile(def user)
+	{
+		if (user instanceof User)
+		{
+			// The User Groovy object follows the new camel casing pattern: Id with lowercase d
+			assert user.vpnProfile.vpnLoginId ==~ /(?i)^$UUID_PATTERN$/
+		}
+		else
+		{
+			// For backward compatibility, the JSON still has the old camel casing pattern: ID with uppercase D
+			assert user.vpnProfile.vpnLoginID ==~ /(?i)^$UUID_PATTERN$/
+		}
+		assert user.vpnProfile.vpnPassword.length() == 32
+		if (user instanceof User)
+		{
+			assert user.vpnProfile.ovpnProfileUrl
+		}
+		else
+		{
+			assert user.vpnProfile._links."yona:ovpnProfile".href
+		}
+	}
+
+	static void assertDefaultOwnDevice(def device)
+	{
+		if (device instanceof Device)
+		{
+			assert device.name == "First device"
+			assert device.operatingSystem == "UNKNOWN"
+		}
+		else
+		{
+			assert device.keySet() == ["name", "operatingSystem", "registrationTime", "appLastOpenedDate", "vpnConnected", "_links"] as Set
+			assert device._links.keySet() == ["self", "edit"] as Set
+			assert device.name == "First device"
+			assert device.operatingSystem == "UNKNOWN"
+			assertDateTimeFormat(device.registrationTime)
+			assertDateFormat(device.appLastOpenedDate)
+			assert device.vpnConnected == true || device.vpnConnected == false
+		}
+	}
+
+	static void assertEquals(String dateTimeString, ZonedDateTime comparisonDateTime, int epsilonSeconds = 10)
+	{
+		// Example date/time string: 2016-02-23T21:28:58.556+0000
+		ZonedDateTime dateTime = YonaServer.parseIsoDateTimeString(dateTimeString)
+		assertEquals(dateTime, comparisonDateTime, epsilonSeconds)
+	}
+
+	static void assertEquals(ZonedDateTime dateTime, ZonedDateTime comparisonDateTime, int epsilonSeconds = 10)
+	{
+		int epsilonMilliseconds = epsilonSeconds * 1000
+
+		assert dateTime.isAfter(comparisonDateTime.minus(Duration.ofMillis(epsilonMilliseconds)))
+		assert dateTime.isBefore(comparisonDateTime.plus(Duration.ofMillis(epsilonMilliseconds)))
+	}
+
+	static void assertDateTimeFormat(dateTimeString)
+	{
+		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\+\d{4}/
+	}
+
+	static void assertEquals(String dateTimeString, LocalDate comparisonDate)
+	{
+		// Example date string: 2016-02-23
+		ZonedDateTime date = YonaServer.parseIsoDateString(dateTimeString)
+		assertEquals(date, comparisonDate)
+	}
+
+	static void assertEquals(LocalDate date, LocalDate comparisonDate)
+	{
+		assert date == comparisonDate
+	}
+
+	static void assertDateFormat(dateTimeString)
+	{
+		assert dateTimeString ==~ /[0-9]{4}-[0-9]{2}-[0-9]{2}/
+	}
+
+	static void assertResponseStatusOk(def response)
+	{
+		assertResponseStatus(response, 200)
+	}
+
+	static void assertResponseStatusCreated(def response)
+	{
+		assertResponseStatus(response, 201)
+	}
+
+	static void assertResponseStatus(def response, int status)
+	{
+		assert response.status == status, "Invalid status: $response.status (expecting $status). Response: $response.data"
+	}
+
+	static void assertResponseStatusSuccess(def response)
+	{
+		assert response.status >= 200 && response.status < 300, "Invalid status: $response.status (expecting 2xx). Response: $response.data"
+	}
+
+	private static assertBuddyUsers(response)
+	{
+		response.responseData._embedded?."yona:buddies"?._embedded?."yona:buddies".each{assertBuddyUser(it._embedded."yona:user")}
+	}
+
+	static def assertBuddyUser(def buddyUser)
+	{
+		assert buddyUser.keySet() -BUDDY_USER_PROPERTIES_VARYING == BUDDY_USER_PROPERTIES
+		assert buddyUser._links.keySet() - USER_LINKS_VARYING == BUDDY_USER_LINKS
+		assert buddyUser._embedded == null || buddyUser._embedded.keySet() == BUDDY_USER_EMBEDDED
+	}
+}

--- a/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
@@ -6,6 +6,8 @@
  *******************************************************************************/
 package nu.yona.server.test
 
+import static nu.yona.server.test.CommonAssertions.*
+
 import nu.yona.server.YonaServer
 
 abstract class Service
@@ -48,19 +50,19 @@ abstract class Service
 	void resetStatistics()
 	{
 		def response = getResource("/hibernateStatistics/", [:], ["reset" : "true"])
-		assert response.status == 200
+		assertResponseStatusOk(response)
 	}
 
 	void clearCaches()
 	{
 		def response = yonaServer.createResource("/hibernateStatistics/clearCaches/", "{}", [:], [:])
-		assert response.status == 200
+		assertResponseStatusOk(response)
 	}
 
 	def getStatistics()
 	{
 		def response = getResource("/hibernateStatistics/", [:], ["reset" : "false"])
-		assert response.status == 200
+		assertResponseStatusOk(response)
 		response.responseData
 	}
 


### PR DESCRIPTION
It's now used in all applicable places. To make the assertions easier to reuse, they are all moved to the class CommonAssertions.

Along with this fixed a mistake in the test OverwriteUserTest.'Overwrite Richard while being a buddy of Bob and verify Richard does not receive Bob\'s goal conflicts anymore'. That tried to fetch the messages of the overwritten user, but that user does not exist anymore, so it results in a 400. Not sure why this ever passed.