### PR TITLE
YD-523 Ignore network activity if app not opened

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -101,6 +101,12 @@ public class AnalysisEngineService
 	public void analyze(UUID userAnonymizedId, NetworkActivityDto networkActivity)
 	{
 		UserAnonymizedDto userAnonymized = userAnonymizedService.getUserAnonymized(userAnonymizedId);
+		if (userAnonymized.getDevicesAnonymized().isEmpty())
+		{
+			// User did not open the app yet, so the migration step did not add the default device
+			// Ignore the network activities till the user opened the app
+			return;
+		}
 		Set<ActivityCategoryDto> matchingActivityCategories = activityCategoryFilterService
 				.getMatchingCategoriesForSmoothwallCategories(networkActivity.getCategories());
 		UUID deviceAnonymizedId = deviceService.getDeviceAnonymizedId(userAnonymized, networkActivity.getDeviceIndex());

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -852,7 +852,7 @@ public class AnalysisEngineServiceTest
 
 	private NetworkActivityDto createNetworkActivityForCategories(String... conflictCategories)
 	{
-		return new NetworkActivityDto(-1, new HashSet<>(Arrays.asList(conflictCategories)),
+		return new NetworkActivityDto(new HashSet<>(Arrays.asList(conflictCategories)),
 				"http://localhost/test" + new Random().nextInt(), Optional.empty());
 	}
 

--- a/core/src/main/java/nu/yona/server/analysis/service/NetworkActivityDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/NetworkActivityDto.java
@@ -30,15 +30,15 @@ public class NetworkActivityDto
 	private final Set<String> categories;
 	private final String url;
 	private final Optional<ZonedDateTime> eventTime;
-	private final int deviceIndex;
+	private int deviceIndex;
 
 	@JsonCreator
-	public NetworkActivityDto(@JsonProperty(value = "deviceIndex", defaultValue = "-1") int deviceIdx,
+	public NetworkActivityDto(
 			@JsonProperty("categories") @JsonDeserialize(as = TreeSet.class, contentAs = String.class) Set<String> categories,
 			@JsonProperty("url") String url,
 			@JsonFormat(pattern = Constants.ISO_DATE_TIME_PATTERN) @JsonProperty("eventTime") Optional<ZonedDateTime> eventTime)
 	{
-		this.deviceIndex = deviceIdx;
+		this.deviceIndex = -1;
 		this.categories = categories;
 		this.url = (url.length() > MAX_SUPPORTED_URL_LENGTH) ? url.substring(0, MAX_SUPPORTED_URL_LENGTH) : url;
 		this.eventTime = eventTime;
@@ -47,6 +47,14 @@ public class NetworkActivityDto
 	public int getDeviceIndex()
 	{
 		return deviceIndex;
+	}
+
+	/**
+	 * Till the Perl script passes a device index, this property is treated as optional and thus not set through the constructor.
+	 */
+	public void setDeviceIndex(int deviceIndex)
+	{
+		this.deviceIndex = deviceIndex;
 	}
 
 	public Set<String> getCategories()


### PR DESCRIPTION
If the user has an "old account", without device and they did not open the Yona app yet after the migration step to add a device was introduced, they still do not have a device. In such a scenario, we now ignore the app activities till they opened the app and with that got a device registered.

Along with this addressed an issue with the default value of the device index in the NetworkActivityDto.