### PR TITLE
YD-529 Fix "No devices" error

### DIFF
--- a/core/src/main/java/nu/yona/server/crypto/seckey/CryptoSession.java
+++ b/core/src/main/java/nu/yona/server/crypto/seckey/CryptoSession.java
@@ -118,6 +118,11 @@ public class CryptoSession implements AutoCloseable
 		return new CryptoSession(secretKey, threadLocal.get());
 	}
 
+	public static boolean isActive()
+	{
+		return threadLocal.get() != null;
+	}
+
 	public static CryptoSession getCurrent()
 	{
 		CryptoSession cryptoSession = threadLocal.get();

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -271,6 +271,10 @@ public class User extends EntityWithUuid
 
 	public boolean canAccessPrivateData()
 	{
+		if (!CryptoSession.isActive())
+		{
+			return false;
+		}
 		return getUserPrivate().isDecryptedProperly();
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -508,6 +508,10 @@ public class UserService
 	{
 		User user = getUserEntityByIdWithUpdateLock(id);
 		updateAction.accept(user);
+		if (user.canAccessPrivateData())
+		{
+			userAnonymizedService.updateUserAnonymized(user.getAnonymized()); // Save and update cache
+		}
 		return userRepository.save(user);
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -510,8 +510,8 @@ public class UserService
 		updateAction.accept(user);
 		if (user.canAccessPrivateData())
 		{
-			// The private data is accessible and might be updated
-			// Let the UserAnonymizedService save it to the repository and cache it
+			// The private data is accessible and might be updated, including the UserAnonymized
+			// Let the UserAnonymizedService save save that to the repository and cache it
 			userAnonymizedService.updateUserAnonymized(user.getAnonymized());
 		}
 		return userRepository.save(user);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -511,7 +511,7 @@ public class UserService
 		if (user.canAccessPrivateData())
 		{
 			// The private data is accessible and might be updated, including the UserAnonymized
-			// Let the UserAnonymizedService save save that to the repository and cache it
+			// Let the UserAnonymizedService save that to the repository and cache it
 			userAnonymizedService.updateUserAnonymized(user.getAnonymized());
 		}
 		return userRepository.save(user);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -510,7 +510,9 @@ public class UserService
 		updateAction.accept(user);
 		if (user.canAccessPrivateData())
 		{
-			userAnonymizedService.updateUserAnonymized(user.getAnonymized()); // Save and update cache
+			// The private data is accessible and might be updated
+			// Let the UserAnonymizedService save it to the repository and cache it
+			userAnonymizedService.updateUserAnonymized(user.getAnonymized());
 		}
 		return userRepository.save(user);
 	}

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
@@ -81,6 +81,9 @@ public class PrivateUserDataMigrationServiceIntegrationTest extends BaseSpringIn
 	@MockBean
 	private MessageSourceRepository mockMessageSourceRepository;
 
+	@MockBean
+	private UserAnonymizedService mockUserAnonymizedService;
+
 	@Autowired
 	private PrivateUserDataMigrationService service;
 


### PR DESCRIPTION
The result of the data migration was not stored in the user anonymized cache.
Now every update to a user also updates the user anonymized cache, provided the update is done in a context where the user private data can be accessed.