### PR TITLE
YD-499 Create first device during migration

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	testCompile "org.springframework.boot:spring-boot-starter-test"
 	testCompile "junit:junit:4.12"
 	testCompile "pl.pragmatists:JUnitParams:1.1.0"
+	testCompile "com.spencerwi:hamcrest-jdk8-time:0.7.1"
 	testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
 	
 	testUtilsCompile "org.codehaus.groovy:groovy-all:2.4.6"

--- a/core/src/main/java/nu/yona/server/device/entities/BuddyDevice.java
+++ b/core/src/main/java/nu/yona/server/device/entities/BuddyDevice.java
@@ -28,9 +28,14 @@ public class BuddyDevice extends DeviceBase
 	{
 	}
 
-	public BuddyDevice(UUID id, String name, UUID deviceAnonymizedId, Boolean isVpnConnected)
+	private BuddyDevice(UUID id, String name, UUID deviceAnonymizedId, Boolean isVpnConnected)
 	{
 		super(id, name, deviceAnonymizedId, isVpnConnected);
+	}
+
+	public static BuddyDevice createInstance(String name, UUID deviceAnonymizedId, Boolean isVpnConnected)
+	{
+		return new BuddyDevice(UUID.randomUUID(), name, deviceAnonymizedId, isVpnConnected);
 	}
 
 	public static BuddyDeviceRepository getRepository()

--- a/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
+++ b/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
@@ -18,6 +18,7 @@ import org.hibernate.annotations.Type;
 
 import nu.yona.server.crypto.seckey.DateFieldEncryptor;
 import nu.yona.server.crypto.seckey.DateTimeFieldEncryptor;
+import nu.yona.server.util.TimeUtil;
 
 @Entity
 @Table(name = "USER_DEVICES")
@@ -41,8 +42,8 @@ public class UserDevice extends DeviceBase
 	public UserDevice(UUID id, String name, UUID deviceAnonymizedId)
 	{
 		super(id, name, deviceAnonymizedId, true); // Consider the VPN to be connected by default
-		this.registrationTime = LocalDateTime.now();
-		this.appLastOpenedDate = LocalDate.now(); // The user registers this device, so the app is open now
+		this.registrationTime = TimeUtil.utcNow();
+		this.appLastOpenedDate = TimeUtil.utcNow().toLocalDate(); // The user registers this device, so the app is open now
 	}
 
 	public UUID getUserPrivateId()

--- a/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
+++ b/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
@@ -39,11 +39,16 @@ public class UserDevice extends DeviceBase
 	{
 	}
 
-	public UserDevice(UUID id, String name, UUID deviceAnonymizedId)
+	private UserDevice(UUID id, String name, UUID deviceAnonymizedId)
 	{
 		super(id, name, deviceAnonymizedId, true); // Consider the VPN to be connected by default
 		this.registrationTime = TimeUtil.utcNow();
 		this.appLastOpenedDate = TimeUtil.utcNow().toLocalDate(); // The user registers this device, so the app is open now
+	}
+
+	public static UserDevice createInstance(String name, UUID deviceAnonymizedId)
+	{
+		return new UserDevice(UUID.randomUUID(), name, deviceAnonymizedId);
 	}
 
 	public UUID getUserPrivateId()

--- a/core/src/main/java/nu/yona/server/device/service/DeviceChange.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceChange.java
@@ -5,12 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
-package nu.yona.server.entities;
+package nu.yona.server.device.service;
 
-import nu.yona.server.device.entities.DeviceAnonymized;
-import nu.yona.server.device.entities.DeviceAnonymizedRepository;
-
-public class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
-		implements DeviceAnonymizedRepository
+public enum DeviceChange
 {
+	ADD, RENAME, DELETE
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -1,20 +1,24 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
 
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.entities.UserDevice;
 import nu.yona.server.device.entities.UserDeviceRepository;
+import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.UserService;
 
 @Service
@@ -26,14 +30,65 @@ public class DeviceService
 	@Autowired(required = false)
 	private UserDeviceRepository userDeviceRepository;
 
+	@Autowired(required = false)
+	private DeviceAnonymizedRepository deviceAnonymizedRepository;
+
+	@Transactional
 	public Set<DeviceBaseDto> getDevicesOfUser(UUID userId)
 	{
 		return userService.getUserEntityById(userId).getDevices().stream().map(UserDeviceDto::createInstance)
 				.collect(Collectors.toSet());
 	}
 
+	@Transactional
 	public DeviceBaseDto getDevice(UUID deviceId)
 	{
-		return UserDeviceDto.createInstance(userDeviceRepository.getOne(deviceId));
+		UserDevice deviceEntity = userDeviceRepository.getOne(deviceId);
+		if (deviceEntity == null)
+		{
+			throw DeviceServiceException.notFoundById(deviceId);
+		}
+		return UserDeviceDto.createInstance(deviceEntity);
+	}
+
+	@Transactional
+	public void addDeviceToUser(User userEntity, UserDeviceDto deviceDto)
+	{
+		DeviceAnonymized deviceAnonymized = new DeviceAnonymized(UUID.randomUUID(), findFirstFreeDeviceId(userEntity),
+				deviceDto.getOperatingSystem());
+		deviceAnonymizedRepository.save(deviceAnonymized);
+		userEntity.addDevice(
+				userDeviceRepository.save(new UserDevice(UUID.randomUUID(), deviceDto.getName(), deviceAnonymized.getId())));
+	}
+
+	private int findFirstFreeDeviceId(User userEntity)
+	{
+		Set<Integer> deviceIds = userEntity.getDevices().stream().map(UserDevice::getDeviceAnonymized)
+				.map(DeviceAnonymized::getDeviceId).collect(Collectors.toSet());
+		return IntStream.range(0, deviceIds.size() + 1).filter(i -> !deviceIds.contains(i)).findFirst()
+				.orElseThrow(() -> new IllegalStateException("Should always find a nonexisting ID"));
+	}
+
+	@Transactional
+	public void deleteDevice(User userEntity, UserDevice device)
+	{
+		Set<UserDevice> devices = userEntity.getDevices();
+		if (((devices.size() == 1) && devices.contains(device)))
+		{
+			throw DeviceServiceException.cannotDeleteLastDevice(device.getId());
+		}
+		deleteDeviceEvenIfLastOne(userEntity, device);
+	}
+
+	@Transactional
+	public void deleteDeviceEvenIfLastOne(User userEntity, UserDevice device)
+	{
+		Set<UserDevice> devices = userEntity.getDevices();
+		if (!devices.contains(device))
+		{
+			throw DeviceServiceException.notFoundById(device.getId());
+		}
+		deviceAnonymizedRepository.delete(device.getDeviceAnonymized());
+		userEntity.removeDevice(device);
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
 
@@ -20,7 +20,7 @@ public class DeviceServiceException extends YonaException
 		super(messageId, parameters);
 	}
 
-	protected DeviceServiceException(HttpStatus statusCode, String messageId, Serializable... parameters)
+	private DeviceServiceException(HttpStatus statusCode, String messageId, Serializable... parameters)
 	{
 		super(statusCode, messageId, parameters);
 	}

--- a/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.device.service;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+
+import nu.yona.server.exceptions.YonaException;
+
+public class DeviceServiceException extends YonaException
+{
+	private static final long serialVersionUID = 8798601529916186731L;
+
+	private DeviceServiceException(String messageId, Serializable... parameters)
+	{
+		super(messageId, parameters);
+	}
+
+	protected DeviceServiceException(HttpStatus statusCode, String messageId, Serializable... parameters)
+	{
+		super(statusCode, messageId, parameters);
+	}
+
+	public static DeviceServiceException notFoundById(UUID id)
+	{
+		return new DeviceServiceException(HttpStatus.NOT_FOUND, "error.device.not.found.id", id);
+	}
+
+	public static DeviceServiceException cannotDeleteLastDevice(UUID id)
+	{
+		return new DeviceServiceException("error.device.cannot.delete.last.one", id);
+	}
+}

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -32,6 +32,7 @@ import nu.yona.server.rest.PolymorphicDto;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.BuddyConnectRequestMessageDto;
 import nu.yona.server.subscriptions.service.BuddyConnectResponseMessageDto;
+import nu.yona.server.subscriptions.service.BuddyDeviceChangeMessageDto;
 import nu.yona.server.subscriptions.service.BuddyDisconnectMessageDto;
 import nu.yona.server.subscriptions.service.BuddyDto;
 import nu.yona.server.subscriptions.service.BuddyInfoChangeMessageDto;
@@ -44,6 +45,7 @@ import nu.yona.server.util.TimeUtil;
 		@Type(value = BuddyConnectResponseMessageDto.class, name = "BuddyConnectResponseMessage"),
 		@Type(value = BuddyDisconnectMessageDto.class, name = "BuddyDisconnectMessage"),
 		@Type(value = BuddyInfoChangeMessageDto.class, name = "BuddyInfoChangeMessage"),
+		@Type(value = BuddyDeviceChangeMessageDto.class, name = "BuddyDeviceChangeMessage"),
 		@Type(value = DisclosureRequestMessageDto.class, name = "DisclosureRequestMessage"),
 		@Type(value = DisclosureResponseMessageDto.class, name = "DisclosureResponseMessage"),
 		@Type(value = GoalConflictMessageDto.class, name = "GoalConflictMessage"),

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.entities;
 import java.util.Optional;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
@@ -17,9 +18,8 @@ import nu.yona.server.messaging.entities.BuddyMessage;
 @Entity
 public class BuddyDeviceChangeMessage extends BuddyMessage
 {
-	@Transient
+	@Column(name = "device_change")
 	private DeviceChange change;
-	private byte[] changeCiphertext;
 
 	@Transient
 	private UUID deviceAnonymizedId;
@@ -91,7 +91,6 @@ public class BuddyDeviceChangeMessage extends BuddyMessage
 	public void encrypt()
 	{
 		super.encrypt();
-		changeCiphertext = SecretKeyUtil.encryptString(getChange().toString());
 		oldNameCiphertext = SecretKeyUtil.encryptString(getOldName().orElse(null));
 		newNameCiphertext = SecretKeyUtil.encryptString(getNewName().orElse(null));
 		deviceAnonymizedIdCiphertext = SecretKeyUtil.encryptUuid(getDeviceAnonymizedId());
@@ -101,7 +100,6 @@ public class BuddyDeviceChangeMessage extends BuddyMessage
 	public void decrypt()
 	{
 		super.decrypt();
-		this.change = DeviceChange.valueOf(SecretKeyUtil.decryptString(changeCiphertext));
 		this.oldName = Optional.ofNullable(SecretKeyUtil.decryptString(oldNameCiphertext));
 		this.newName = Optional.ofNullable(SecretKeyUtil.decryptString(newNameCiphertext));
 		this.deviceAnonymizedId = SecretKeyUtil.decryptUuid(deviceAnonymizedIdCiphertext);

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.entities;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+import nu.yona.server.crypto.seckey.SecretKeyUtil;
+import nu.yona.server.device.service.DeviceChange;
+import nu.yona.server.messaging.entities.BuddyMessage;
+
+@Entity
+public class BuddyDeviceChangeMessage extends BuddyMessage
+{
+	@Transient
+	private DeviceChange change;
+	private byte[] changeCiphertext;
+
+	@Transient
+	private UUID deviceAnonymizedId;
+	private byte[] deviceAnonymizedIdCiphertext;
+
+	@Transient
+	private Optional<String> oldName;
+	private byte[] oldNameCiphertext;
+
+	@Transient
+	private Optional<String> newName;
+	private byte[] newNameCiphertext;
+
+	private boolean isProcessed;
+
+	// Default constructor is required for JPA
+	public BuddyDeviceChangeMessage()
+	{
+		super();
+	}
+
+	private BuddyDeviceChangeMessage(BuddyInfoParameters buddyInfoParameters, String messageText, DeviceChange change,
+			UUID deviceAnonymizedId, Optional<String> oldName, Optional<String> newName)
+	{
+		super(buddyInfoParameters, messageText);
+		this.change = change;
+		this.deviceAnonymizedId = deviceAnonymizedId;
+		this.oldName = oldName;
+		this.newName = newName;
+	}
+
+	public static BuddyDeviceChangeMessage createInstance(BuddyInfoParameters buddyInfoParameters, String messageText,
+			DeviceChange change, UUID deviceAnonymizedId, Optional<String> oldName, Optional<String> newName)
+	{
+		return new BuddyDeviceChangeMessage(buddyInfoParameters, messageText, change, deviceAnonymizedId, oldName, newName);
+	}
+
+	public DeviceChange getChange()
+	{
+		return change;
+	}
+
+	public UUID getDeviceAnonymizedId()
+	{
+		return deviceAnonymizedId;
+	}
+
+	public Optional<String> getOldName()
+	{
+		return oldName;
+	}
+
+	public Optional<String> getNewName()
+	{
+		return newName;
+	}
+
+	public boolean isProcessed()
+	{
+		return isProcessed;
+	}
+
+	public void setProcessed()
+	{
+		this.isProcessed = true;
+	}
+
+	@Override
+	public void encrypt()
+	{
+		super.encrypt();
+		changeCiphertext = SecretKeyUtil.encryptString(getChange().toString());
+		oldNameCiphertext = SecretKeyUtil.encryptString(getOldName().orElse(null));
+		newNameCiphertext = SecretKeyUtil.encryptString(getNewName().orElse(null));
+		deviceAnonymizedIdCiphertext = SecretKeyUtil.encryptUuid(getDeviceAnonymizedId());
+	}
+
+	@Override
+	public void decrypt()
+	{
+		super.decrypt();
+		this.change = DeviceChange.valueOf(SecretKeyUtil.decryptString(changeCiphertext));
+		this.oldName = Optional.ofNullable(SecretKeyUtil.decryptString(oldNameCiphertext));
+		this.newName = Optional.ofNullable(SecretKeyUtil.decryptString(newNameCiphertext));
+		this.deviceAnonymizedId = SecretKeyUtil.decryptUuid(deviceAnonymizedIdCiphertext);
+	}
+}

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -25,7 +25,6 @@ import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.exceptions.MobileNumberConfirmationException;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.messaging.entities.MessageDestination;
-import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService;
 import nu.yona.server.util.TimeUtil;
 
 @Entity
@@ -67,6 +66,8 @@ public class User extends EntityWithUuid
 	@OneToOne(fetch = FetchType.LAZY)
 	private MessageDestination messageDestination;
 
+	private static int currentPrivateDataMigrationVersion;
+
 	// Default constructor is required for JPA
 	public User()
 	{
@@ -84,12 +85,25 @@ public class User extends EntityWithUuid
 		this.mobileNumber = mobileNumber;
 		this.setUserPrivate(userPrivate);
 		this.messageDestination = messageDestination;
-		this.privateDataMigrationVersion = PrivateUserDataMigrationService.getCurrentVersion();
+		this.privateDataMigrationVersion = currentPrivateDataMigrationVersion;
 	}
 
 	public static UserRepository getRepository()
 	{
 		return (UserRepository) RepositoryProvider.getRepository(User.class, UUID.class);
+	}
+
+	public static void setCurrentPrivateDataMigrationVersion(int currentPrivateDataMigrationVersion)
+	{
+		User.currentPrivateDataMigrationVersion = currentPrivateDataMigrationVersion;
+	}
+
+	/**
+	 * For testing purposes only.
+	 */
+	static int getCurrentPrivateDataMigrationVersion()
+	{
+		return currentPrivateDataMigrationVersion;
 	}
 
 	public LocalDateTime getCreationTime()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
@@ -64,6 +64,7 @@ public class UserAnonymized extends EntityWithUuid
 		this.anonymousDestination = anonymousDestination;
 		this.goals = new HashSet<>(goals);
 		this.buddiesAnonymized = new HashSet<>();
+		this.devicesAnonymized = new HashSet<>();
 	}
 
 	public static UserAnonymizedRepository getRepository()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -214,6 +214,7 @@ public class UserPrivate extends EntityWithUuidAndTouchVersion
 	{
 		devices.add(device);
 		device.setUserPrivateId(getId());
+		getUserAnonymized().addDeviceAnonymized(device.getDeviceAnonymized());
 	}
 
 	public void removeDevice(UserDevice device)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDto.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.service;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import nu.yona.server.messaging.entities.Message;
+import nu.yona.server.messaging.service.BuddyMessageDto;
+import nu.yona.server.messaging.service.BuddyMessageLinkedUserDto;
+import nu.yona.server.messaging.service.MessageActionDto;
+import nu.yona.server.messaging.service.MessageDto;
+import nu.yona.server.messaging.service.MessageService.TheDtoManager;
+import nu.yona.server.messaging.service.SenderInfo;
+import nu.yona.server.subscriptions.entities.BuddyDeviceChangeMessage;
+
+@JsonRootName("buddyDeviceChangeMessage")
+public class BuddyDeviceChangeMessageDto extends BuddyMessageLinkedUserDto
+{
+	private static final String PROCESS = "process";
+	private final boolean isProcessed;
+
+	private BuddyDeviceChangeMessageDto(long id, LocalDateTime creationTime, boolean isRead, SenderInfo senderInfo,
+			String message, boolean isProcessed)
+	{
+		super(id, creationTime, isRead, senderInfo, message);
+		this.isProcessed = isProcessed;
+	}
+
+	@Override
+	public String getType()
+	{
+		return "BuddyDeviceChangeMessage";
+	}
+
+	@JsonIgnore
+	public boolean isProcessed()
+	{
+		return isProcessed;
+	}
+
+	@Override
+	public Set<String> getPossibleActions()
+	{
+		Set<String> possibleActions = super.getPossibleActions();
+		if (!isProcessed)
+		{
+			possibleActions.add(PROCESS);
+		}
+		return possibleActions;
+	}
+
+	@Override
+	public boolean canBeDeleted()
+	{
+		return this.isProcessed;
+	}
+
+	public static BuddyDeviceChangeMessageDto createInstance(BuddyDeviceChangeMessage messageEntity, SenderInfo senderInfo)
+	{
+		return new BuddyDeviceChangeMessageDto(messageEntity.getId(), messageEntity.getCreationTime(), messageEntity.isRead(),
+				senderInfo, messageEntity.getMessage(), messageEntity.isProcessed());
+	}
+
+	@Component
+	static class Manager extends BuddyMessageDto.Manager
+	{
+		@Autowired
+		private TheDtoManager theDtoFactory;
+
+		@Autowired
+		private BuddyService buddyService;
+
+		@PostConstruct
+		private void init()
+		{
+			theDtoFactory.addManager(BuddyDeviceChangeMessage.class, this);
+		}
+
+		@Override
+		public MessageDto createInstance(UserDto actingUser, Message messageEntity)
+		{
+			return BuddyDeviceChangeMessageDto.createInstance((BuddyDeviceChangeMessage) messageEntity,
+					getSenderInfo(actingUser, messageEntity));
+		}
+
+		@Override
+		public MessageActionDto handleAction(UserDto actingUser, Message messageEntity, String action,
+				MessageActionDto requestPayload)
+		{
+			switch (action)
+			{
+				case PROCESS:
+					return handleAction_Process(actingUser, (BuddyDeviceChangeMessage) messageEntity, requestPayload);
+				default:
+					return super.handleAction(actingUser, messageEntity, action, requestPayload);
+			}
+		}
+
+		private MessageActionDto handleAction_Process(UserDto actingUser, BuddyDeviceChangeMessage messageEntity,
+				MessageActionDto requestPayload)
+		{
+			if (messageEntity.getRelatedUserAnonymizedId().isPresent())
+			{
+				buddyService.processDeviceChange(actingUser.getId(), messageEntity.getRelatedUserAnonymizedId().get(),
+						messageEntity.getChange(), messageEntity.getDeviceAnonymizedId(), messageEntity.getOldName(),
+						messageEntity.getNewName());
+			}
+
+			messageEntity = updateMessageStatusAsProcessed(messageEntity);
+
+			return MessageActionDto.createInstanceActionDone(theDtoFactory.createInstance(actingUser, messageEntity));
+		}
+
+		private BuddyDeviceChangeMessage updateMessageStatusAsProcessed(BuddyDeviceChangeMessage messageEntity)
+		{
+			messageEntity.setProcessed();
+			return Message.getRepository().save(messageEntity);
+		}
+	}
+}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -254,7 +254,7 @@ public class BuddyService
 	@Transactional
 	public void removeBuddyAfterConnectRejection(UUID idOfRequestingUser, UUID buddyId)
 	{
-		User user = userService.getValidatedUserbyId(idOfRequestingUser);
+		User user = userService.getValidatedUserById(idOfRequestingUser);
 		Buddy buddy = buddyRepository.findOne(buddyId);
 
 		if (buddy != null)
@@ -278,7 +278,7 @@ public class BuddyService
 	@Transactional
 	public void removeBuddy(UUID idOfRequestingUser, UUID buddyId, Optional<String> message)
 	{
-		User user = userService.getValidatedUserbyId(idOfRequestingUser);
+		User user = userService.getValidatedUserById(idOfRequestingUser);
 		Buddy buddy = getEntityById(buddyId);
 
 		if (buddy.getSendingStatus() == Status.REQUESTED || buddy.getReceivingStatus() == Status.REQUESTED)
@@ -407,7 +407,7 @@ public class BuddyService
 	@Transactional
 	public void removeBuddyAfterBuddyRemovedConnection(UUID idOfRequestingUser, UUID relatedUserId)
 	{
-		User user = userService.getValidatedUserbyId(idOfRequestingUser);
+		User user = userService.getValidatedUserById(idOfRequestingUser);
 		user.getBuddies().stream().filter(b -> b.getUserId().equals(relatedUserId)).findFirst()
 				.ifPresent(b -> removeBuddy(user, b));
 	}
@@ -692,7 +692,7 @@ public class BuddyService
 	public void updateBuddyUserInfo(UUID idOfRequestingUser, UUID relatedUserAnonymizedId, String buddyNickname,
 			Optional<UUID> buddyUserPhotoId)
 	{
-		User user = userService.getValidatedUserbyId(idOfRequestingUser);
+		User user = userService.getValidatedUserById(idOfRequestingUser);
 		Buddy buddy = user.getBuddyByUserAnonymizedId(relatedUserAnonymizedId);
 
 		buddy.setNickName(buddyNickname);
@@ -712,7 +712,7 @@ public class BuddyService
 	public void processDeviceChange(UUID idOfRequestingUser, UUID relatedUserAnonymizedId, DeviceChange change,
 			UUID deviceAnonymizedId, Optional<String> oldName, Optional<String> newName)
 	{
-		User user = userService.getValidatedUserbyId(idOfRequestingUser);
+		User user = userService.getValidatedUserById(idOfRequestingUser);
 		Buddy buddy = user.getBuddyByUserAnonymizedId(relatedUserAnonymizedId);
 
 		switch (change)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyServiceException.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyServiceException.java
@@ -5,6 +5,7 @@
 package nu.yona.server.subscriptions.service;
 
 import java.io.Serializable;
+import java.util.UUID;
 
 import nu.yona.server.exceptions.YonaException;
 
@@ -65,5 +66,10 @@ public class BuddyServiceException extends YonaException
 	public static BuddyServiceException cannotInviteExistingBuddy()
 	{
 		return new BuddyServiceException("error.buddy.cannot.invite.existing.buddy");
+	}
+
+	public static BuddyServiceException deviceNotFoundByAnonymizedId(UUID buddyId, UUID deviceAnonymizedId)
+	{
+		return new BuddyServiceException("error.buddy.device.not.found.by.anonymized.id", buddyId, deviceAnonymizedId);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
@@ -40,7 +40,7 @@ public class NewDeviceRequestService
 	@Transactional
 	public NewDeviceRequestDto setNewDeviceRequestForUser(UUID userId, String yonaPassword, String newDeviceRequestPassword)
 	{
-		User userEntity = userService.getValidatedUserbyId(userId);
+		User userEntity = userService.getValidatedUserById(userId);
 
 		NewDeviceRequest newDeviceRequestEntity = NewDeviceRequest.createInstance(yonaPassword);
 		newDeviceRequestEntity.encryptYonaPassword(newDeviceRequestPassword);
@@ -56,7 +56,7 @@ public class NewDeviceRequestService
 	@Transactional
 	public NewDeviceRequestDto getNewDeviceRequestForUser(UUID userId, Optional<String> newDeviceRequestPassword)
 	{
-		User userEntity = userService.getValidatedUserbyId(userId);
+		User userEntity = userService.getValidatedUserById(userId);
 		NewDeviceRequest newDeviceRequestEntity = userEntity.getNewDeviceRequest();
 
 		if (newDeviceRequestEntity == null)
@@ -87,7 +87,7 @@ public class NewDeviceRequestService
 	@Transactional
 	public void clearNewDeviceRequestForUser(UUID userId)
 	{
-		User user = userService.getValidatedUserbyId(userId);
+		User user = userService.getValidatedUserById(userId);
 
 		NewDeviceRequest existingNewDeviceRequestEntity = user.getNewDeviceRequest();
 		if (existingNewDeviceRequestEntity != null)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -203,7 +203,7 @@ public class UserService
 	@Transactional
 	public UserDto getPrivateValidatedUser(UUID id)
 	{
-		User validatedUser = getValidatedUserbyId(id);
+		User validatedUser = getValidatedUserById(id);
 		User updatedUser = handlePrivateDataActions(validatedUser);
 		return createUserDtoWithPrivateData(updatedUser);
 	}
@@ -748,7 +748,7 @@ public class UserService
 	 * @param id The id of the user.
 	 * @return The validated user entity. An exception is thrown is something is missing.
 	 */
-	public User getValidatedUserbyId(UUID id)
+	public User getValidatedUserById(UUID id)
 	{
 		User retVal = getUserEntityById(id);
 		retVal.assertMobileNumberConfirmed();

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -5,6 +5,7 @@
 package nu.yona.server.subscriptions.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,10 +36,7 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
 import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.crypto.CryptoUtil;
 import nu.yona.server.crypto.seckey.CryptoSession;
-import nu.yona.server.device.entities.DeviceAnonymized;
-import nu.yona.server.device.entities.DeviceAnonymizedRepository;
-import nu.yona.server.device.entities.UserDevice;
-import nu.yona.server.device.entities.UserDeviceRepository;
+import nu.yona.server.device.service.DeviceService;
 import nu.yona.server.device.service.UserDeviceDto;
 import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.exceptions.MobileNumberConfirmationException;
@@ -106,12 +104,6 @@ public class UserService
 	private ActivityCategoryRepository activityCategoryRepository;
 
 	@Autowired(required = false)
-	private UserDeviceRepository userDeviceRepository;
-
-	@Autowired(required = false)
-	private DeviceAnonymizedRepository deviceAnonymizedRepository;
-
-	@Autowired(required = false)
 	private LDAPUserService ldapUserService;
 
 	@Autowired
@@ -122,6 +114,9 @@ public class UserService
 
 	@Autowired(required = false)
 	private BuddyService buddyService;
+
+	@Autowired(required = false)
+	private DeviceService deviceService;
 
 	@Autowired(required = false)
 	private TransactionHelper transactionHelper;
@@ -289,7 +284,7 @@ public class UserService
 	private void addDevicesToEntity(UserDto userDto, User userEntity)
 	{
 		userDto.getOwnPrivateData().getDevices().orElse(Collections.emptySet()).stream().map(d -> (UserDeviceDto) d)
-				.map(d -> createUserDeviceEntity(d, 0)).forEach(userEntity::addDevice);
+				.forEach(d -> deviceService.addDeviceToUser(userEntity, d));
 	}
 
 	private Set<Goal> buildGoalsSet(UserDto user, UserSignUp signUp)
@@ -305,13 +300,6 @@ public class UserService
 					.collect(Collectors.toSet());
 		}
 		return goals;
-	}
-
-	private UserDevice createUserDeviceEntity(UserDeviceDto deviceDto, int deviceId)
-	{
-		DeviceAnonymized deviceAnonymized = new DeviceAnonymized(UUID.randomUUID(), deviceId, deviceDto.getOperatingSystem());
-		deviceAnonymizedRepository.save(deviceAnonymized);
-		return userDeviceRepository.save(new UserDevice(UUID.randomUUID(), deviceDto.getName(), deviceAnonymized.getId()));
 	}
 
 	private Optional<ConfirmationCode> createConfirmationCodeIfNeeded(Optional<String> overwriteUserConfirmationCode,
@@ -635,7 +623,7 @@ public class UserService
 		allGoalsIncludingHistoryItems.forEach(Goal::removeAllWeekActivities);
 		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
 
-		deleteDevicesAnonymized(updatedUserEntity);
+		new ArrayList<>(userEntity.getDevices()).stream().forEach(d -> deviceService.deleteDeviceEvenIfLastOne(userEntity, d));
 
 		userAnonymizedService.deleteUserAnonymized(userAnonymizedId);
 		userRepository.delete(updatedUserEntity);
@@ -660,11 +648,6 @@ public class UserService
 		List<IntervalActivity> allWeekActivities = allGoalsIncludingHistoryItems.stream()
 				.flatMap(g -> g.getWeekActivities().stream()).collect(Collectors.toList());
 		messageService.deleteMessagesForIntervalActivities(allWeekActivities);
-	}
-
-	private void deleteDevicesAnonymized(User userEntity)
-	{
-		userEntity.getDevices().stream().forEach(d -> deviceAnonymizedRepository.delete(d.getDeviceAnonymized()));
 	}
 
 	private Set<Goal> getAllGoalsIncludingHistoryItems(User userEntity)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.service.migration;
+
+import java.util.Set;
+
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
+
+public class AddFirstDevice implements MigrationStep
+{
+
+	@Override
+	public void upgrade(User user)
+	{
+		Set<UserDevice> devices = user.getDevices();
+		if (devices.isEmpty())
+		{
+			createInitialDevice(user);
+		}
+		else
+		{
+			addDevicesAnonymizedToUserAnonymizedIfNotDoneYet(user);
+		}
+	}
+
+	private void createInitialDevice(User user)
+	{
+		// TODO Auto-generated method stub
+	}
+
+	private void addDevicesAnonymizedToUserAnonymizedIfNotDoneYet(User user)
+	{
+		UserAnonymized userAnonymized = user.getAnonymized();
+		Set<UserDevice> devices = user.getDevices();
+		devices.stream().map(UserDevice::getDeviceAnonymized)
+				.forEach(d -> addDeviceAnonymizedToUserAnonymizedIfNotDoneYet(userAnonymized, d));
+	}
+
+	private void addDeviceAnonymizedToUserAnonymizedIfNotDoneYet(UserAnonymized userAnonymized, DeviceAnonymized deviceAnonimized)
+	{
+		if (!userAnonymized.getDevicesAnonymized().contains(deviceAnonimized))
+		{
+			userAnonymized.addDeviceAnonymized(deviceAnonimized);
+			UserAnonymized.getRepository().save(userAnonymized);
+		}
+	}
+}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
@@ -6,14 +6,23 @@ package nu.yona.server.subscriptions.service.migration;
 
 import java.util.Set;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
 import nu.yona.server.device.entities.DeviceAnonymized;
 import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.device.service.DeviceService;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 
+@Component
+@Order(1) // Never change the order or remove a migration step. If the step is obsolete, make it empty
 public class AddFirstDevice implements MigrationStep
 {
+	@Autowired
+	private DeviceService deviceService;
 
 	@Override
 	public void upgrade(User user)
@@ -31,7 +40,7 @@ public class AddFirstDevice implements MigrationStep
 
 	private void createInitialDevice(User user)
 	{
-		// TODO Auto-generated method stub
+		deviceService.addDeviceToUser(user, deviceService.createDefaultUserDeviceDto());
 	}
 
 	private void addDevicesAnonymizedToUserAnonymizedIfNotDoneYet(User user)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/migration/EncryptBuddyLastStatusChangeTime.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/migration/EncryptBuddyLastStatusChangeTime.java
@@ -4,9 +4,14 @@
  *******************************************************************************/
 package nu.yona.server.subscriptions.service.migration;
 
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService;
 
+@Component
+@Order(0) // Never change the order or remove a migration step. If the step is obsolete, make it empty
 public class EncryptBuddyLastStatusChangeTime implements PrivateUserDataMigrationService.MigrationStep
 {
 	@Override

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -8,9 +8,9 @@
 message.user.account.deleted=User account was deleted
 message.user.removed.buddy=User removed you as a buddy
 message.buddy.user.info.changed=User changed personal info
-message.buddy.device.added=User added a device named {0}
-message.buddy.device.renamed=User renamed device {0} into {1}
-message.buddy.device.deleted=User deleted device {0}
+message.buddy.device.added=User added a device named ''{0}''
+message.buddy.device.renamed=User renamed device ''{0}'' into ''{1}''
+message.buddy.device.deleted=User deleted device ''{0}''
 
 # Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -8,6 +8,9 @@
 message.user.account.deleted=User account was deleted
 message.user.removed.buddy=User removed you as a buddy
 message.buddy.user.info.changed=User changed personal info
+message.buddy.device.added=User added a device named {0}
+message.buddy.device.renamed=User renamed device {0} into {1}
+message.buddy.device.deleted=User deleted device {0}
 
 # Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}
@@ -77,6 +80,7 @@ error.buddy.accepting.user.is.null=The accepting user cannot be null
 error.buddy.request.must.contain.user.inside.embedded=The buddy resource must contain a ''{0}'' entity inside _embedded
 error.buddy.cannot.invite.self=Cannot yourself as a buddy
 error.buddy.cannot.invite.existing.buddy=Cannot invite someone who is already a buddy
+error.buddy.device.not.found.by.anonymized.id=Buddy with ID ''{0}'' does not have a device related to the device anonymized ID ''{1}''
 
 error.activity.date.goal.mismatch=At {1}, user with ID ''{0}'' did not have a goal with ID ''{2}''
 error.activity.buddy.day.activity.not.found=Buddy ''{1}'' of user with ID ''{0}'' does not have activity on date ''{2}'' for goal with ID ''{3}''

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -102,6 +102,8 @@ error.device.request.expired=New device request expired for mobile number ''{0}'
 error.device.request.invalid.password=Invalid temporary password to use new device request for mobile number ''{0}''. Maybe the request was replaced with a different secret?
 error.device.unknown.operating.system=Operating system ''{0}'' is not supported.
 error.device.invalid.device.name=Device name ''{0}'' is invalid. A valid device name is not longer than {1} characters and does not contain a ''{2}''.
+error.device.not.found.id=Device with ID ''{0}'' not found.
+error.device.cannot.delete.last.one=Cannot delete the last device. Device ID: ''{0}''
 
 error.message.not.found=Message with ID ''{0}'' not found
 error.message.no.dto.manager.registered=No DTO manager registered for class ''{0}''

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -102,6 +102,8 @@ error.device.request.expired=Het ''new device request'' voor gebruiker met ID ''
 error.device.request.invalid.password=Het tijdelijke wachtwoord voor het ''new device request'' is ongeldig. Is het verzoek misschien vervangen door een ander?
 error.device.unknown.operating.system=Besturingssysteem ''{0}'' wordt niet ondersteund.
 error.device.invalid.device.name=De apparaatnaam ''{0}'' is niet toegestaan. Een geldige apparaatnaam is niet langer dan {1} tekens en bevat geen ''{2}''.
+error.device.not.found.id=Apparaat met ID ''{0}'' niet gevonden.
+error.device.cannot.delete.last.one=Kan laatste apparaat niet verwijderen. Apparaat ID: ''{0}''
 
 
 error.message.not.found=Bericht met ID ''{0}'' niet gevonden

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -8,6 +8,9 @@
 message.user.account.deleted=Gebruikersaccount verwijderd
 message.user.removed.buddy=De gebruiker heeft je 'ontvriend'
 message.buddy.user.info.changed=De gebruiker heeft zijn persoonlijke gegevens aangepast
+message.buddy.device.added=De gebruiker heeft een nieuw apparaat met met de naam {0} toegevoegd
+message.buddy.device.renamed=De gebruiker heeft het apparaat met met de naam {0} hernoemd naar {1}
+message.buddy.device.deleted=De gebruiker heeft het apparaat met met de naam {0} verwijderd
 
 # Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}
@@ -77,6 +80,7 @@ error.buddy.accepting.user.is.null=De accepterende gebruiker mag niet null zijn
 error.buddy.request.must.contain.user.inside.embedded=De buddy resource moet in de _embedded een ''{0}'' entity bevatten
 error.buddy.cannot.invite.self=Je kunt jezelf niet als vriend uitnodigen
 error.buddy.cannot.invite.existing.buddy=Iemand die al een vriend is kan je niet opnieuw uitnodigen
+error.buddy.device.not.found.by.anonymized.id=Vriend met ID ''{0}'' heeft geen apparaat gerelateerd aan device anonymized ID ''{1}''
 
 error.activity.date.goal.mismatch=Op {1} had de gebruiker met ID ''{0}'' geen challenge met ID ''{2}''
 error.activity.buddy.day.activity.not.found=Vriend ''{1}'' van gebruiker met ID ''{0}'' heeft op ''{2}'' geen activiteiten voor doel ''{3}''

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -8,9 +8,9 @@
 message.user.account.deleted=Gebruikersaccount verwijderd
 message.user.removed.buddy=De gebruiker heeft je 'ontvriend'
 message.buddy.user.info.changed=De gebruiker heeft zijn persoonlijke gegevens aangepast
-message.buddy.device.added=De gebruiker heeft een nieuw apparaat met met de naam {0} toegevoegd
-message.buddy.device.renamed=De gebruiker heeft het apparaat met met de naam {0} hernoemd naar {1}
-message.buddy.device.deleted=De gebruiker heeft het apparaat met met de naam {0} verwijderd
+message.buddy.device.added=De gebruiker heeft een nieuw apparaat met met de naam ''{0}'' toegevoegd
+message.buddy.device.renamed=De gebruiker heeft het apparaat met met de naam ''{0}'' hernoemd naar ''{1}''
+message.buddy.device.deleted=De gebruiker heeft het apparaat met met de naam ''{0}'' verwijderd
 
 # Temporary nickname is based on firstName and lastName
 message.temp.nickname={0} {1}

--- a/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
@@ -152,9 +152,6 @@ public class ActivityServiceTest
 		when(mockGoalService.getGoalEntityForUserAnonymizedId(userAnonId, gamingGoal.getId())).thenReturn(gamingGoal);
 		when(mockGoalService.getGoalEntityForUserAnonymizedId(userAnonId, socialGoal.getId())).thenReturn(socialGoal);
 		when(mockGoalService.getGoalEntityForUserAnonymizedId(userAnonId, shoppingGoal.getId())).thenReturn(shoppingGoal);
-
-		JUnitUtil.setUpRepositoryMock(mockDayActivityRepository);
-		JUnitUtil.setUpRepositoryMock(mockWeekActivityRepository);
 	}
 
 	private Map<Locale, String> usString(String string)
@@ -177,16 +174,15 @@ public class ActivityServiceTest
 				yesterday.plusHours(21).plusMinutes(00).toLocalDateTime(), Optional.empty());
 		yesterdayRecordedActivity.addActivity(recordedActivity);
 		Set<UUID> relevantGoalIds = userAnonEntity.getGoals().stream().map(Goal::getId).collect(Collectors.toSet());
-		when(mockDayActivityRepository.findAll(userAnonId, relevantGoalIds,
-				today.minusDays(2).toLocalDate(), today.plusDays(1).toLocalDate()))
-						.thenReturn(Arrays.asList(yesterdayRecordedActivity));
+		when(mockDayActivityRepository.findAll(userAnonId, relevantGoalIds, today.minusDays(2).toLocalDate(),
+				today.plusDays(1).toLocalDate())).thenReturn(Arrays.asList(yesterdayRecordedActivity));
 
 		Page<DayActivityOverviewDto<DayActivityDto>> dayOverviews = service.getUserDayActivityOverviews(userId,
 				new PageRequest(0, 3));
 
 		// assert that the right retrieve from database was done
-		verify(mockDayActivityRepository, times(1)).findAll(userAnonId, relevantGoalIds,
-				today.minusDays(2).toLocalDate(), today.plusDays(1).toLocalDate());
+		verify(mockDayActivityRepository, times(1)).findAll(userAnonId, relevantGoalIds, today.minusDays(2).toLocalDate(),
+				today.plusDays(1).toLocalDate());
 
 		// because the gambling goal was added with creation date two weeks ago, there are multiple days, equal to the limit of
 		// our page request = 3

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -124,6 +124,7 @@ public class DeviceServiceTest
 		JUnitUtil.setUpRepositoryMock(mockUserRepository);
 
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(User.class, mockUserRepository);
 		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -1,0 +1,376 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.device.service;
+
+import static com.spencerwi.hamcrestJDK8Time.matchers.IsBetween.between;
+import static nu.yona.server.test.util.Matchers.hasMessageId;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.repository.Repository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import nu.yona.server.Translator;
+import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
+import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.device.entities.UserDeviceRepository;
+import nu.yona.server.entities.MockJpaRepositoryEntityWithUuid;
+import nu.yona.server.messaging.entities.MessageSource;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.UserPrivate;
+import nu.yona.server.subscriptions.entities.UserRepository;
+import nu.yona.server.test.util.CryptoSessionRule;
+import nu.yona.server.test.util.JUnitUtil;
+import nu.yona.server.util.TimeUtil;
+
+@Configuration
+@ComponentScan(useDefaultFilters = false, basePackages = { "nu.yona.server.device.service",
+		"nu.yona.server.properties" }, includeFilters = {
+				@ComponentScan.Filter(pattern = "nu.yona.server.device.service.DeviceService", type = FilterType.REGEX),
+				@ComponentScan.Filter(pattern = "nu.yona.server.properties.YonaProperties", type = FilterType.REGEX) })
+class DeviceServiceTestConfiguration
+{
+	@Bean
+	DeviceAnonymizedRepository getMockDeviceAnonymizedRepository()
+	{
+		return new DeviceAnonymizedRepositoryMock();
+	}
+
+	@Bean
+	UserAnonymizedRepository getMockUserAnonymizedRepository()
+	{
+		return new UserAnonymizedRepositoryMock();
+	}
+
+	private static class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
+			implements DeviceAnonymizedRepository
+	{
+	}
+
+	private static class UserAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<UserAnonymized>
+			implements UserAnonymizedRepository
+	{
+
+		@Override
+		public int countByLastMonitoredActivityDateBetween(LocalDate startDate, LocalDate endDate)
+		{
+			throw new NotImplementedException();
+		}
+
+		@Override
+		public int countByLastMonitoredActivityDateIsNull()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { DeviceServiceTestConfiguration.class })
+public class DeviceServiceTest
+{
+	@MockBean
+	private UserDeviceRepository mockUserDeviceRepository;
+
+	@Autowired
+	private DeviceService service;
+
+	@Autowired
+	private DeviceAnonymizedRepository deviceAnonymizedRepository;
+
+	@Autowired
+	private UserAnonymizedRepository userAnonymizedRepository;
+
+	@MockBean
+	private UserRepository mockUserRepository;
+
+	private static final String PASSWORD = "password";
+	private User john;
+
+	@Rule
+	public MethodRule cryptoSession = new CryptoSessionRule(PASSWORD);
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Before
+	public void setUpForAll()
+	{
+		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
+	}
+
+	@Before
+	public void setUpPerTest()
+	{
+		deviceAnonymizedRepository.deleteAll();
+		userAnonymizedRepository.deleteAll();
+		JUnitUtil.setUpRepositoryMock(mockUserDeviceRepository);
+		JUnitUtil.setUpRepositoryMock(mockUserRepository);
+
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
+		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
+		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
+
+		MessageSource anonymousMessageSource = MessageSource.createInstance();
+		UserAnonymized johnAnonymized = UserAnonymized.createInstance(anonymousMessageSource.getDestination(),
+				Collections.emptySet());
+		UserAnonymized.getRepository().save(johnAnonymized);
+
+		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
+		{
+			byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
+			MessageSource namedMessageSource = MessageSource.createInstance();
+			UserPrivate userPrivate = UserPrivate.createInstance("jd", "topSecret", johnAnonymized.getId(),
+					anonymousMessageSource.getId(), namedMessageSource);
+			john = new User(UUID.randomUUID(), initializationVector, "John", "Doe", "+31612345678", userPrivate,
+					namedMessageSource.getDestination());
+		}
+
+		when(mockUserRepository.findOne(john.getId())).thenReturn(john);
+	}
+
+	@Test
+	public void getDevice_tryGetNonExistingDevice_exception() throws Exception
+	{
+		expectedException.expect(DeviceServiceException.class);
+		expectedException.expect(hasMessageId("error.device.not.found.id"));
+		service.getDevice(UUID.randomUUID());
+	}
+
+	@Test
+	public void addDeviceToUser_addFirstDevice_userHasOneDevice()
+	{
+		String deviceName = "Testing";
+		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
+		LocalDateTime startTime = TimeUtil.utcNow();
+		UserDeviceDto deviceDto = new UserDeviceDto(deviceName, operatingSystem);
+		service.addDeviceToUser(john, deviceDto);
+
+		verify(mockUserDeviceRepository, times(1)).save(any(UserDevice.class));
+		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+
+		UserDevice device = devices.iterator().next();
+		assertDevice(device, startTime, deviceName, operatingSystem, 0);
+	}
+
+	@Test
+	public void addDeviceToUser_addSecondDevice_userHasTwoDevices()
+	{
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		LocalDateTime startTime = TimeUtil.utcNow();
+		UserDeviceDto deviceDto1 = new UserDeviceDto(deviceName1, operatingSystem1);
+		service.addDeviceToUser(john, deviceDto1);
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName2, operatingSystem2);
+		service.addDeviceToUser(john, deviceDto2);
+
+		verify(mockUserDeviceRepository, times(2)).save(any(UserDevice.class));
+		assertThat(deviceAnonymizedRepository.count(), equalTo(2L));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(2));
+
+		Optional<UserDevice> device1Optional = devices.stream().filter(d -> d.getName().equals(deviceName1)).findAny();
+		assertThat(device1Optional.isPresent(), equalTo(true));
+		UserDevice device1 = device1Optional.get();
+		assertDevice(device1, startTime, deviceName1, operatingSystem1, 0);
+
+		Optional<UserDevice> device2Optional = devices.stream().filter(d -> d.getName().equals(deviceName2)).findAny();
+		assertThat(device2Optional.isPresent(), equalTo(true));
+		UserDevice device2 = device2Optional.get();
+		assertDevice(device2, startTime, deviceName2, operatingSystem2, 1);
+	}
+
+	@Test
+	public void deleteDevice_deleteOneOfTwo_userHasOneDevice()
+	{
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		LocalDateTime startTime = TimeUtil.utcNow();
+		UserDeviceDto deviceDto1 = new UserDeviceDto(deviceName1, operatingSystem1);
+		service.addDeviceToUser(john, deviceDto1);
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName2, operatingSystem2);
+		service.addDeviceToUser(john, deviceDto2);
+
+		verify(mockUserDeviceRepository, times(2)).save(any(UserDevice.class));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(2));
+
+		Optional<UserDevice> device1Optional = devices.stream().filter(d -> d.getName().equals(deviceName1)).findAny();
+		assertThat(device1Optional.isPresent(), equalTo(true));
+		UserDevice device1 = device1Optional.get();
+		assertDevice(device1, startTime, deviceName1, operatingSystem1, 0);
+
+		service.deleteDevice(john, device1);
+		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
+
+		devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+
+		UserDevice device2 = devices.iterator().next();
+		assertDevice(device2, startTime, deviceName2, operatingSystem2, 1);
+	}
+
+	@Test
+	public void addDeviceToUser_addAfterDelete_deviceIdReused()
+	{
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		LocalDateTime startTime = TimeUtil.utcNow();
+		UserDeviceDto deviceDto1 = new UserDeviceDto(deviceName1, operatingSystem1);
+		service.addDeviceToUser(john, deviceDto1);
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName2, operatingSystem2);
+		service.addDeviceToUser(john, deviceDto2);
+
+		verify(mockUserDeviceRepository, times(2)).save(any(UserDevice.class));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(2));
+
+		Optional<UserDevice> device1Optional = devices.stream().filter(d -> d.getName().equals(deviceName1)).findAny();
+		assertThat(device1Optional.isPresent(), equalTo(true));
+		UserDevice device1 = device1Optional.get();
+
+		service.deleteDevice(john, device1);
+		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
+
+		devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+
+		String deviceName3 = "Third";
+		OperatingSystem operatingSystem3 = OperatingSystem.IOS;
+		UserDeviceDto deviceDto3 = new UserDeviceDto(deviceName3, operatingSystem3);
+		service.addDeviceToUser(john, deviceDto3);
+
+		devices = john.getDevices();
+		assertThat(devices.size(), equalTo(2));
+
+		Optional<UserDevice> device2Optional = devices.stream().filter(d -> d.getName().equals(deviceName2)).findAny();
+		assertThat(device2Optional.isPresent(), equalTo(true));
+		UserDevice device2 = device2Optional.get();
+		assertDevice(device2, startTime, deviceName2, operatingSystem2, 1);
+
+		Optional<UserDevice> device3Optional = devices.stream().filter(d -> d.getName().equals(deviceName3)).findAny();
+		assertThat(device3Optional.isPresent(), equalTo(true));
+		UserDevice device3 = device3Optional.get();
+		assertDevice(device3, startTime, deviceName3, operatingSystem3, 0);
+	}
+
+	@Test
+	public void deleteDevice_tryDeleteOneAndOnlyDevice_exception() throws Exception
+	{
+		expectedException.expect(DeviceServiceException.class);
+		expectedException.expect(hasMessageId("error.device.cannot.delete.last.one"));
+		String deviceName = "Testing";
+		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
+		UserDeviceDto deviceDto = new UserDeviceDto(deviceName, operatingSystem);
+		service.addDeviceToUser(john, deviceDto);
+
+		verify(mockUserDeviceRepository, times(1)).save(any(UserDevice.class));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+
+		UserDevice device = devices.iterator().next();
+
+		service.deleteDevice(john, device);
+	}
+
+	@Test
+	public void deleteDevice_tryDeleteNonExistingDevice_exception() throws Exception
+	{
+		expectedException.expect(DeviceServiceException.class);
+		expectedException.expect(hasMessageId("error.device.not.found.id"));
+
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		LocalDateTime startTime = TimeUtil.utcNow();
+		UserDeviceDto deviceDto1 = new UserDeviceDto(deviceName1, operatingSystem1);
+		service.addDeviceToUser(john, deviceDto1);
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName2, operatingSystem2);
+		service.addDeviceToUser(john, deviceDto2);
+
+		verify(mockUserDeviceRepository, times(2)).save(any(UserDevice.class));
+
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(2));
+
+		Optional<UserDevice> device1Optional = devices.stream().filter(d -> d.getName().equals(deviceName1)).findAny();
+		assertThat(device1Optional.isPresent(), equalTo(true));
+		UserDevice device1 = device1Optional.get();
+		assertDevice(device1, startTime, deviceName1, operatingSystem1, 0);
+
+		service.deleteDevice(john, device1);
+		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
+
+		service.deleteDevice(john, device1);
+	}
+
+	private void assertDevice(UserDevice device, LocalDateTime startTime, String expectedDeviceName,
+			OperatingSystem expectedOperatingSystem, int expectedDeviceId)
+	{
+		assertThat(device.getName(), equalTo(expectedDeviceName));
+		assertThat(device.getAppLastOpenedDate(), equalTo(TimeUtil.utcNow().toLocalDate()));
+		assertThat(device.getRegistrationTime(), is(between(startTime, TimeUtil.utcNow())));
+		assertThat(device.isVpnConnected(), equalTo(true));
+
+		DeviceAnonymized deviceAnonymized = device.getDeviceAnonymized();
+		assertThat(deviceAnonymized.getOperatingSystem(), equalTo(expectedOperatingSystem));
+		assertThat(deviceAnonymized.getLastMonitoredActivityDate().isPresent(), equalTo(false));
+		assertThat(deviceAnonymized.getDeviceId(), equalTo(expectedDeviceId));
+		assertThat(deviceAnonymized.getUserAnonymized().getId(), equalTo(john.getAnonymized().getId()));
+	}
+}

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -14,17 +14,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,15 +43,14 @@ import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.device.entities.DeviceAnonymized;
 import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
+import nu.yona.server.entities.DeviceAnonymizedRepositoryMock;
+import nu.yona.server.entities.UserAnonymizedRepositoryMock;
 import nu.yona.server.device.entities.DeviceAnonymizedRepository;
 import nu.yona.server.device.entities.UserDevice;
 import nu.yona.server.device.entities.UserDeviceRepository;
-import nu.yona.server.entities.MockJpaRepositoryEntityWithUuid;
-import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
-import nu.yona.server.subscriptions.entities.UserPrivate;
 import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.test.util.CryptoSessionRule;
 import nu.yona.server.test.util.JUnitUtil;
@@ -76,28 +73,6 @@ class DeviceServiceTestConfiguration
 	UserAnonymizedRepository getMockUserAnonymizedRepository()
 	{
 		return new UserAnonymizedRepositoryMock();
-	}
-
-	private static class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
-			implements DeviceAnonymizedRepository
-	{
-	}
-
-	private static class UserAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<UserAnonymized>
-			implements UserAnonymizedRepository
-	{
-
-		@Override
-		public int countByLastMonitoredActivityDateBetween(LocalDate startDate, LocalDate endDate)
-		{
-			throw new NotImplementedException();
-		}
-
-		@Override
-		public int countByLastMonitoredActivityDateIsNull()
-		{
-			throw new NotImplementedException();
-		}
 	}
 }
 
@@ -129,8 +104,8 @@ public class DeviceServiceTest
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 
-	@Before
-	public void setUpForAll()
+	@BeforeClass
+	public static void setUpForAll()
 	{
 		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
 	}
@@ -148,19 +123,9 @@ public class DeviceServiceTest
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
 
-		MessageSource anonymousMessageSource = MessageSource.createInstance();
-		UserAnonymized johnAnonymized = UserAnonymized.createInstance(anonymousMessageSource.getDestination(),
-				Collections.emptySet());
-		UserAnonymized.getRepository().save(johnAnonymized);
-
 		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
 		{
-			byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
-			MessageSource namedMessageSource = MessageSource.createInstance();
-			UserPrivate userPrivate = UserPrivate.createInstance("jd", "topSecret", johnAnonymized.getId(),
-					anonymousMessageSource.getId(), namedMessageSource);
-			john = new User(UUID.randomUUID(), initializationVector, "John", "Doe", "+31612345678", userPrivate,
-					namedMessageSource.getDestination());
+			john = JUnitUtil.createUserEntity();
 		}
 
 		when(mockUserRepository.findOne(john.getId())).thenReturn(john);

--- a/core/src/test/java/nu/yona/server/entities/BuddyAnonymizedRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/BuddyAnonymizedRepositoryMock.java
@@ -7,10 +7,10 @@
  *******************************************************************************/
 package nu.yona.server.entities;
 
-import nu.yona.server.device.entities.DeviceAnonymized;
-import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.BuddyAnonymized;
+import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
 
-public class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
-		implements DeviceAnonymizedRepository
+public class BuddyAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<BuddyAnonymized>
+		implements BuddyAnonymizedRepository
 {
 }

--- a/core/src/test/java/nu/yona/server/entities/DeviceAnonymizedRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/DeviceAnonymizedRepositoryMock.java
@@ -1,0 +1,9 @@
+package nu.yona.server.entities;
+
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+
+public class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
+		implements DeviceAnonymizedRepository
+{
+}

--- a/core/src/test/java/nu/yona/server/entities/MockCrudRepositoryEntityWithUuid.java
+++ b/core/src/test/java/nu/yona/server/entities/MockCrudRepositoryEntityWithUuid.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.entities;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+
+import nu.yona.server.entities.EntityWithUuid;
+
+public class MockCrudRepositoryEntityWithUuid<T extends EntityWithUuid> implements CrudRepository<T, UUID>
+{
+	private Map<UUID, T> entities = new HashMap<>();
+
+	@Override
+	public <S extends T> S save(S entity)
+	{
+		entities.put(entity.getId(), entity);
+		return entity;
+	}
+
+	@Override
+	public <S extends T> Iterable<S> save(Iterable<S> entities)
+	{
+		for (S entity : entities)
+		{
+			save(entity);
+		}
+		return entities;
+	}
+
+	@Override
+	public T findOne(UUID id)
+	{
+		return entities.get(id);
+	}
+
+	@Override
+	public boolean exists(UUID id)
+	{
+		return entities.containsKey(id);
+	}
+
+	@Override
+	public Iterable<T> findAll()
+	{
+		return entities.values();
+	}
+
+	@Override
+	public Iterable<T> findAll(Iterable<UUID> ids)
+	{
+		List<T> matchingEntities = new ArrayList<>();
+		for (UUID id : ids)
+		{
+			T entity = entities.get(id);
+			if (entity != null)
+			{
+				matchingEntities.add(entity);
+			}
+		}
+		return matchingEntities;
+	}
+
+	@Override
+	public long count()
+	{
+		return entities.size();
+	}
+
+	@Override
+	public void delete(UUID id)
+	{
+		entities.remove(id);
+	}
+
+	@Override
+	public void delete(T entity)
+	{
+		delete(entity.getId());
+	}
+
+	@Override
+	public void delete(Iterable<? extends T> entities)
+	{
+		for (T entity : entities)
+		{
+			delete(entity);
+		}
+	}
+
+	@Override
+	public void deleteAll()
+	{
+		entities.clear();
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/MockJpaRepositoryEntityWithUuid.java
+++ b/core/src/test/java/nu/yona/server/entities/MockJpaRepositoryEntityWithUuid.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.google.common.collect.Lists;
+
+public class MockJpaRepositoryEntityWithUuid<T extends EntityWithUuid> extends MockCrudRepositoryEntityWithUuid<T>
+		implements JpaRepository<T, UUID>
+{
+	@Override
+	public Page<T> findAll(Pageable pageable)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public <S extends T> S findOne(Example<S> example)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public <S extends T> Page<S> findAll(Example<S> example, Pageable pageable)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public <S extends T> long count(Example<S> example)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public <S extends T> boolean exists(Example<S> example)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public List<T> findAll()
+	{
+		return Lists.newArrayList(super.findAll());
+	}
+
+	@Override
+	public List<T> findAll(Sort sort)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public List<T> findAll(Iterable<UUID> ids)
+	{
+		return new ArrayList<>(findAll(ids));
+	}
+
+	@Override
+	public <S extends T> List<S> save(Iterable<S> entities)
+	{
+		return new ArrayList<>(save(entities));
+	}
+
+	@Override
+	public void flush()
+	{
+		// No-op
+	}
+
+	@Override
+	public <S extends T> S saveAndFlush(S entity)
+	{
+		return save(entity);
+	}
+
+	@Override
+	public void deleteInBatch(Iterable<T> entities)
+	{
+		delete(entities);
+	}
+
+	@Override
+	public void deleteAllInBatch()
+	{
+		deleteAll();
+	}
+
+	@Override
+	public T getOne(UUID id)
+	{
+		T entity = findOne(id);
+		if (entity == null)
+		{
+			throw new javax.persistence.EntityNotFoundException("ID " + id + " not found");
+		}
+		return entity;
+	}
+
+	@Override
+	public <S extends T> List<S> findAll(Example<S> example)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public <S extends T> List<S> findAll(Example<S> example, Sort sort)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/MockJpaRepositoryEntityWithUuid.java
+++ b/core/src/test/java/nu/yona/server/entities/MockJpaRepositoryEntityWithUuid.java
@@ -1,9 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.entities;
 
@@ -68,7 +65,12 @@ public class MockJpaRepositoryEntityWithUuid<T extends EntityWithUuid> extends M
 	@Override
 	public List<T> findAll(Iterable<UUID> ids)
 	{
-		return new ArrayList<>(findAll(ids));
+		List<T> retVal = new ArrayList<>();
+		for (T entity : super.findAll(ids))
+		{
+			retVal.add(entity);
+		}
+		return retVal;
 	}
 
 	@Override

--- a/core/src/test/java/nu/yona/server/entities/UserAnonymizedRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserAnonymizedRepositoryMock.java
@@ -1,0 +1,25 @@
+package nu.yona.server.entities;
+
+import java.time.LocalDate;
+
+import org.apache.commons.lang.NotImplementedException;
+
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+
+public class UserAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<UserAnonymized>
+		implements UserAnonymizedRepository
+{
+
+	@Override
+	public int countByLastMonitoredActivityDateBetween(LocalDate startDate, LocalDate endDate)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByLastMonitoredActivityDateIsNull()
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/UserAnonymizedRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserAnonymizedRepositoryMock.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
 package nu.yona.server.entities;
 
 import java.time.LocalDate;

--- a/core/src/test/java/nu/yona/server/entities/UserDeviceRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserDeviceRepositoryMock.java
@@ -7,10 +7,9 @@
  *******************************************************************************/
 package nu.yona.server.entities;
 
-import nu.yona.server.device.entities.DeviceAnonymized;
-import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.device.entities.UserDeviceRepository;
 
-public class DeviceAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<DeviceAnonymized>
-		implements DeviceAnonymizedRepository
+public class UserDeviceRepositoryMock extends MockJpaRepositoryEntityWithUuid<UserDevice> implements UserDeviceRepository
 {
 }

--- a/core/src/test/java/nu/yona/server/entities/UserRepositoriesConfiguration.java
+++ b/core/src/test/java/nu/yona/server/entities/UserRepositoriesConfiguration.java
@@ -1,0 +1,22 @@
+package nu.yona.server.entities;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.UserRepository;
+
+public class UserRepositoriesConfiguration
+{
+	@Bean
+	UserRepository getMockUserRepository()
+	{
+		return Mockito.spy(new UserRepositoryMock());
+	}
+
+	@Bean
+	UserAnonymizedRepository getMockUserAnonymizedRepository()
+	{
+		return Mockito.spy(new UserAnonymizedRepositoryMock());
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.entities;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import org.apache.commons.lang.NotImplementedException;
+
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserRepository;
+
+public class UserRepositoryMock extends MockJpaRepositoryEntityWithUuid<User> implements UserRepository
+{
+
+	@Override
+	public User findByMobileNumber(String mobileNumber)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByAppLastOpenedDateBetween(LocalDate startDate, LocalDate endDate)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByAppLastOpenedDateIsNull()
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByMobileNumberConfirmationCodeIsNull()
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByMobileNumberConfirmationCodeIsNotNull()
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public int countByMobileNumberConfirmationCodeIsNotNullAndIsCreatedOnBuddyRequest(boolean isCreatedOnBuddyRequest)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public Set<User> findAllWithExpiredNewDeviceRequests(LocalDateTime cuttOffDate)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.messaging.entities.MessageSource;
-import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService;
 
 public class UserTest
 {
@@ -37,6 +36,6 @@ public class UserTest
 	@Test
 	public void getPrivateDataMigrationVersion_newUser_returnsCurrentVersion()
 	{
-		assertThat(john.getPrivateDataMigrationVersion(), equalTo(PrivateUserDataMigrationService.getCurrentVersion()));
+		assertThat(john.getPrivateDataMigrationVersion(), equalTo(User.getCurrentPrivateDataMigrationVersion()));
 	}
 }

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
@@ -189,6 +189,7 @@ public class BuddyDeviceChangeMessageDtoTest
 		JUnitUtil.setUpRepositoryMock(mockMessageRepository);
 
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(User.class, userRepository);
 		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		repositoriesMap.put(BuddyAnonymized.class, buddyAnonymizedRepository);
@@ -200,8 +201,6 @@ public class BuddyDeviceChangeMessageDtoTest
 			richard = JUnitUtil.createRichard();
 			bob = JUnitUtil.createBob();
 			JUnitUtil.makeBuddies(richard, bob);
-			userRepository.save(richard);
-			userRepository.save(bob);
 		}
 	}
 

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
@@ -58,7 +58,6 @@ import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
 import nu.yona.server.subscriptions.entities.BuddyDeviceChangeMessage;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.CryptoSessionRule;
 import nu.yona.server.test.util.JUnitUtil;
@@ -159,8 +158,6 @@ public class BuddyDeviceChangeMessageDtoTest extends BaseSpringIntegrationTest
 	protected Map<Class<?>, Repository<?, ?>> getRepositories()
 	{
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
-		repositoriesMap.put(User.class, userRepository);
-		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		repositoriesMap.put(BuddyAnonymized.class, buddyAnonymizedRepository);
 		repositoriesMap.put(Message.class, mockMessageRepository);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
@@ -14,35 +14,27 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.repository.Repository;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.CryptoSession;
-import nu.yona.server.entities.UserAnonymizedRepositoryMock;
-import nu.yona.server.entities.UserRepositoryMock;
+import nu.yona.server.entities.UserRepositoriesConfiguration;
 import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.messaging.entities.MessageSourceRepository;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserAnonymized;
-import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
-import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
+import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.JUnitUtil;
 
 @Configuration
@@ -53,19 +45,8 @@ import nu.yona.server.test.util.JUnitUtil;
 				@ComponentScan.Filter(pattern = "nu.yona.server.properties.YonaProperties", type = FilterType.REGEX),
 				@ComponentScan.Filter(pattern = "nu.yona.server.subscriptions.service.MockMigrationStep1", type = FilterType.REGEX),
 				@ComponentScan.Filter(pattern = "nu.yona.server.subscriptions.service.MockMigrationStep2", type = FilterType.REGEX) })
-class PrivateUserDataMigrationServiceIntegrationTestConfiguration
+class PrivateUserDataMigrationServiceIntegrationTestConfiguration extends UserRepositoriesConfiguration
 {
-	@Bean
-	UserRepository getMockUserRepository()
-	{
-		return Mockito.spy(new UserRepositoryMock());
-	}
-
-	@Bean
-	UserAnonymizedRepository getMockUserAnonymizedRepository()
-	{
-		return new UserAnonymizedRepositoryMock();
-	}
 }
 
 @Component
@@ -92,19 +73,13 @@ class MockMigrationStep2 implements MigrationStep
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { PrivateUserDataMigrationServiceIntegrationTestConfiguration.class })
-public class PrivateUserDataMigrationServiceIntegrationTest
+public class PrivateUserDataMigrationServiceIntegrationTest extends BaseSpringIntegrationTest
 {
 	@MockBean
 	private BuddyService buddyService;
 
-	@Autowired
-	private UserRepository userRepository;
-
 	@MockBean
 	private MessageSourceRepository mockMessageSourceRepository;
-
-	@Autowired
-	private UserAnonymizedRepository userAnonymizedRepository;
 
 	@Autowired
 	private PrivateUserDataMigrationService service;
@@ -115,30 +90,22 @@ public class PrivateUserDataMigrationServiceIntegrationTest
 	private final String password = "password";
 	private User richard;
 
-	@BeforeClass
-	public static void setUpForAll()
-	{
-		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
-	}
-
 	@Before
 	public void setUpPerTest()
 	{
-		userAnonymizedRepository.deleteAll();
-		userRepository.deleteAll();
-		JUnitUtil.setUpRepositoryMock(mockMessageSourceRepository);
-
-		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
-		repositoriesMap.put(User.class, userRepository);
-		repositoriesMap.put(MessageSource.class, mockMessageSourceRepository);
-		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
-		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
-
 		try (CryptoSession cryptoSession = CryptoSession.start(password))
 		{
 			richard = JUnitUtil.createRichard();
 		}
 		reset(userRepository);
+	}
+
+	@Override
+	protected Map<Class<?>, Repository<?, ?>> getRepositories()
+	{
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(MessageSource.class, mockMessageSourceRepository);
+		return repositoriesMap;
 	}
 
 	@Test

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -11,12 +11,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,6 @@ import nu.yona.server.messaging.entities.MessageSourceRepository;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
-import nu.yona.server.subscriptions.entities.UserPrivate;
 import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.subscriptions.service.UserService.UserPurpose;
 import nu.yona.server.test.util.JUnitUtil;
@@ -67,11 +65,11 @@ public class UserServiceTest
 	@Autowired
 	private UserService service;
 
-	private final String password = "password";
+	private static final String PASSWORD = "password";
 	private User john;
 
-	@Before
-	public void setUpForAll()
+	@BeforeClass
+	public static void setUpForAll()
 	{
 		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
 	}
@@ -88,19 +86,9 @@ public class UserServiceTest
 		repositoriesMap.put(UserAnonymized.class, mockUserAnonymizedRepository);
 		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
 
-		MessageSource anonymousMessageSource = MessageSource.createInstance();
-		UserAnonymized johnAnonymized = UserAnonymized.createInstance(anonymousMessageSource.getDestination(),
-				Collections.emptySet());
-		UserAnonymized.getRepository().save(johnAnonymized);
-
-		try (CryptoSession cryptoSession = CryptoSession.start(password))
+		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
 		{
-			byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
-			MessageSource namedMessageSource = MessageSource.createInstance();
-			UserPrivate userPrivate = UserPrivate.createInstance("jd", "topSecret", johnAnonymized.getId(),
-					anonymousMessageSource.getId(), namedMessageSource);
-			john = new User(UUID.randomUUID(), initializationVector, "John", "Doe", "+31612345678", userPrivate,
-					namedMessageSource.getDestination());
+			john = JUnitUtil.createUserEntity();
 		}
 
 		when(mockUserRepository.findOne(john.getId())).thenReturn(john);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -66,7 +66,7 @@ public class UserServiceTest
 	private UserService service;
 
 	private static final String PASSWORD = "password";
-	private User john;
+	private User richard;
 
 	@BeforeClass
 	public static void setUpForAll()
@@ -88,29 +88,29 @@ public class UserServiceTest
 
 		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
 		{
-			john = JUnitUtil.createUserEntity();
+			richard = JUnitUtil.createRichard();
 		}
 
-		when(mockUserRepository.findOne(john.getId())).thenReturn(john);
+		when(mockUserRepository.findOne(richard.getId())).thenReturn(richard);
 	}
 
 	@Test
 	public void postOpenAppEvent_appLastOpenedDateOnEarlierDay_appLastOpenedDateUpdated()
 	{
-		john.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate().minusDays(1));
+		richard.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate().minusDays(1));
 
-		service.postOpenAppEvent(john.getId());
+		service.postOpenAppEvent(richard.getId());
 
-		assertThat(john.getAppLastOpenedDate().get(), equalTo(TimeUtil.utcNow().toLocalDate()));
+		assertThat(richard.getAppLastOpenedDate().get(), equalTo(TimeUtil.utcNow().toLocalDate()));
 		verify(mockUserRepository, times(1)).save(any(User.class));
 	}
 
 	@Test
 	public void postOpenAppEvent_appLastOpenedDateOnSameDay_notUpdated()
 	{
-		john.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate());
+		richard.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate());
 
-		service.postOpenAppEvent(john.getId());
+		service.postOpenAppEvent(richard.getId());
 
 		verify(mockUserRepository, times(0)).save(any(User.class));
 	}

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.service;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -83,6 +84,7 @@ public class UserServiceTest
 
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
 		repositoriesMap.put(MessageSource.class, mockMessageSourceRepository);
+		repositoriesMap.put(User.class, mockUserRepository);
 		repositoriesMap.put(UserAnonymized.class, mockUserAnonymizedRepository);
 		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
 
@@ -90,7 +92,7 @@ public class UserServiceTest
 		{
 			richard = JUnitUtil.createRichard();
 		}
-
+		reset(mockUserRepository);
 		when(mockUserRepository.findOne(richard.getId())).thenReturn(richard);
 	}
 

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -10,13 +10,11 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,20 +22,17 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.data.repository.Repository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.entities.UserRepositoriesConfiguration;
 import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.messaging.entities.MessageSourceRepository;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserAnonymized;
-import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
-import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.subscriptions.service.UserService.UserPurpose;
+import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.JUnitUtil;
 import nu.yona.server.util.TimeUtil;
 
@@ -46,22 +41,16 @@ import nu.yona.server.util.TimeUtil;
 		"nu.yona.server.properties" }, includeFilters = {
 				@ComponentScan.Filter(pattern = "nu.yona.server.subscriptions.service.UserService", type = FilterType.REGEX),
 				@ComponentScan.Filter(pattern = "nu.yona.server.properties.YonaProperties", type = FilterType.REGEX) })
-class UserServiceTestConfiguration
+class UserServiceTestConfiguration extends UserRepositoriesConfiguration
 {
 }
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { UserServiceTestConfiguration.class })
-public class UserServiceTest
+public class UserServiceTest extends BaseSpringIntegrationTest
 {
 	@MockBean
-	private UserRepository mockUserRepository;
-
-	@MockBean
 	private MessageSourceRepository mockMessageSourceRepository;
-
-	@MockBean
-	private UserAnonymizedRepository mockUserAnonymizedRepository;
 
 	@Autowired
 	private UserService service;
@@ -69,31 +58,22 @@ public class UserServiceTest
 	private static final String PASSWORD = "password";
 	private User richard;
 
-	@BeforeClass
-	public static void setUpForAll()
-	{
-		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
-	}
-
 	@Before
 	public void setUpPerTest()
 	{
-		JUnitUtil.setUpRepositoryMock(mockUserRepository);
-		JUnitUtil.setUpRepositoryMock(mockMessageSourceRepository);
-		JUnitUtil.setUpRepositoryMock(mockUserAnonymizedRepository);
-
-		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
-		repositoriesMap.put(MessageSource.class, mockMessageSourceRepository);
-		repositoriesMap.put(User.class, mockUserRepository);
-		repositoriesMap.put(UserAnonymized.class, mockUserAnonymizedRepository);
-		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
-
 		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
 		{
 			richard = JUnitUtil.createRichard();
 		}
-		reset(mockUserRepository);
-		when(mockUserRepository.findOne(richard.getId())).thenReturn(richard);
+		reset(userRepository);
+	}
+
+	@Override
+	protected Map<Class<?>, Repository<?, ?>> getRepositories()
+	{
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(MessageSource.class, mockMessageSourceRepository);
+		return repositoriesMap;
 	}
 
 	@Test
@@ -104,7 +84,7 @@ public class UserServiceTest
 		service.postOpenAppEvent(richard.getId());
 
 		assertThat(richard.getAppLastOpenedDate().get(), equalTo(TimeUtil.utcNow().toLocalDate()));
-		verify(mockUserRepository, times(1)).save(any(User.class));
+		verify(userRepository, times(1)).save(any(User.class));
 	}
 
 	@Test
@@ -114,7 +94,7 @@ public class UserServiceTest
 
 		service.postOpenAppEvent(richard.getId());
 
-		verify(mockUserRepository, times(0)).save(any(User.class));
+		verify(userRepository, times(0)).save(any(User.class));
 	}
 
 	@Test

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -46,14 +46,15 @@ import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.device.entities.DeviceAnonymized;
 import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
-import nu.yona.server.device.service.DeviceChange;
 import nu.yona.server.device.entities.DeviceAnonymizedRepository;
 import nu.yona.server.device.entities.UserDevice;
 import nu.yona.server.device.entities.UserDeviceRepository;
+import nu.yona.server.device.service.DeviceChange;
 import nu.yona.server.entities.BuddyAnonymizedRepositoryMock;
 import nu.yona.server.entities.DeviceAnonymizedRepositoryMock;
 import nu.yona.server.entities.UserAnonymizedRepositoryMock;
 import nu.yona.server.entities.UserDeviceRepositoryMock;
+import nu.yona.server.entities.UserRepositoryMock;
 import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized;
@@ -62,6 +63,7 @@ import nu.yona.server.subscriptions.entities.BuddyDeviceChangeMessage;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
 import nu.yona.server.test.util.CryptoSessionRule;
@@ -86,6 +88,12 @@ class AddFirstDeviceIntegrationTestConfiguration
 	UserAnonymizedRepository getMockUserAnonymizedRepository()
 	{
 		return new UserAnonymizedRepositoryMock();
+	}
+
+	@Bean
+	UserRepository getMockUserRepository()
+	{
+		return new UserRepositoryMock();
 	}
 
 	@Bean
@@ -114,6 +122,9 @@ public class AddFirstDeviceTest
 	private static final String PASSWORD = "password";
 	private User richard;
 	private User bob;
+
+	@Autowired
+	private UserRepository userRepository;
 
 	@Autowired
 	private UserAnonymizedRepository userAnonymizedRepository;
@@ -149,11 +160,13 @@ public class AddFirstDeviceTest
 	public void setUpPerTest() throws Exception
 	{
 		MockitoAnnotations.initMocks(this);
+		userRepository.deleteAll();
 		userAnonymizedRepository.deleteAll();
 		userDeviceRepository.deleteAll();
 		deviceAnonymizedRepository.deleteAll();
 		buddyAnonymizedRepository.deleteAll();
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(User.class, userRepository);
 		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		repositoriesMap.put(BuddyAnonymized.class, buddyAnonymizedRepository);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -56,7 +56,6 @@ import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
 import nu.yona.server.subscriptions.entities.BuddyDeviceChangeMessage;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
@@ -138,8 +137,6 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 	protected Map<Class<?>, Repository<?, ?>> getRepositories()
 	{
 		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
-		repositoriesMap.put(User.class, userRepository);
-		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
 		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
 		repositoriesMap.put(BuddyAnonymized.class, buddyAnonymizedRepository);
 		return repositoriesMap;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.service.migration;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.repository.Repository;
+
+import nu.yona.server.Translator;
+import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
+import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.entities.DeviceAnonymizedRepositoryMock;
+import nu.yona.server.entities.UserAnonymizedRepositoryMock;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
+import nu.yona.server.test.util.CryptoSessionRule;
+import nu.yona.server.test.util.JUnitUtil;
+
+public class AddFirstDeviceTest
+{
+	private static final String PASSWORD = "password";
+	private User john;
+
+	private UserAnonymizedRepository userAnonymizedRepository = new UserAnonymizedRepositoryMock();
+	private DeviceAnonymizedRepository deviceAnonymizedRepository = new DeviceAnonymizedRepositoryMock();
+
+	private MigrationStep migrationStep = new AddFirstDevice();
+
+	@Rule
+	public MethodRule cryptoSession = new CryptoSessionRule(PASSWORD);
+
+	@BeforeClass
+	public static void setUpForAll()
+	{
+		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
+	}
+
+	@Before
+	public void setUpPerTest() throws Exception
+	{
+		userAnonymizedRepository.deleteAll();
+		deviceAnonymizedRepository.deleteAll();
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
+		repositoriesMap.put(DeviceAnonymized.class, deviceAnonymizedRepository);
+		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
+
+		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
+		{
+			john = JUnitUtil.createUserEntity();
+		}
+
+	}
+
+	@Test
+	public void upgrade_addDeviceAnonymizedToUserAnonymized_linkEstablished()
+	{
+		// Add device
+		String deviceName = "Testing";
+		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
+		DeviceAnonymized deviceAnonymized = new DeviceAnonymized(UUID.randomUUID(), 0, operatingSystem);
+		deviceAnonymizedRepository.save(deviceAnonymized);
+		UserDevice device = new UserDevice(UUID.randomUUID(), deviceName, deviceAnonymized.getId());
+		john.addDevice(device);
+
+		// Verify device is present
+		Set<UserDevice> devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+
+		// Remove all devices from user anonymized
+		new ArrayList<>(john.getAnonymized().getDevicesAnonymized()).forEach(d -> john.getAnonymized().removeDeviceAnonymized(d));
+		assertThat(john.getAnonymized().getDevicesAnonymized().size(), equalTo(0));
+
+		// Verify they're gone
+		devices = john.getDevices();
+		UserDevice deviceToBeMigrated = devices.iterator().next();
+		assertThat(deviceToBeMigrated.getDeviceAnonymized().getUserAnonymized(), nullValue());
+		assertThat(john.getAnonymized().getDevicesAnonymized().size(), equalTo(0));
+
+		// Migrate and assert success
+		migrationStep.upgrade(john);
+		devices = john.getDevices();
+		assertThat(devices.size(), equalTo(1));
+		UserDevice deviceAsMigrated = devices.iterator().next();
+		assertThat(deviceAsMigrated.getDeviceAnonymized().getUserAnonymized(), notNullValue());
+		assertThat(john.getAnonymized().getDevicesAnonymized().size(), equalTo(1));
+		assertThat(john.getAnonymized().getDevicesAnonymized().contains(deviceAnonymized), equalTo(true));
+	}
+}

--- a/core/src/test/java/nu/yona/server/test/util/BaseSpringIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/test/util/BaseSpringIntegrationTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.test.util;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.mockito.MockingDetails;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import nu.yona.server.Translator;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.UserRepository;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public abstract class BaseSpringIntegrationTest
+{
+	@Autowired
+	protected UserRepository userRepository;
+
+	@Autowired
+	protected UserAnonymizedRepository userAnonymizedRepository;
+
+	@BeforeClass
+	public static void setUpForAll()
+	{
+		LocaleContextHolder.setLocale(Translator.EN_US_LOCALE);
+	}
+
+	@Before
+	public final void setUpPerTestBase()
+	{
+		MockitoAnnotations.initMocks(this);
+
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(User.class, userRepository);
+		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
+		repositoriesMap.putAll(getRepositories());
+		Set<CrudRepository<?, ?>> crudRepositories = filterForCrudRepositories(repositoriesMap.values());
+		crudRepositories.forEach(CrudRepository::deleteAll);
+		crudRepositories.stream().filter(this::isMock).forEach(r -> JUnitUtil.setUpRepositoryMock(r));
+		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
+	}
+
+	private Set<CrudRepository<?, ?>> filterForCrudRepositories(Collection<Repository<?, ?>> values)
+	{
+		return values.stream().filter(r -> r instanceof CrudRepository).map(r -> (CrudRepository<?, ?>) r)
+				.collect(Collectors.toSet());
+	}
+
+	private boolean isMock(Object objectoInspect)
+	{
+		MockingDetails mockingDetails = Mockito.mockingDetails(objectoInspect);
+		return mockingDetails.isMock() && !mockingDetails.isSpy();
+	}
+
+	protected abstract Map<Class<?>, Repository<?, ?>> getRepositories();
+}

--- a/core/src/test/java/nu/yona/server/test/util/CryptoSessionRule.java
+++ b/core/src/test/java/nu/yona/server/test/util/CryptoSessionRule.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.test.util;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import nu.yona.server.crypto.seckey.CryptoSession;
+
+/**
+ * This JUnit rule executes each test inside a CryptoSession with the given password.
+ */
+public class CryptoSessionRule implements MethodRule
+{
+	private String password;
+
+	public CryptoSessionRule(String password)
+	{
+		this.password = password;
+	}
+
+	@Override
+	public Statement apply(Statement base, FrameworkMethod method, Object target)
+	{
+		return new Statement() {
+			@Override
+			public void evaluate() throws Throwable
+			{
+				try (CryptoSession cryptoSession = CryptoSession.start(password))
+				{
+					base.evaluate();
+				}
+			}
+		};
+	}
+}

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -23,6 +23,8 @@ import org.springframework.data.repository.support.Repositories;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.messaging.entities.MessageSource;
+import nu.yona.server.subscriptions.entities.Buddy;
+import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 import nu.yona.server.subscriptions.entities.UserPrivate;
@@ -70,9 +72,14 @@ public class JUnitUtil
 		return mockRepositories;
 	}
 
-	public static User createUserEntity()
+	public static User createRichard()
 	{
-		return createUserEntity("John", "Doe", "+31612345678", "jd", "topSecret");
+		return createUserEntity("Richard", "Quinn", "+31610000000", "RQ", "topSecret");
+	}
+
+	public static User createBob()
+	{
+		return createUserEntity("Bob", "Dunn", "+31610000001", "BD", "heelGeheim");
 	}
 
 	public static User createUserEntity(String firstName, String lastName, String mobileNumber, String nickname,
@@ -89,6 +96,18 @@ public class JUnitUtil
 				anonymousMessageSource.getId(), namedMessageSource);
 		return new User(UUID.randomUUID(), initializationVector, firstName, lastName, mobileNumber, userPrivate,
 				namedMessageSource.getDestination());
+	}
 
+	public static void makeBuddies(User user, User buddyToBe)
+	{
+		addAsBuddy(user, buddyToBe);
+		addAsBuddy(buddyToBe, user);
+	}
+
+	private static void addAsBuddy(User user, User buddyToBe)
+	{
+		Buddy buddy = Buddy.createInstance(buddyToBe.getId(), buddyToBe.getNickname(), Status.ACCEPTED, Status.ACCEPTED);
+		buddy.setUserAnonymizedId(buddyToBe.getAnonymized().getId());
+		user.addBuddy(buddy);
 	}
 }

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -94,8 +94,9 @@ public class JUnitUtil
 		MessageSource namedMessageSource = MessageSource.createInstance();
 		UserPrivate userPrivate = UserPrivate.createInstance(nickname, vpnPassword, johnAnonymized.getId(),
 				anonymousMessageSource.getId(), namedMessageSource);
-		return new User(UUID.randomUUID(), initializationVector, firstName, lastName, mobileNumber, userPrivate,
-				namedMessageSource.getDestination());
+		User user = new User(UUID.randomUUID(), initializationVector, firstName, lastName, mobileNumber,
+				userPrivate, namedMessageSource.getDestination());
+		return User.getRepository().save(user);
 	}
 
 	public static void makeBuddies(User user, User buddyToBe)

--- a/core/src/test/java/nu/yona/server/test/util/Matchers.java
+++ b/core/src/test/java/nu/yona/server/test/util/Matchers.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.test.util;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import nu.yona.server.exceptions.ResourceBasedException;
+
+public class Matchers
+{
+	private Matchers()
+	{
+		// No instances
+	}
+
+	public static Matcher<ResourceBasedException> hasMessageId(String messageId)
+	{
+		return new BaseMatcher<ResourceBasedException>() {
+			@Override
+			public boolean matches(Object item)
+			{
+				final ResourceBasedException exception = (ResourceBasedException) item;
+				return exception.getMessageId().equals(messageId);
+			}
+
+			@Override
+			public void describeTo(final Description description)
+			{
+				description.appendText("message ID should be ").appendValue(messageId);
+			}
+		};
+	}
+
+}

--- a/dbinit/src/main/liquibase/updates/changelog-0010-yd-499.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0010-yd-499.yml
@@ -6,8 +6,8 @@ databaseChangeLog:
     - addColumn:
         columns:
         - column:
-            name: change_ciphertext
-            type: tinyblob
+            name: device_change
+            type: INT
         tableName: messages
 - changeSet:
     id: 1513023183603-2

--- a/dbinit/src/main/liquibase/updates/changelog-0010-yd-499.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0010-yd-499.yml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+- changeSet:
+    id: 1513023183603-1
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: change_ciphertext
+            type: tinyblob
+        tableName: messages
+- changeSet:
+    id: 1513023183603-2
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: device_anonymized_id_ciphertext
+            type: tinyblob
+        tableName: messages
+- changeSet:
+    id: 1513023183603-3
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: new_name_ciphertext
+            type: tinyblob
+        tableName: messages
+- changeSet:
+    id: 1513023183603-4
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: old_name_ciphertext
+            type: tinyblob
+        tableName: messages

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0009-yd-495.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0010-yd-499.yml


### PR DESCRIPTION
Along with this corrected an earlier bug (user and device anonymized weren't linked).

This functionality is covered with Spring migration tests. Considerably enhanced our Spring JUnit integration test utilities.