### PR TITLE
YD-524 Correct user entity locking and remove superfluous devices

### DIFF
--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
@@ -185,6 +185,12 @@ public class UserController extends ControllerBase
 				UserDto user = userService.getPrivateUser(userId, isCreatedOnBuddyRequest);
 				Optional<UUID> requestingDeviceId = determineRequestingDeviceId(user, requestingDeviceIdStr,
 						isCreatedOnBuddyRequest);
+				if (requestingDeviceId.isPresent() && user.getOwnPrivateData().getDevices().map(d -> d.size() > 1).orElse(false))
+				{
+					// User has multiple devices
+					deviceService.removeDuplicateDefaultDevices(user, requestingDeviceId.get());
+					user = userService.getPrivateUser(userId, isCreatedOnBuddyRequest);
+				}
 				return createOkResponse(user, createResourceAssemblerForOwnUser(requestingUserId, requestingDeviceId));
 			}
 			return createOkResponse(buddyService.getUserOfBuddy(requestingUserId, userId),

--- a/core/src/main/java/nu/yona/server/analysis/entities/Activity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/Activity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
@@ -138,6 +138,11 @@ public class Activity extends EntityWithId
 	public DeviceAnonymized getDeviceAnonymized()
 	{
 		return deviceAnonymized;
+	}
+
+	public void setDeviceAnonymized(DeviceAnonymized deviceAnonymized)
+	{
+		this.deviceAnonymized = Objects.requireNonNull(deviceAnonymized);
 	}
 
 	@Override

--- a/core/src/main/java/nu/yona/server/analysis/entities/ActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/ActivityRepository.java
@@ -1,17 +1,20 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import nu.yona.server.device.entities.DeviceAnonymized;
 
 @Repository
 public interface ActivityRepository extends CrudRepository<Activity, Long>
@@ -24,4 +27,6 @@ public interface ActivityRepository extends CrudRepository<Activity, Long>
 	List<Activity> findOverlappingOfSameApp(@Param("dayActivity") DayActivity dayActivity,
 			@Param("deviceAnonymizedId") UUID deviceAnonymizedId, @Param("activityCategoryId") UUID activityCategoryId,
 			@Param("app") String app, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+
+	Set<Activity> findByDeviceAnonymized(DeviceAnonymized deviceAnonymized);
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
@@ -29,6 +30,7 @@ import nu.yona.server.util.TimeUtil;
 
 @Entity
 @Table(name = "USERS")
+@EntityListeners(UserLockChecker.class)
 public class User extends EntityWithUuid
 {
 	private int privateDataMigrationVersion;

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserLockChecker.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserLockChecker.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.entities;
+
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PreUpdate;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserLockChecker
+{
+	private static EntityManager entityManager;
+
+	@PersistenceContext
+	public void setEntityManager(EntityManager entityManager)
+	{
+		UserLockChecker.entityManager = entityManager;
+	}
+
+	@PreUpdate
+	void onPreUpdate(User user)
+	{
+		LockModeType lockMode = entityManager.getLockMode(user);
+		if (lockMode != LockModeType.PESSIMISTIC_WRITE)
+		{
+			throw new IllegalStateException("Invalid lock mode: " + lockMode);
+		}
+	}
+}

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserRepository.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserRepository.java
@@ -9,12 +9,19 @@ import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, UUID>
 {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select u from User u where u.id = :id")
+	User findOneForUpdate(@Param("id") UUID id);
+
 	User findByMobileNumber(String mobileNumber);
 
 	int countByAppLastOpenedDateBetween(LocalDate startDate, LocalDate endDate);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -254,7 +254,7 @@ public class BuddyService
 	@Transactional
 	public void removeBuddyAfterConnectRejection(UUID idOfRequestingUser, UUID buddyId)
 	{
-		userService.getValidatedUserById(idOfRequestingUser);
+		userService.assertValidatedUser(userService.getUserEntityById(idOfRequestingUser));
 		Buddy buddy = buddyRepository.findOne(buddyId);
 
 		if (buddy != null)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -254,25 +254,26 @@ public class BuddyService
 	@Transactional
 	public void removeBuddyAfterConnectRejection(UUID idOfRequestingUser, UUID buddyId)
 	{
-		User user = userService.getValidatedUserById(idOfRequestingUser);
+		userService.getValidatedUserById(idOfRequestingUser);
 		Buddy buddy = buddyRepository.findOne(buddyId);
 
 		if (buddy != null)
 		{
-			removeBuddy(user, buddy);
+			removeBuddy(idOfRequestingUser, buddy);
 		}
 		// else: buddy already removed, probably in response to removing the user
 	}
 
-	private void removeBuddy(User user, Buddy buddy)
+	private void removeBuddy(UUID userId, Buddy buddy)
 	{
-		user.removeBuddy(buddy);
-		User.getRepository().save(user);
-		buddyRepository.delete(buddy);
+		userService.updateUser(userId, user -> {
+			user.removeBuddy(buddy);
+			buddyRepository.delete(buddy);
 
-		UserAnonymized userAnonymizedEntity = user.getAnonymized();
-		userAnonymizedEntity.removeBuddyAnonymized(buddy.getBuddyAnonymized());
-		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
+			UserAnonymized userAnonymizedEntity = user.getAnonymized();
+			userAnonymizedEntity.removeBuddyAnonymized(buddy.getBuddyAnonymized());
+			userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
+		});
 	}
 
 	@Transactional
@@ -290,7 +291,7 @@ public class BuddyService
 		removeMessagesSentByBuddy(user, buddy);
 		removeBuddyInfoForBuddy(user, buddy, message, DropBuddyReason.USER_REMOVED_BUDDY);
 
-		removeBuddy(user, buddy);
+		removeBuddy(user.getId(), buddy);
 
 		User buddyUser = buddy.getUser();
 		if (buddyUser == null)
@@ -395,7 +396,7 @@ public class BuddyService
 					user.getUserAnonymizedId(), buddy.getId(), user.getDevices(), Status.REJECTED,
 					getDropBuddyMessage(DropBuddyReason.USER_ACCOUNT_DELETED, Optional.empty()));
 		}
-		removeBuddy(user, buddy);
+		removeBuddy(user.getId(), buddy);
 	}
 
 	private UUID getUserAnonymizedIdForBuddy(Buddy buddy)
@@ -409,7 +410,7 @@ public class BuddyService
 	{
 		User user = userService.getValidatedUserById(idOfRequestingUser);
 		user.getBuddies().stream().filter(b -> b.getUserId().equals(relatedUserId)).findFirst()
-				.ifPresent(b -> removeBuddy(user, b));
+				.ifPresent(b -> removeBuddy(user.getId(), b));
 	}
 
 	public void setBuddyAcceptedWithSecretUserInfo(UserDto actingUser, BuddyConnectResponseMessage connectResponseMessageEntity)

--- a/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
@@ -40,8 +40,8 @@ public class NewDeviceRequestService
 	@Transactional
 	public NewDeviceRequestDto setNewDeviceRequestForUser(UUID userId, String yonaPassword, String newDeviceRequestPassword)
 	{
-		userService.updateUser(userId, ue -> {
-			User userEntity = userService.getValidatedUserById(ue.getId());
+		userService.updateUser(userId, userEntity -> {
+			userService.assertValidatedUser(userEntity);
 
 			NewDeviceRequest newDeviceRequestEntity = NewDeviceRequest.createInstance(yonaPassword);
 			newDeviceRequestEntity.encryptYonaPassword(newDeviceRequestPassword);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
@@ -182,15 +182,13 @@ public class UserDto
 				+ ((privateData == null) ? "is null" : " is of type " + privateData.getClass().getName()));
 	}
 
-	User updateUser(User originalUserEntity)
+	void updateUser(User originalUserEntity)
 	{
 		originalUserEntity.setFirstName(firstName);
 		originalUserEntity.setLastName(lastName);
 		originalUserEntity.setMobileNumber(mobileNumber);
 		originalUserEntity.setNickname(privateData.getNickname());
 		originalUserEntity.setUserPhotoId(privateData.getUserPhotoId());
-
-		return originalUserEntity;
 	}
 
 	/**

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
+import javax.persistence.LockModeType;
 import javax.transaction.Transactional;
 
 import org.apache.commons.lang.StringUtils;
@@ -63,7 +64,6 @@ import nu.yona.server.subscriptions.entities.UserPrivate;
 import nu.yona.server.subscriptions.entities.UserRepository;
 import nu.yona.server.subscriptions.service.BuddyService.DropBuddyReason;
 import nu.yona.server.util.TimeUtil;
-import nu.yona.server.util.TransactionHelper;
 
 @Service
 public class UserService
@@ -117,9 +117,6 @@ public class UserService
 
 	@Autowired(required = false)
 	private DeviceService deviceService;
-
-	@Autowired(required = false)
-	private TransactionHelper transactionHelper;
 
 	@Autowired(required = false)
 	private UserAnonymizedService userAnonymizedService;
@@ -214,8 +211,7 @@ public class UserService
 
 		if (!privateUserDataMigrationService.isUpToDate(user))
 		{
-			privateUserDataMigrationService.upgrade(user);
-			return userRepository.save(user);
+			updateUser(user.getId(), privateUserDataMigrationService::upgrade);
 		}
 
 		return user;
@@ -224,24 +220,22 @@ public class UserService
 	@Transactional
 	public void setOverwriteUserConfirmationCode(String mobileNumber)
 	{
-		User existingUserEntity = findUserByMobileNumber(mobileNumber);
-		ConfirmationCode confirmationCode = createConfirmationCode();
-		existingUserEntity.setOverwriteUserConfirmationCode(confirmationCode);
-		userRepository.save(existingUserEntity);
-		sendConfirmationCodeTextMessage(mobileNumber, confirmationCode, SmsTemplate.OVERWRITE_USER_CONFIRMATION);
-		logger.info("User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code",
-				existingUserEntity.getMobileNumber(), existingUserEntity.getId());
+		updateUser(findUserByMobileNumber(mobileNumber).getId(), existingUserEntity -> {
+			ConfirmationCode confirmationCode = createConfirmationCode();
+			existingUserEntity.setOverwriteUserConfirmationCode(confirmationCode);
+			sendConfirmationCodeTextMessage(mobileNumber, confirmationCode, SmsTemplate.OVERWRITE_USER_CONFIRMATION);
+			logger.info("User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code",
+					existingUserEntity.getMobileNumber(), existingUserEntity.getId());
+		});
 	}
 
-	@Transactional
+	@Transactional(dontRollbackOn = UserOverwriteConfirmationException.class)
 	public UserDto addUser(UserDto user, Optional<String> overwriteUserConfirmationCode)
 	{
 		assert user.getPrivateData().getDevices().orElse(Collections.emptySet()).size() == 1;
 		assertValidUserFields(user, UserPurpose.USER);
 
-		// use a separate transaction because in the top transaction we insert a user with the same unique key
-		transactionHelper.executeInNewTransaction(
-				() -> handleExistingUserForMobileNumber(user.getMobileNumber(), overwriteUserConfirmationCode));
+		handleExistingUserForMobileNumber(user.getMobileNumber(), overwriteUserConfirmationCode);
 
 		User userEntity = createUserEntity(user, UserSignUp.FREE);
 		addDevicesToEntity(user, userEntity);
@@ -406,60 +400,61 @@ public class UserService
 		// because the anonymized data cannot be retrieved
 		// (the relation is encrypted, the password is not available)
 		userRepository.delete(existingUserEntity);
+		userRepository.flush(); // So we can insert another one
 		logger.info("User with mobile number '{}' and ID '{}' removed, to overwrite the account",
 				existingUserEntity.getMobileNumber(), existingUserEntity.getId());
 	}
 
-	@Transactional
+	@Transactional(dontRollbackOn = MobileNumberConfirmationException.class)
 	public UserDto confirmMobileNumber(UUID userId, String userProvidedConfirmationCode)
 	{
-		User userEntity = getUserEntityById(userId);
-		ConfirmationCode confirmationCode = userEntity.getMobileNumberConfirmationCode();
+		User updatedUserEntity = updateUser(userId, userEntity -> {
+			ConfirmationCode confirmationCode = userEntity.getMobileNumberConfirmationCode();
 
-		assertValidConfirmationCode(userEntity, confirmationCode, userProvidedConfirmationCode,
-				() -> MobileNumberConfirmationException.confirmationCodeNotSet(userEntity.getMobileNumber()),
-				r -> MobileNumberConfirmationException.confirmationCodeMismatch(userEntity.getMobileNumber(),
-						userProvidedConfirmationCode, r),
-				() -> MobileNumberConfirmationException.tooManyAttempts(userEntity.getMobileNumber()));
+			assertValidConfirmationCode(userEntity, confirmationCode, userProvidedConfirmationCode,
+					() -> MobileNumberConfirmationException.confirmationCodeNotSet(userEntity.getMobileNumber()),
+					r -> MobileNumberConfirmationException.confirmationCodeMismatch(userEntity.getMobileNumber(),
+							userProvidedConfirmationCode, r),
+					() -> MobileNumberConfirmationException.tooManyAttempts(userEntity.getMobileNumber()));
 
-		if (userEntity.isMobileNumberConfirmed())
-		{
-			throw MobileNumberConfirmationException.mobileNumberAlreadyConfirmed(userEntity.getMobileNumber());
-		}
+			if (userEntity.isMobileNumberConfirmed())
+			{
+				throw MobileNumberConfirmationException.mobileNumberAlreadyConfirmed(userEntity.getMobileNumber());
+			}
 
-		userEntity.setMobileNumberConfirmationCode(null);
-		userEntity.markMobileNumberConfirmed();
-		userRepository.save(userEntity);
+			userEntity.setMobileNumberConfirmationCode(null);
+			userEntity.markMobileNumberConfirmed();
 
-		logger.info("User with mobile number '{}' and ID '{}' successfully confirmed their mobile number",
-				userEntity.getMobileNumber(), userEntity.getId());
-		return createUserDtoWithPrivateData(userEntity);
+			logger.info("User with mobile number '{}' and ID '{}' successfully confirmed their mobile number",
+					userEntity.getMobileNumber(), userEntity.getId());
+		});
+		return createUserDtoWithPrivateData(updatedUserEntity);
 	}
 
 	@Transactional
-	public Object resendMobileNumberConfirmationCode(UUID userId)
+	public void resendMobileNumberConfirmationCode(UUID userId)
 	{
-		User userEntity = getUserEntityById(userId);
-		logger.info("User with mobile number '{}' and ID '{}' requests to resend the mobile number confirmation code",
-				userEntity.getMobileNumber(), userEntity.getId());
-		ConfirmationCode confirmationCode = createConfirmationCode();
-		userEntity.setMobileNumberConfirmationCode(confirmationCode);
-		userRepository.save(userEntity);
-		sendConfirmationCodeTextMessage(userEntity.getMobileNumber(), confirmationCode, SmsTemplate.ADD_USER_NUMBER_CONFIRMATION);
-		return null;
+		updateUser(userId, userEntity -> {
+			logger.info("User with mobile number '{}' and ID '{}' requests to resend the mobile number confirmation code",
+					userEntity.getMobileNumber(), userEntity.getId());
+			ConfirmationCode confirmationCode = createConfirmationCode();
+			userEntity.setMobileNumberConfirmationCode(confirmationCode);
+			sendConfirmationCodeTextMessage(userEntity.getMobileNumber(), confirmationCode,
+					SmsTemplate.ADD_USER_NUMBER_CONFIRMATION);
+		});
 	}
 
 	@Transactional
 	public void postOpenAppEvent(UUID userId)
 	{
-		User userEntity = getUserEntityById(userId);
-		LocalDate now = TimeUtil.utcNow().toLocalDate();
-		Optional<LocalDate> appLastOpenedDate = userEntity.getAppLastOpenedDate();
-		if (!appLastOpenedDate.isPresent() || appLastOpenedDate.get().isBefore(now))
-		{
-			userEntity.setAppLastOpenedDate(now);
-			userRepository.save(userEntity);
-		}
+		updateUser(userId, userEntity -> {
+			LocalDate now = TimeUtil.utcNow().toLocalDate();
+			Optional<LocalDate> appLastOpenedDate = userEntity.getAppLastOpenedDate();
+			if (!appLastOpenedDate.isPresent() || appLastOpenedDate.get().isBefore(now))
+			{
+				userEntity.setAppLastOpenedDate(now);
+			}
+		});
 	}
 
 	@Transactional
@@ -479,45 +474,52 @@ public class UserService
 	@Transactional
 	public UserDto updateUser(UUID id, UserDto user)
 	{
-		User originalUserEntity = getUserEntityById(id);
-		UserDto originalUser = createUserDtoWithPrivateData(originalUserEntity);
-		assertValidUpdateRequest(user, originalUser, originalUserEntity);
+		User updatedUserEntity = updateUser(id, userEntity -> {
+			UserDto originalUser = createUserDtoWithPrivateData(userEntity);
+			assertValidUpdateRequest(user, originalUser, userEntity);
 
-		User updatedUserEntity = user.updateUser(originalUserEntity);
-		Optional<ConfirmationCode> confirmationCode = createConfirmationCodeIfNumberUpdated(user, originalUser,
-				updatedUserEntity);
-		User savedUserEntity = userRepository.save(updatedUserEntity);
-		if (confirmationCode.isPresent())
-		{
-			sendConfirmationCodeTextMessage(updatedUserEntity.getMobileNumber(), confirmationCode.get(),
-					SmsTemplate.CHANGED_USER_NUMBER_CONFIRMATION);
-		}
-		UserDto userDto = createUserDtoWithPrivateData(savedUserEntity);
-		logger.info("Updated user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(), userDto.getId());
-		buddyService.broadcastUserInfoChangeToBuddies(savedUserEntity, originalUser);
-		return userDto;
+			user.updateUser(userEntity);
+			Optional<ConfirmationCode> confirmationCode = createConfirmationCodeIfNumberUpdated(user, originalUser, userEntity);
+			if (confirmationCode.isPresent())
+			{
+				sendConfirmationCodeTextMessage(userEntity.getMobileNumber(), confirmationCode.get(),
+						SmsTemplate.CHANGED_USER_NUMBER_CONFIRMATION);
+			}
+			UserDto userDto = createUserDtoWithPrivateData(userEntity);
+			logger.info("Updated user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(), userDto.getId());
+			buddyService.broadcastUserInfoChangeToBuddies(userEntity, originalUser);
+		});
+		return createUserDtoWithPrivateData(updatedUserEntity);
+	}
+
+	@Transactional
+	public User updateUser(UUID id, Consumer<User> updateAction)
+	{
+		User user = getUserEntityByIdWithUpdateLock(id);
+		updateAction.accept(user);
+		return userRepository.save(user);
 	}
 
 	@Transactional
 	public UserDto updateUserPhoto(UUID id, Optional<UUID> userPhotoId)
 	{
-		User userEntity = getUserEntityById(id);
-		UserDto originalUser = createUserDtoWithPrivateData(userEntity);
-		userEntity.setUserPhotoId(userPhotoId);
-		User savedUserEntity = userRepository.save(userEntity);
-		UserDto userDto = createUserDtoWithPrivateData(savedUserEntity);
-		if (userPhotoId.isPresent())
-		{
-			logger.info("Updated user photo for user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(),
-					userDto.getId());
-		}
-		else
-		{
-			logger.info("Deleted user photo for user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(),
-					userDto.getId());
-		}
-		buddyService.broadcastUserInfoChangeToBuddies(savedUserEntity, originalUser);
-		return userDto;
+		User updatedUserEntity = updateUser(id, userEntity -> {
+			UserDto originalUser = createUserDtoWithPrivateData(userEntity);
+			userEntity.setUserPhotoId(userPhotoId);
+			UserDto userDto = createUserDtoWithPrivateData(userEntity);
+			if (userPhotoId.isPresent())
+			{
+				logger.info("Updated user photo for user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(),
+						userDto.getId());
+			}
+			else
+			{
+				logger.info("Deleted user photo for user with mobile number '{}' and ID '{}'", userDto.getMobileNumber(),
+						userDto.getId());
+			}
+			buddyService.broadcastUserInfoChangeToBuddies(userEntity, originalUser);
+		});
+		return createUserDtoWithPrivateData(updatedUserEntity);
 	}
 
 	private void assertValidUpdateRequest(UserDto user, UserDto originalUser, User originalUserEntity)
@@ -593,7 +595,7 @@ public class UserService
 	@Transactional
 	public void deleteUser(UUID id, Optional<String> message)
 	{
-		User userEntity = getUserEntityById(id);
+		User userEntity = getUserEntityByIdWithUpdateLock(id);
 		buddyService.processPossiblePendingBuddyResponseMessages(userEntity);
 
 		handleBuddyUsersRemovedWhileOffline(userEntity);
@@ -680,16 +682,16 @@ public class UserService
 			throw InvalidDataException.emptyBuddyId();
 		}
 
-		User userEntity = getUserEntityById(user.getId());
-		userEntity.assertMobileNumberConfirmed();
+		updateUser(user.getId(), userEntity -> {
+			userEntity.assertMobileNumberConfirmed();
 
-		Buddy buddyEntity = buddyRepository.findOne(buddy.getId());
-		userEntity.addBuddy(buddyEntity);
-		userRepository.save(userEntity);
+			Buddy buddyEntity = buddyRepository.findOne(buddy.getId());
+			userEntity.addBuddy(buddyEntity);
 
-		UserAnonymized userAnonymizedEntity = userEntity.getAnonymized();
-		userAnonymizedEntity.addBuddyAnonymized(buddyEntity.getBuddyAnonymized());
-		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
+			UserAnonymized userAnonymizedEntity = userEntity.getAnonymized();
+			userAnonymizedEntity.addBuddyAnonymized(buddyEntity.getBuddyAnonymized());
+			userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
+		});
 	}
 
 	public String generatePassword()
@@ -714,7 +716,7 @@ public class UserService
 
 	/**
 	 * This method returns a user entity. The passed on Id is checked whether or not it is set. it also checks that the return
-	 * value is always the user entity. If not an exception is thrown.
+	 * value is always the user entity. If not an exception is thrown. The entity is fetched without lock.
 	 * 
 	 * @param id the ID of the user
 	 * @return The user entity (never null)
@@ -722,12 +724,42 @@ public class UserService
 	@Transactional
 	public User getUserEntityById(UUID id)
 	{
+		return getUserEntityById(id, LockModeType.NONE);
+	}
+
+	/**
+	 * This method returns a user entity. The passed on Id is checked whether or not it is set. it also checks that the return
+	 * value is always the user entity. If not an exception is thrown. A pessimistic database write lock is claimed when fetching
+	 * the entity.
+	 * 
+	 * @param id the ID of the user
+	 * @return The user entity (never null)
+	 */
+	@Transactional
+	public User getUserEntityByIdWithUpdateLock(UUID id)
+	{
+		return getUserEntityById(id, LockModeType.PESSIMISTIC_WRITE);
+	}
+
+	private User getUserEntityById(UUID id, LockModeType lockModeType)
+	{
 		if (id == null)
 		{
 			throw InvalidDataException.emptyUserId();
 		}
 
-		User entity = userRepository.findOne(id);
+		User entity;
+		switch (lockModeType)
+		{
+			case NONE:
+				entity = userRepository.findOne(id);
+				break;
+			case PESSIMISTIC_WRITE:
+				entity = userRepository.findOneForUpdate(id);
+				break;
+			default:
+				throw new IllegalArgumentException("Lock mode type " + lockModeType + " is unsupported");
+		}
 
 		if (entity == null)
 		{
@@ -806,27 +838,25 @@ public class UserService
 
 	public void registerFailedAttempt(User userEntity, ConfirmationCode confirmationCode)
 	{
-		transactionHelper.executeInNewTransaction(() -> {
-			confirmationCode.incrementAttempts();
-			userRepository.save(userEntity);
-		});
+		updateUser(userEntity.getId(), u -> confirmationCode.incrementAttempts());
 	}
 
 	private User saveUserEncryptedDataWithNewPassword(EncryptedUserData retrievedEntitySet, UserDto user)
 	{
-		assert user.getPrivateData().getDevices().orElse(Collections.emptySet()).size() == 1;
-		// touch and save all user related data containing encryption
-		// see architecture overview for which classes contain encrypted data
-		// (this could also be achieved with very complex reflection)
-		retrievedEntitySet.userEntity.getBuddies().forEach(buddy -> buddyRepository.save(buddy.touch()));
-		messageSourceRepository.save(retrievedEntitySet.namedMessageSource.touch());
-		messageSourceRepository.save(retrievedEntitySet.anonymousMessageSource.touch());
-		user.updateUser(retrievedEntitySet.userEntity);
-		retrievedEntitySet.userEntity.unsetIsCreatedOnBuddyRequest();
-		retrievedEntitySet.userEntity.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate());
-		addDevicesToEntity(user, retrievedEntitySet.userEntity);
-		retrievedEntitySet.userEntity.touch();
-		return userRepository.save(retrievedEntitySet.userEntity);
+		return updateUser(retrievedEntitySet.userEntity.getId(), userEntity -> {
+			assert user.getPrivateData().getDevices().orElse(Collections.emptySet()).size() == 1;
+			// touch and save all user related data containing encryption
+			// see architecture overview for which classes contain encrypted data
+			// (this could also be achieved with very complex reflection)
+			userEntity.getBuddies().forEach(buddy -> buddyRepository.save(buddy.touch()));
+			messageSourceRepository.save(retrievedEntitySet.namedMessageSource.touch());
+			messageSourceRepository.save(retrievedEntitySet.anonymousMessageSource.touch());
+			user.updateUser(userEntity);
+			userEntity.unsetIsCreatedOnBuddyRequest();
+			userEntity.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate());
+			addDevicesToEntity(user, userEntity);
+			userEntity.touch();
+		});
 	}
 
 	void assertValidUserFields(UserDto userResource, UserPurpose userPurpose)

--- a/core/src/test/java/nu/yona/server/entities/ActivityRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/ActivityRepositoryMock.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.entities;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.lang.NotImplementedException;
+
+import nu.yona.server.analysis.entities.Activity;
+import nu.yona.server.analysis.entities.ActivityRepository;
+import nu.yona.server.analysis.entities.DayActivity;
+import nu.yona.server.device.entities.DeviceAnonymized;
+
+public class ActivityRepositoryMock extends MockCrudRepositoryEntityWithId<Activity> implements ActivityRepository
+{
+
+	@Override
+	public List<Activity> findOverlappingOfSameApp(DayActivity dayActivity, UUID deviceAnonymizedId, UUID activityCategoryId,
+			String app, LocalDateTime startTime, LocalDateTime endTime)
+	{
+		throw new NotImplementedException();
+	}
+
+	@Override
+	public Set<Activity> findByDeviceAnonymized(DeviceAnonymized deviceAnonymized)
+	{
+		return StreamSupport.stream(findAll().spliterator(), false)
+				.filter(a -> a.getDeviceAnonymized().getId() == deviceAnonymized.getId()).collect(Collectors.toSet());
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/MockCrudRepositoryEntityWithId.java
+++ b/core/src/test/java/nu/yona/server/entities/MockCrudRepositoryEntityWithId.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.entities;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.repository.CrudRepository;
+
+public class MockCrudRepositoryEntityWithId<T extends EntityWithId> implements CrudRepository<T, Long>
+{
+	private static final Field idField = getIdField();
+	private int nextId;
+	private Map<Long, T> entities = new HashMap<>();
+
+	private static Field getIdField()
+	{
+		Field field = Arrays.asList(EntityWithId.class.getDeclaredFields()).stream().filter(f -> f.getName().equals("id"))
+				.findAny().orElseThrow(() -> new IllegalStateException("Cannot find field 'id'"));
+		field.setAccessible(true);
+		return field;
+	}
+
+	@Override
+	public <S extends T> S save(S entity)
+	{
+		try
+		{
+			idField.setLong(entity, nextId++);
+			entities.put(entity.getId(), entity);
+			return entity;
+		}
+		catch (IllegalArgumentException | IllegalAccessException | SecurityException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public <S extends T> Iterable<S> save(Iterable<S> entities)
+	{
+		for (S entity : entities)
+		{
+			save(entity);
+		}
+		return entities;
+	}
+
+	@Override
+	public T findOne(Long id)
+	{
+		return entities.get(id);
+	}
+
+	@Override
+	public boolean exists(Long id)
+	{
+		return entities.containsKey(id);
+	}
+
+	@Override
+	public Iterable<T> findAll()
+	{
+		return entities.values();
+	}
+
+	@Override
+	public Iterable<T> findAll(Iterable<Long> ids)
+	{
+		List<T> matchingEntities = new ArrayList<>();
+		for (Long id : ids)
+		{
+			T entity = entities.get(id);
+			if (entity != null)
+			{
+				matchingEntities.add(entity);
+			}
+		}
+		return matchingEntities;
+	}
+
+	@Override
+	public long count()
+	{
+		return entities.size();
+	}
+
+	@Override
+	public void delete(Long id)
+	{
+		entities.remove(id);
+	}
+
+	@Override
+	public void delete(T entity)
+	{
+		delete(entity.getId());
+	}
+
+	@Override
+	public void delete(Iterable<? extends T> entities)
+	{
+		for (T entity : entities)
+		{
+			delete(entity);
+		}
+	}
+
+	@Override
+	public void deleteAll()
+	{
+		entities.clear();
+	}
+}

--- a/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
@@ -1,15 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.entities;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.lang.NotImplementedException;
 
@@ -18,6 +16,12 @@ import nu.yona.server.subscriptions.entities.UserRepository;
 
 public class UserRepositoryMock extends MockJpaRepositoryEntityWithUuid<User> implements UserRepository
 {
+
+	@Override
+	public User findOneForUpdate(UUID id)
+	{
+		return findOne(id);
+	}
 
 	@Override
 	public User findByMobileNumber(String mobileNumber)

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -5,12 +5,14 @@
 package nu.yona.server.subscriptions.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -90,11 +92,12 @@ public class UserServiceTest extends BaseSpringIntegrationTest
 	@Test
 	public void postOpenAppEvent_appLastOpenedDateOnSameDay_notUpdated()
 	{
-		richard.setAppLastOpenedDate(TimeUtil.utcNow().toLocalDate());
+		LocalDate originalDate = TimeUtil.utcNow().toLocalDate();
+		richard.setAppLastOpenedDate(originalDate);
 
 		service.postOpenAppEvent(richard.getId());
 
-		verify(userRepository, times(0)).save(any(User.class));
+		assertThat(richard.getAppLastOpenedDate().get(), sameInstance(originalDate));
 	}
 
 	@Test


### PR DESCRIPTION
All updates to the User entity are now done while owning a pessimistic lock database lock. This lead to some deadlocks where updates happened in different transactions on the same thread. These issues have been resolved through changes in the exception-based rollback.