### PR TITLE
YD-517 Don't record time for network activities on Android devices

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -69,6 +69,7 @@ import nu.yona.server.crypto.pubkey.PublicKeyUtil;
 import nu.yona.server.device.entities.DeviceAnonymized;
 import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
 import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.service.DeviceAnonymizedDto;
 import nu.yona.server.device.service.DeviceService;
 import nu.yona.server.goals.entities.ActivityCategory;
 import nu.yona.server.goals.entities.BudgetGoal;
@@ -142,8 +143,11 @@ public class AnalysisEngineServiceTest
 	private UUID deviceAnonId;
 	private DeviceAnonymized deviceAnonEntity;
 	private UserAnonymized userAnonEntity;
+	private UserAnonymizedDto userAnonDto;
 
 	private ZoneId userAnonZoneId;
+
+	private DeviceAnonymizedDto deviceAnonDto;
 
 	@Before
 	public void setUp()
@@ -207,17 +211,18 @@ public class AnalysisEngineServiceTest
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown");
 		deviceAnonId = deviceAnonEntity.getId();
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
-		UserAnonymizedDto userAnon = UserAnonymizedDto.createInstance(userAnonEntity);
-		anonMessageDestination = userAnon.getAnonymousDestination();
-		userAnonId = userAnon.getId();
-		userAnonZoneId = userAnon.getTimeZone();
+		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);
+		deviceAnonDto = DeviceAnonymizedDto.createInstance(deviceAnonEntity);
+		anonMessageDestination = userAnonDto.getAnonymousDestination();
+		userAnonId = userAnonDto.getId();
+		userAnonZoneId = userAnonDto.getTimeZone();
 
 		// Stub the UserAnonymizedService to return our user.
-		when(mockUserAnonymizedService.getUserAnonymized(userAnonId)).thenReturn(userAnon);
+		when(mockUserAnonymizedService.getUserAnonymized(userAnonId)).thenReturn(userAnonDto);
 		when(mockUserAnonymizedService.getUserAnonymizedEntity(userAnonId)).thenReturn(userAnonEntity);
 
 		// Stub the GoalService to return our goals.
@@ -255,7 +260,8 @@ public class AnalysisEngineServiceTest
 				});
 
 		// Mock device service and repo
-		when(mockDeviceService.getDeviceAnonymizedId(userAnon, -1)).thenReturn(deviceAnonId);
+		when(mockDeviceService.getDeviceAnonymized(userAnonDto, -1)).thenReturn(deviceAnonDto);
+		when(mockDeviceService.getDeviceAnonymized(userAnonDto, deviceAnonId)).thenReturn(deviceAnonDto);
 		when(mockDeviceAnonymizedRepository.getOne(deviceAnonId)).thenReturn(deviceAnonEntity);
 
 		// Set up the repository mocks

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
@@ -1,0 +1,235 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.analysis.service;
+
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import nu.yona.server.Translator;
+import nu.yona.server.analysis.service.AnalysisEngineService.ActivityPayload;
+import nu.yona.server.crypto.pubkey.PublicKeyUtil;
+import nu.yona.server.device.entities.DeviceAnonymized;
+import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
+import nu.yona.server.device.service.DeviceAnonymizedDto;
+import nu.yona.server.goals.entities.ActivityCategory;
+import nu.yona.server.goals.entities.BudgetGoal;
+import nu.yona.server.goals.entities.Goal;
+import nu.yona.server.goals.entities.TimeZoneGoal;
+import nu.yona.server.goals.service.ActivityCategoryDto;
+import nu.yona.server.goals.service.GoalDto;
+import nu.yona.server.messaging.entities.MessageDestination;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.service.UserAnonymizedDto;
+import nu.yona.server.util.TimeUtil;
+
+@RunWith(Parameterized.class)
+public class AnalysisEngineService_determineRelevantGoalsTest
+{
+	private OperatingSystem operatingSystem;
+	private boolean isIOs;
+	private Goal gamblingGoal;
+	private Goal newsGoal;
+	private Goal gamingGoal;
+	private Goal socialGoal;
+	private Goal shoppingGoal;
+	private Goal shoppingGoalHistoryItem;
+	private DeviceAnonymized deviceAnonEntity;
+	private UserAnonymized userAnonEntity;
+	private UserAnonymizedDto userAnonDto;
+
+	private ZoneId userAnonZoneId;
+
+	private DeviceAnonymizedDto deviceAnonDto;
+
+	public AnalysisEngineService_determineRelevantGoalsTest(String operatingSystem, boolean isIOs)
+	{
+		this.operatingSystem = OperatingSystem.valueOf(operatingSystem);
+		this.isIOs = isIOs;
+	}
+
+	@Parameters
+	public static Collection<Object[]> data()
+	{
+		return Arrays.asList(new Object[][] { { "IOS", true }, { "ANDROID", false } });
+	}
+
+	@Before
+	public void setUp()
+	{
+		initMocks(this);
+
+		LocalDateTime yesterday = TimeUtil.utcNow().minusDays(1);
+		LocalDateTime dayBeforeYesterday = yesterday.minusDays(1);
+		gamblingGoal = BudgetGoal.createNoGoInstance(dayBeforeYesterday,
+				ActivityCategory.createInstance(UUID.randomUUID(), usString("gambling"), false,
+						new HashSet<>(Arrays.asList("poker", "lotto")), new HashSet<>(Arrays.asList("Poker App", "Lotto App")),
+						usString("Descr")));
+		newsGoal = BudgetGoal.createNoGoInstance(dayBeforeYesterday,
+				ActivityCategory.createInstance(UUID.randomUUID(), usString("news"), false,
+						new HashSet<>(Arrays.asList("refdag", "bbc")), Collections.emptySet(), usString("Descr")));
+		gamingGoal = BudgetGoal.createNoGoInstance(dayBeforeYesterday, ActivityCategory.createInstance(UUID.randomUUID(),
+				usString("gaming"), false, new HashSet<>(Arrays.asList("games")), Collections.emptySet(), usString("Descr")));
+		socialGoal = TimeZoneGoal.createInstance(dayBeforeYesterday,
+				ActivityCategory.createInstance(UUID.randomUUID(), usString("social"), false,
+						new HashSet<>(Arrays.asList("social")), Collections.emptySet(), usString("Descr")),
+				Collections.emptyList());
+		shoppingGoal = BudgetGoal.createInstance(dayBeforeYesterday, ActivityCategory.createInstance(UUID.randomUUID(),
+				usString("shopping"), false, new HashSet<>(Arrays.asList("webshop")), Collections.emptySet(), usString("Descr")),
+				1);
+		shoppingGoalHistoryItem = shoppingGoal.cloneAsHistoryItem(yesterday);
+
+		// Set up UserAnonymized instance.
+		MessageDestination anonMessageDestinationEntity = MessageDestination
+				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
+		Set<Goal> goals = new HashSet<>(
+				Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal, shoppingGoalHistoryItem));
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown");
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
+		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);
+		deviceAnonDto = DeviceAnonymizedDto.createInstance(deviceAnonEntity);
+		userAnonZoneId = userAnonDto.getTimeZone();
+	}
+
+	private Map<Locale, String> usString(String string)
+	{
+		return Collections.singletonMap(Translator.EN_US_LOCALE, string);
+	}
+
+	@Test
+	public void determineRelevantGoals_appActategoryNotUserGoal_emptySet()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(), makeCategorySet(newsGoal));
+		assertThat(relevantGoals, empty());
+	}
+
+	@Test
+	public void determineRelevantGoals_appActOneUserGoal_userGoal()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(), makeCategorySet(socialGoal));
+		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal)));
+		assertNoHistoryItems(relevantGoals);
+	}
+
+	@Test
+	public void determineRelevantGoals_appActTwoUserGoals_bothUserGoals()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(),
+				makeCategorySet(socialGoal, gamblingGoal));
+		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal), GoalDto.createInstance(gamblingGoal)));
+		assertNoHistoryItems(relevantGoals);
+	}
+
+	@Test
+	public void determineRelevantGoals_appActTwoGoalsOneUserGoal_userGoal()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(),
+				makeCategorySet(newsGoal, gamblingGoal));
+		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(gamblingGoal)));
+		assertNoHistoryItems(relevantGoals);
+	}
+
+	@Test
+	public void determineRelevantGoals_appActBeforeGoalStart_emptySet()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(Duration.ofDays(3)),
+				makeCategorySet(socialGoal));
+		assertThat(relevantGoals, empty());
+	}
+
+	@Test
+	public void determineRelevantGoals_appActOnGoalWithHistory_oneGoalReturned()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(Duration.ofDays(1)),
+				makeCategorySet(shoppingGoal));
+		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(shoppingGoal)));
+		assertNoHistoryItems(relevantGoals);
+	}
+
+	@Test
+	public void determineRelevantGoals_netActNoGoOneUserGoal_userGoal()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetPayload(), makeCategorySet(gamingGoal));
+		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(gamingGoal)));
+		assertNoHistoryItems(relevantGoals);
+	}
+
+	@Test
+	public void determineRelevantGoals_netActOptionalOneUserGoal_userGoalOnIOs()
+	{
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetPayload(), makeCategorySet(socialGoal));
+		if (isIOs)
+		{
+			assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal)));
+		}
+		else
+		{
+			assertThat(relevantGoals, empty());
+		}
+	}
+
+	private Set<ActivityCategoryDto> makeCategorySet(Goal... goals)
+	{
+		return Arrays.asList(goals).stream().map(Goal::getActivityCategory).map(ActivityCategoryDto::createInstance)
+				.collect(Collectors.toSet());
+	}
+
+	private ActivityPayload makeAppPayload()
+	{
+		return makeAppPayload(Duration.ofDays(0));
+	}
+
+	private ActivityPayload makeAppPayload(Duration timeAgo)
+	{
+		ZonedDateTime endTime = now().minus(timeAgo);
+		ZonedDateTime startTime = endTime.minusMinutes(2);
+		return ActivityPayload.createInstance(userAnonDto, deviceAnonDto, startTime, endTime, "n/a");
+	}
+
+	private ActivityPayload makeNetPayload()
+	{
+		return makeNetPayload(Duration.ofDays(0));
+	}
+
+	private ActivityPayload makeNetPayload(Duration timeAgo)
+	{
+		ZonedDateTime eventTime = now().minus(timeAgo);
+		NetworkActivityDto networkActivity = new NetworkActivityDto(Collections.singleton("n/a"), "n/a", Optional.of(eventTime));
+		return ActivityPayload.createInstance(userAnonDto, deviceAnonDto, networkActivity);
+	}
+
+	private void assertNoHistoryItems(Set<GoalDto> goals)
+	{
+		assertThat(goals.stream().map(GoalDto::isHistoryItem).collect(Collectors.toSet()), containsInAnyOrder(false));
+	}
+
+	private ZonedDateTime now()
+	{
+		return ZonedDateTime.now().withZoneSameInstant(userAnonZoneId);
+	}
+}

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
@@ -122,40 +122,37 @@ public class AnalysisEngineService_determineRelevantGoalsTest
 	}
 
 	@Test
-	public void determineRelevantGoals_appActategoryNotUserGoal_emptySet()
+	public void determineRelevantGoals_appActivityNotAUserGoal_emptySet()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(), makeCategorySet(newsGoal));
 		assertThat(relevantGoals, empty());
 	}
 
 	@Test
-	public void determineRelevantGoals_appActOneUserGoal_userGoal()
+	public void determineRelevantGoals_appActivityOneUserGoal_userGoal()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(), makeCategorySet(socialGoal));
 		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal)));
-		assertNoHistoryItems(relevantGoals);
 	}
 
 	@Test
-	public void determineRelevantGoals_appActTwoUserGoals_bothUserGoals()
+	public void determineRelevantGoals_appActivityTwoUserGoals_bothUserGoals()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(),
 				makeCategorySet(socialGoal, gamblingGoal));
 		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal), GoalDto.createInstance(gamblingGoal)));
-		assertNoHistoryItems(relevantGoals);
 	}
 
 	@Test
-	public void determineRelevantGoals_appActTwoGoalsOneUserGoal_userGoal()
+	public void determineRelevantGoals_appActivityTwoGoalsOneUserGoal_userGoal()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(),
 				makeCategorySet(newsGoal, gamblingGoal));
 		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(gamblingGoal)));
-		assertNoHistoryItems(relevantGoals);
 	}
 
 	@Test
-	public void determineRelevantGoals_appActBeforeGoalStart_emptySet()
+	public void determineRelevantGoals_appActivityBeforeGoalStart_emptySet()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(Duration.ofDays(3)),
 				makeCategorySet(socialGoal));
@@ -163,26 +160,26 @@ public class AnalysisEngineService_determineRelevantGoalsTest
 	}
 
 	@Test
-	public void determineRelevantGoals_appActOnGoalWithHistory_oneGoalReturned()
+	public void determineRelevantGoals_appActivityOnGoalWithHistory_oneGoalReturned()
 	{
 		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeAppPayload(Duration.ofDays(1)),
 				makeCategorySet(shoppingGoal));
 		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(shoppingGoal)));
-		assertNoHistoryItems(relevantGoals);
 	}
 
 	@Test
-	public void determineRelevantGoals_netActNoGoOneUserGoal_userGoal()
+	public void determineRelevantGoals_networkActivityOneNoGoUserGoal_userGoal()
 	{
-		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetPayload(), makeCategorySet(gamingGoal));
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetworkPayload(),
+				makeCategorySet(gamingGoal));
 		assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(gamingGoal)));
-		assertNoHistoryItems(relevantGoals);
 	}
 
 	@Test
-	public void determineRelevantGoals_netActOptionalOneUserGoal_userGoalOnIOs()
+	public void determineRelevantGoals_networkActivityOneOptionalUserGoal_userGoalOnIOs()
 	{
-		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetPayload(), makeCategorySet(socialGoal));
+		Set<GoalDto> relevantGoals = AnalysisEngineService.determineRelevantGoals(makeNetworkPayload(),
+				makeCategorySet(socialGoal));
 		if (isIOs)
 		{
 			assertThat(relevantGoals, containsInAnyOrder(GoalDto.createInstance(socialGoal)));
@@ -211,21 +208,16 @@ public class AnalysisEngineService_determineRelevantGoalsTest
 		return ActivityPayload.createInstance(userAnonDto, deviceAnonDto, startTime, endTime, "n/a");
 	}
 
-	private ActivityPayload makeNetPayload()
+	private ActivityPayload makeNetworkPayload()
 	{
-		return makeNetPayload(Duration.ofDays(0));
+		return makeNetworkPayload(Duration.ofDays(0));
 	}
 
-	private ActivityPayload makeNetPayload(Duration timeAgo)
+	private ActivityPayload makeNetworkPayload(Duration timeAgo)
 	{
 		ZonedDateTime eventTime = now().minus(timeAgo);
 		NetworkActivityDto networkActivity = new NetworkActivityDto(Collections.singleton("n/a"), "n/a", Optional.of(eventTime));
 		return ActivityPayload.createInstance(userAnonDto, deviceAnonDto, networkActivity);
-	}
-
-	private void assertNoHistoryItems(Set<GoalDto> goals)
-	{
-		assertThat(goals.stream().map(GoalDto::isHistoryItem).collect(Collectors.toSet()), containsInAnyOrder(false));
 	}
 
 	private ZonedDateTime now()

--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -68,32 +68,40 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	@Shared
 	private def fullDay = [ Sun: "SUNDAY", Mon : "MONDAY", Tue : "TUESDAY", Wed : "WEDNESDAY", Thu : "THURSDAY", Fri: "FRIDAY", Sat: "SATURDAY" ]
 
-	User addRichard(boolean reload = true)
+	User addRichard(boolean reload = true, def operatingSystem = "IOS")
 	{
+		def deviceName = makeDeviceName("Richard", operatingSystem)
 		User richard = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Richard", "Quinn", "RQ",
-				makeMobileNumber(timestamp))
+				makeMobileNumber(timestamp), deviceName, operatingSystem)
 		richard = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, richard)
 		def response = appService.addGoal(richard, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
 		assertResponseStatusCreated(response)
 		return reload ? appService.reloadUser(richard) : richard
 	}
 
-	User addBob(boolean reload = true)
+	User addBob(boolean reload = true, def operatingSystem = "IOS")
 	{
+		def deviceName = makeDeviceName("Bob", operatingSystem)
 		User bob = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Bob", "Dunn", "BD",
-				makeMobileNumber(timestamp))
+				makeMobileNumber(timestamp), deviceName, "IOS")
 		bob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, bob)
 		def response = appService.addGoal(bob, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
 		assertResponseStatusCreated(response)
 		return reload? appService.reloadUser(bob) : bob
 	}
 
-	User addBea(boolean reload = true)
+	User addBea(boolean reload = true, def operatingSystem = "IOS")
 	{
+		def deviceName = makeDeviceName("Bea", operatingSystem)
 		User bea = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Bea", "Dundee", "BDD",
-				makeMobileNumber(timestamp))
+				makeMobileNumber(timestamp), deviceName, "IOS")
 		bea = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, bea)
 		return reload? appService.reloadUser(bea) : bea
+	}
+
+	def makeDeviceName(def userName, def operatingSystem)
+	{
+		(operatingSystem == "IOS") ? "$userName's iPhone" : "$userName's S8"
 	}
 
 	def addRichardAndBobAsBuddies()

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1546,7 +1546,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richardDefault)
 	}
 
-	def 'Richard\'s network activity is measured on iOS only'(def operatingSystem, def expectedValue)
+	def 'Richard\'s \'non-no-go\' network activity is measured on iOS only'(def operatingSystem, def expectedValue)
 	{
 		given:
 		User richard = addRichard(false, operatingSystem)

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -18,6 +18,7 @@ import java.time.temporal.IsoFields
 import groovy.json.*
 import nu.yona.server.test.AppActivity
 import nu.yona.server.test.BudgetGoal
+import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.Goal
 import nu.yona.server.test.TimeZoneGoal
 import nu.yona.server.test.User
@@ -1426,7 +1427,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 	def 'Richard works on two devices'()
 	{
 		given:
-		def defaultDeviceName = "First device"
+		def defaultDeviceName = "Richard's iPhone"
 		User richardDefault = addRichard()
 		setCreationTimeOfMandatoryGoalsToNow(richardDefault)
 		setGoalCreationTime(richardDefault, NEWS_ACT_CAT_URL, "W-1 Mon 02:18")
@@ -1543,6 +1544,61 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		cleanup:
 		appService.deleteUser(richardDefault)
+	}
+
+	def 'Richard\'s network activity is measured on iOS only'(def operatingSystem, def expectedValue)
+	{
+		given:
+		User richard = addRichard(false, operatingSystem)
+		setCreationTimeOfMandatoryGoalsToNow(richard)
+		addTimeZoneGoal(richard, SOCIAL_ACT_CAT_URL, ["01:00-12:00"], "W-1 Mon 02:18")
+		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataIgnoreDefaultDevice)
+		Goal timeZoneGoalSocialRichard = richard.findActiveGoal(SOCIAL_ACT_CAT_URL)
+
+		// Activities on default device
+		reportNetworkActivity(richard, ["social"], "http://www.facebook.com", "W-1 Mon 03:20")
+
+		def expectedValuesRichardLastWeek = [
+			"Mon" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: expectedValue]]],
+			"Tue" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Wed" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Thu" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Fri" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Sat" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]]]
+
+		def currentDayOfWeek = YonaServer.getCurrentDayOfWeek()
+		def expectedTotalDays = 6 + currentDayOfWeek + 1
+		def expectedTotalWeeks = 2
+
+		when:
+		def responseWeekOverviews = appService.getWeekActivityOverviews(richard)
+		//get all days at once (max 2 weeks) to make assertion easy
+		def responseDayOverviewsAll = appService.getDayActivityOverviews(richard, ["size": 14])
+
+		then:
+		assertWeekOverviewBasics(responseWeekOverviews, [3, 1], expectedTotalWeeks)
+		assertWeekDateForCurrentWeek(responseWeekOverviews)
+
+		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+
+		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, timeZoneGoalSocialRichard, 6)
+
+		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, "Mon")
+
+		assertWeekDetailForGoal(richard, weekOverviewLastWeek, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek)
+
+		assertDayOverviewBasics(responseDayOverviewsAll, expectedTotalDays, expectedTotalDays, 14)
+		assertDayOverviewForTimeZoneGoal(responseDayOverviewsAll, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
+
+		assertDayDetail(richard, responseDayOverviewsAll, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
+
+		cleanup:
+		appService.deleteUser(richard)
+
+		where:
+		operatingSystem | expectedValue
+		"ANDROID" | [ : ]
+		"IOS" | [13 : 1]
 	}
 
 	private def getRawActivityData(User user, relativeDate, goal) {

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -358,14 +358,16 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(bob)
 	}
 
-	def 'Goal conflict of Bob is reported to Richard and Bob'()
+	def 'Goal conflict of Bob (on iOS and Android) is reported to Richard and Bob'(def operatingSystem)
 	{
 		given:
-		def richardAndBob = addRichardAndBobAsBuddies()
-		User richard = richardAndBob.richard
-		User bob = richardAndBob.bob
+		User richard = addRichard(false)
+		User bob = addBob(false, operatingSystem)
+		bob.emailAddress = "bob@dunn.com"
+		appService.makeBuddies(richard, bob)
 		richard = appService.reloadUser(richard)
-		bob = appService.reloadUser(bob)
+		bob = appService.reloadUser(bob, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataIgnoreDefaultDevice)
+
 		Goal goalBob = bob.findActiveGoal(GAMBLING_ACT_CAT_URL)
 		Goal goalBuddyBob = richard.buddies[0].findActiveGoal(GAMBLING_ACT_CAT_URL)
 		ZonedDateTime goalConflictTime = YonaServer.now
@@ -407,6 +409,11 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		cleanup:
 		appService.deleteUser(richard)
 		appService.deleteUser(bob)
+
+		where:
+		operatingSystem | _
+		"ANDROID" | _
+		"IOS" | _
 	}
 
 	def 'Goal conflict of Richard with an 2k long URL is reported to Richard and Bob'()

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
@@ -169,7 +169,7 @@ public class UserActivityController extends ActivityControllerBase
 
 	private Map<UUID, String> buildDeviceAnonymizedIdToDeviceNameMap(UUID userId)
 	{
-		return userService.getPrivateUser(userId).getOwnPrivateData().getDevices().get().stream().map(UserDeviceDto.class::cast)
+		return userService.getPrivateUser(userId).getOwnPrivateData().getOwnDevices().stream()
 				.collect(Collectors.toMap(UserDeviceDto::getDeviceAnonymizedId, UserDeviceDto::getName));
 	}
 

--- a/core/src/main/java/nu/yona/server/crypto/seckey/CryptoSession.java
+++ b/core/src/main/java/nu/yona/server/crypto/seckey/CryptoSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.crypto.seckey;

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.entities;
 
@@ -84,6 +84,11 @@ public class DeviceAnonymized extends EntityWithUuid
 	public OperatingSystem getOperatingSystem()
 	{
 		return operatingSystem;
+	}
+
+	public void setOperatingSystem(OperatingSystem operatingSystem)
+	{
+		this.operatingSystem = operatingSystem;
 	}
 
 	public Optional<LocalDate> getLastMonitoredActivityDate()

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -171,17 +171,17 @@ public class DeviceService
 	{
 		UserAnonymizedDto userAnonymized = userAnonymizedService
 				.getUserAnonymized(userDto.getOwnPrivateData().getUserAnonymizedId());
-		UUID defaultDeviceAnonymizedId = getDefaultDeviceAnonymizedId(userAnonymized);
+		UUID defaultDeviceAnonymizedId = getDefaultDeviceAnonymized(userAnonymized).getId();
 		return userDto.getOwnPrivateData().getOwnDevices().stream()
 				.filter(d -> d.getDeviceAnonymizedId().equals(defaultDeviceAnonymizedId)).map(DeviceBaseDto::getId).findAny()
 				.orElseThrow(() -> DeviceServiceException.noDevicesFound(userAnonymized.getId()));
 	}
 
-	private UUID getDefaultDeviceAnonymizedId(UserAnonymizedDto userAnonymized)
+	private DeviceAnonymizedDto getDefaultDeviceAnonymized(UserAnonymizedDto userAnonymized)
 	{
 		return userAnonymized.getDevicesAnonymized().stream()
 				.sorted((d1, d2) -> Integer.compare(d1.getDeviceIndex(), d2.getDeviceIndex())).findFirst()
-				.map(DeviceAnonymizedDto::getId).orElseThrow(() -> DeviceServiceException.noDevicesFound(userAnonymized.getId()));
+				.orElseThrow(() -> DeviceServiceException.noDevicesFound(userAnonymized.getId()));
 	}
 
 	public UUID getDeviceAnonymizedId(UserDto userDto, UUID deviceId)
@@ -191,12 +191,17 @@ public class DeviceService
 				.orElseThrow(() -> DeviceServiceException.notFoundById(deviceId));
 	}
 
-	public UUID getDeviceAnonymizedId(UserAnonymizedDto userAnonymized, int deviceIndex)
+	public DeviceAnonymizedDto getDeviceAnonymized(UserAnonymizedDto userAnonymized, int deviceIndex)
 	{
-		return deviceIndex < 0 ? getDefaultDeviceAnonymizedId(userAnonymized)
+		return deviceIndex < 0 ? getDefaultDeviceAnonymized(userAnonymized)
 				: userAnonymized.getDevicesAnonymized().stream().filter(d -> d.getDeviceIndex() == deviceIndex).findAny()
-						.map(DeviceAnonymizedDto::getId)
 						.orElseThrow(() -> DeviceServiceException.notFoundByIndex(userAnonymized.getId(), deviceIndex));
+	}
+
+	public DeviceAnonymizedDto getDeviceAnonymized(UserAnonymizedDto userAnonymized, UUID deviceAnonymizedId)
+	{
+		return userAnonymized.getDevicesAnonymized().stream().filter(d -> d.getId().equals(deviceAnonymizedId)).findAny()
+				.orElseThrow(() -> DeviceServiceException.notFoundByAnonymizedId(userAnonymized.getId(), deviceAnonymizedId));
 	}
 
 	@Transactional

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -66,12 +66,17 @@ public class DeviceService
 	@Transactional
 	public DeviceBaseDto getDevice(UUID deviceId)
 	{
+		return UserDeviceDto.createInstance(getDeviceEntity(deviceId));
+	}
+
+	private UserDevice getDeviceEntity(UUID deviceId)
+	{
 		UserDevice deviceEntity = userDeviceRepository.findOne(deviceId);
 		if (deviceEntity == null)
 		{
 			throw DeviceServiceException.notFoundById(deviceId);
 		}
-		return UserDeviceDto.createInstance(deviceEntity);
+		return deviceEntity;
 	}
 
 	@Transactional
@@ -167,9 +172,8 @@ public class DeviceService
 		UserAnonymizedDto userAnonymized = userAnonymizedService
 				.getUserAnonymized(userDto.getOwnPrivateData().getUserAnonymizedId());
 		UUID defaultDeviceAnonymizedId = getDefaultDeviceAnonymizedId(userAnonymized);
-		return userDto.getOwnPrivateData().getDevices().get().stream()
-				.filter(d -> ((UserDeviceDto) d).getDeviceAnonymizedId().equals(defaultDeviceAnonymizedId))
-				.map(DeviceBaseDto::getId).findAny()
+		return userDto.getOwnPrivateData().getOwnDevices().stream()
+				.filter(d -> d.getDeviceAnonymizedId().equals(defaultDeviceAnonymizedId)).map(DeviceBaseDto::getId).findAny()
 				.orElseThrow(() -> DeviceServiceException.noDevicesFound(userAnonymized.getId()));
 	}
 
@@ -223,5 +227,15 @@ public class DeviceService
 		Set<Activity> activitiesOnDevice = activityRepository.findByDeviceAnonymized(deviceToBeRemoved.getDeviceAnonymized());
 		activitiesOnDevice.forEach(a -> a.setDeviceAnonymized(requestingDevice.getDeviceAnonymized()));
 		deleteDevice(userEntity, deviceToBeRemoved);
+	}
+
+	@Transactional
+	public void updateOperatingSystem(UUID userId, UUID deviceId, OperatingSystem operatingSystem)
+	{
+		userService.updateUser(userId, userEntity -> {
+			DeviceAnonymized deviceAnonymized = getDeviceEntity(deviceId).getDeviceAnonymized();
+			deviceAnonymized.setOperatingSystem(operatingSystem);
+			deviceAnonymizedRepository.save(deviceAnonymized);
+		});
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
 
@@ -28,6 +28,12 @@ public class DeviceServiceException extends YonaException
 	public static DeviceServiceException notFoundById(UUID id)
 	{
 		return new DeviceServiceException(HttpStatus.NOT_FOUND, "error.device.not.found.id", id);
+	}
+
+	public static DeviceServiceException notFoundByAnonymizedId(UUID userAnonymizedId, UUID deviceAnonymizedId)
+	{
+		return new DeviceServiceException(HttpStatus.NOT_FOUND, "error.device.not.found.anonymized.id", userAnonymizedId,
+				deviceAnonymizedId);
 	}
 
 	public static DeviceServiceException cannotDeleteLastDevice(UUID id)

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.service;
 
@@ -59,6 +59,30 @@ public abstract class GoalDto extends PolymorphicDto implements Serializable
 	protected GoalDto(Optional<LocalDateTime> creationTime)
 	{
 		this(null, creationTime, Optional.empty(), null, false /* ignored */);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return id.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj)
+	{
+		if (this == obj)
+			return true;
+		if (getClass() != obj.getClass())
+			return false;
+		GoalDto other = (GoalDto) obj;
+		if (id == null)
+		{
+			if (other.id != null)
+				return false;
+		}
+		else if (!id.equals(other.id))
+			return false;
+		return true;
 	}
 
 	public abstract void validate();

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
@@ -64,25 +64,37 @@ public abstract class GoalDto extends PolymorphicDto implements Serializable
 	@Override
 	public int hashCode()
 	{
-		return id.hashCode();
+		return (id == null) ? super.hashCode() : id.hashCode();
 	}
 
 	@Override
 	public boolean equals(Object obj)
 	{
 		if (this == obj)
-			return true;
-		if (getClass() != obj.getClass())
-			return false;
-		GoalDto other = (GoalDto) obj;
-		if (id == null)
 		{
-			if (other.id != null)
-				return false;
+			return true;
 		}
-		else if (!id.equals(other.id))
+		if (getClass() != obj.getClass())
+		{
 			return false;
-		return true;
+		}
+		GoalDto that = (GoalDto) obj;
+		if (this.id == that.id)
+		{
+			return true;
+		}
+		if (this.id == null)
+		{
+			// that.id isn't null, see previous if
+			return false;
+		}
+		return this.id.equals(that.id);
+	}
+
+	@Override
+	public String toString()
+	{
+		return this.getClass().getSimpleName() + " with ID " + id + " for activity category " + activityCategoryId;
 	}
 
 	public abstract void validate();

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/NewDeviceRequestService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/OwnUserPrivateDataDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/OwnUserPrivateDataDto.java
@@ -100,4 +100,11 @@ public class OwnUserPrivateDataDto extends UserPrivateDataBaseDto
 	{
 		return userAnonymizedId;
 	}
+
+	@JsonIgnore
+	public Set<UserDeviceDto> getOwnDevices()
+	{
+		return getDevices().orElseThrow(() -> new IllegalStateException("User must have devices")).stream()
+				.map(UserDeviceDto.class::cast).collect(Collectors.toSet());
+	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/PinResetRequestService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -107,6 +107,7 @@ error.device.request.invalid.password=Invalid temporary password to use new devi
 error.device.unknown.operating.system=Operating system ''{0}'' is not supported.
 error.device.invalid.device.name=Device name ''{0}'' is invalid. A valid device name is not longer than {1} characters and does not contain a ''{2}''.
 error.device.not.found.id=Device with ID ''{0}'' not found.
+error.device.not.found.anonymized.id=Device anonymized with ID ''{1}'' not found on user anonymized with ID ''{0}''
 error.device.cannot.delete.last.one=Cannot delete the last device. Device ID: ''{0}''
 error.device.collection.empty=The user anonymized with ID ''{0}'' has no devices. This is an invalid user state.
 error.device.not.found.index=The user anonymized with ID ''{0}'' has no device with the index ''{1}''

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -107,6 +107,7 @@ error.device.request.invalid.password=Het tijdelijke wachtwoord voor het ''new d
 error.device.unknown.operating.system=Besturingssysteem ''{0}'' wordt niet ondersteund.
 error.device.invalid.device.name=De apparaatnaam ''{0}'' is niet toegestaan. Een geldige apparaatnaam is niet langer dan {1} tekens en bevat geen ''{2}''.
 error.device.not.found.id=Apparaat met ID ''{0}'' niet gevonden.
+error.device.not.found.anonymized.id=Geanonimiseerd apparaat met ID ''{1}'' niet gevonden op geanonimiseerde gebruiker met ID ''{0}''
 error.device.cannot.delete.last.one=Kan laatste apparaat niet verwijderen. Apparaat ID: ''{0}''
 error.device.collection.empty=De geanonymiseerde gebruiker met ID ''{0}'' heeft geen apparaten. Dit is geen geldige toestand.
 error.device.not.found.index=De geanonymiseerde gebruiker met ID ''{0}'' heeft geen apparaat de index ''{1}''

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -363,7 +363,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	}
 
 	@Test
-	public void getDeviceAnonymizedId_byIndex_firstDevice_correctDevice()
+	public void getDeviceAnonymized_byIndex_firstDevice_correctDevice()
 	{
 		// Add devices
 		String deviceName1 = "First";
@@ -379,15 +379,15 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
 				containsInAnyOrder(deviceName1, deviceName2));
 
-		// Get the anonymized ID for the first index
-		UUID deviceAnonymizedId = service.getDeviceAnonymizedId(createRichardAnonymizedDto(), 0);
+		// Get the anonymized device for the first index
+		DeviceAnonymizedDto deviceAnonymized = service.getDeviceAnonymized(createRichardAnonymizedDto(), 0);
 
 		// Assert success
-		assertThat(deviceAnonymizedId, equalTo(userDeviceRepository.getOne(device1.getId()).getDeviceAnonymizedId()));
+		assertThat(deviceAnonymized.getId(), equalTo(userDeviceRepository.getOne(device1.getId()).getDeviceAnonymizedId()));
 	}
 
 	@Test
-	public void getDeviceAnonymizedId_byIndex_secondDevice_correctDevice()
+	public void getDeviceAnonymized_byIndex_secondDevice_correctDevice()
 	{
 		// Add devices
 		String deviceName1 = "First";
@@ -403,15 +403,15 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
 				containsInAnyOrder(deviceName1, deviceName2));
 
-		// Get the anonymized ID for the second index
-		UUID deviceAnonymizedId = service.getDeviceAnonymizedId(createRichardAnonymizedDto(), 1);
+		// Get the anonymized device for the second index
+		DeviceAnonymizedDto deviceAnonymized = service.getDeviceAnonymized(createRichardAnonymizedDto(), 1);
 
 		// Assert success
-		assertThat(deviceAnonymizedId, equalTo(userDeviceRepository.getOne(device2.getId()).getDeviceAnonymizedId()));
+		assertThat(deviceAnonymized.getId(), equalTo(userDeviceRepository.getOne(device2.getId()).getDeviceAnonymizedId()));
 	}
 
 	@Test
-	public void getDeviceAnonymizedId_byIndex_defaultDevice_correctDevice()
+	public void getDeviceAnonymized_byIndex_defaultDevice_correctDevice()
 	{
 		// Add devices
 		String deviceName1 = "First";
@@ -427,15 +427,15 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
 				containsInAnyOrder(deviceName1, deviceName2));
 
-		// Get the anonymized ID for a negative index, implies fall back to default device
-		UUID deviceAnonymizedId = service.getDeviceAnonymizedId(createRichardAnonymizedDto(), -1);
+		// Get the anonymized device for a negative index, implies fall back to default device
+		DeviceAnonymizedDto deviceAnonymized = service.getDeviceAnonymized(createRichardAnonymizedDto(), -1);
 
 		// Assert success
-		assertThat(deviceAnonymizedId, equalTo(userDeviceRepository.getOne(device1.getId()).getDeviceAnonymizedId()));
+		assertThat(deviceAnonymized.getId(), equalTo(userDeviceRepository.getOne(device1.getId()).getDeviceAnonymizedId()));
 	}
 
 	@Test
-	public void getDeviceAnonymizedId_byIndex_tryGetNonExistingIndex_exception()
+	public void getDeviceAnonymized_byIndex_tryGetNonExistingIndex_exception()
 	{
 		expectedException.expect(DeviceServiceException.class);
 		expectedException.expect(hasMessageId("error.device.not.found.index"));
@@ -455,7 +455,81 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 				containsInAnyOrder(deviceName1, deviceName2));
 
 		// Try to get the anonymized ID for a nonexisting index
-		service.getDeviceAnonymizedId(createRichardAnonymizedDto(), 2);
+		service.getDeviceAnonymized(createRichardAnonymizedDto(), 2);
+	}
+
+	@Test
+	public void getDeviceAnonymized_byId_firstDevice_correctDevice()
+	{
+		// Add devices
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		UserDevice device1 = addDeviceToRichard(0, deviceName1, operatingSystem1, "Unknown");
+		UUID deviceAnonymizedId1 = device1.getDeviceAnonymizedId();
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		addDeviceToRichard(1, deviceName2, operatingSystem2, "Unknown");
+
+		// Verify two devices are present
+		Set<UserDevice> devices = richard.getDevices();
+		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
+				containsInAnyOrder(deviceName1, deviceName2));
+
+		// Get the anonymized device for the first ID
+		DeviceAnonymizedDto deviceAnonymized = service.getDeviceAnonymized(createRichardAnonymizedDto(), deviceAnonymizedId1);
+
+		// Assert success
+		assertThat(deviceAnonymized.getId(), equalTo(userDeviceRepository.getOne(device1.getId()).getDeviceAnonymizedId()));
+	}
+
+	@Test
+	public void getDeviceAnonymized_byId_secondDevice_correctDevice()
+	{
+		// Add devices
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		addDeviceToRichard(0, deviceName1, operatingSystem1, "Unknown");
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		UserDevice device2 = addDeviceToRichard(1, deviceName2, operatingSystem2, "Unknown");
+		UUID deviceAnonymizedId2 = device2.getDeviceAnonymizedId();
+
+		// Verify two devices are present
+		Set<UserDevice> devices = richard.getDevices();
+		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
+				containsInAnyOrder(deviceName1, deviceName2));
+
+		// Get the anonymized device for the second ID
+		DeviceAnonymizedDto deviceAnonymized = service.getDeviceAnonymized(createRichardAnonymizedDto(), deviceAnonymizedId2);
+
+		// Assert success
+		assertThat(deviceAnonymized.getId(), equalTo(userDeviceRepository.getOne(device2.getId()).getDeviceAnonymizedId()));
+	}
+
+	@Test
+	public void getDeviceAnonymized_byId_tryGetNonExistingId_exception()
+	{
+		expectedException.expect(DeviceServiceException.class);
+		expectedException.expect(hasMessageId("error.device.not.found.anonymized.id"));
+
+		// Add devices
+		String deviceName1 = "First";
+		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
+		addDeviceToRichard(0, deviceName1, operatingSystem1, "Unknown");
+
+		String deviceName2 = "Second";
+		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
+		addDeviceToRichard(1, deviceName2, operatingSystem2, "Unknown");
+
+		// Verify two devices are present
+		Set<UserDevice> devices = richard.getDevices();
+		assertThat(devices.stream().map(UserDevice::getName).collect(Collectors.toSet()),
+				containsInAnyOrder(deviceName1, deviceName2));
+
+		// Try to get the anonymized ID for a nonexisting ID
+		service.getDeviceAnonymized(createRichardAnonymizedDto(), UUID.randomUUID());
 	}
 
 	@Test

--- a/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/UserRepositoryMock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.entities;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/UserServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
@@ -195,7 +195,7 @@ class CommonAssertions extends Service
 			assert device.keySet() == ["name", "operatingSystem", "registrationTime", "appLastOpenedDate", "vpnConnected", "_links"] as Set
 			assert device._links.keySet() == ["self", "edit"] as Set
 			assert device.name == "First device"
-			assert device.operatingSystem == "UNKNOWN"
+			assert device.operatingSystem == "UNKNOWN" || device.operatingSystem == "ANDROID" // Android is autorecognized on app activity post
 			assertDateTimeFormat(device.registrationTime)
 			assertDateFormat(device.appLastOpenedDate)
 			assert device.vpnConnected == true || device.vpnConnected == false

--- a/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -46,6 +46,12 @@ class CommonAssertions extends Service
 	{
 		assertResponseStatusOk(response)
 		assertUserWithPrivateData(response.responseData, false)
+	}
+
+	static void assertUserGetResponseDetailsWithPrivateDataIgnoreDefaultDevice(def response)
+	{
+		assertResponseStatusSuccess(response)
+		assertUserWithPrivateData(response.responseData, false, false, false)
 	}
 
 	static void assertUserGetResponseDetailsWithPrivateData(def response, assertDefaultDevice = true)
@@ -194,8 +200,8 @@ class CommonAssertions extends Service
 		{
 			assert device.keySet() == ["name", "operatingSystem", "registrationTime", "appLastOpenedDate", "vpnConnected", "_links"] as Set
 			assert device._links.keySet() == ["self", "edit"] as Set
-			assert device.name == "First device"
-			assert device.operatingSystem == "UNKNOWN" || device.operatingSystem == "ANDROID" // Android is autorecognized on app activity post
+			assert device.name == "First device" || device.name ==~ /.*'s iPhone/
+			assert device.operatingSystem == "UNKNOWN" || device.operatingSystem == "IOS"
 			assertDateTimeFormat(device.registrationTime)
 			assertDateFormat(device.appLastOpenedDate)
 			assert device.vpnConnected == true || device.vpnConnected == false


### PR DESCRIPTION
* When a device of the type UNKNOWN registers app activities, it is autoclassified as Android (as today only Android is capable of registering app activities)
* Network activities for Android devices are ignored unless they relate to a no-go goal of the user