### PR TITLE
YD-531 Fix error message for duplicate on white list

### DIFF
--- a/adminservice/src/main/resources/messages/messages.properties
+++ b/adminservice/src/main/resources/messages/messages.properties
@@ -1,8 +1,0 @@
-###############################################################################
-# Copyright (c) 2016 Stichting Yona Foundation
-#
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
-###############################################################################
-error.loading.goals.from.file=Error loading goals from file '{0}'

--- a/core/src/main/java/nu/yona/server/subscriptions/service/WhiteListedNumberService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/WhiteListedNumberService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import nu.yona.server.subscriptions.entities.WhiteListedNumber;
+import nu.yona.server.subscriptions.entities.WhiteListedNumberRepository;
 
 @Service
 public class WhiteListedNumberService
@@ -20,12 +21,20 @@ public class WhiteListedNumberService
 	@Autowired
 	private UserService userService;
 
+	@Autowired
+	private WhiteListedNumberRepository whiteListedNumberRepository;
+
 	@Transactional
 	public void addWhiteListedNumber(String mobileNumber)
 	{
 		userService.assertValidMobileNumber(mobileNumber);
 
-		WhiteListedNumber.getRepository().save(WhiteListedNumber.createInstance(mobileNumber));
+		if (whiteListedNumberRepository.findByMobileNumber(mobileNumber) != null)
+		{
+			throw WhiteListedNumberServiceException.numberAlreadyWhiteListed(mobileNumber);
+		}
+
+		whiteListedNumberRepository.save(WhiteListedNumber.createInstance(mobileNumber));
 	}
 
 	@Transactional

--- a/core/src/main/java/nu/yona/server/subscriptions/service/WhiteListedNumberServiceException.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/WhiteListedNumberServiceException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
@@ -17,6 +17,11 @@ public class WhiteListedNumberServiceException extends YonaException
 	private WhiteListedNumberServiceException(HttpStatus statusCode, String messageId, Serializable... parameters)
 	{
 		super(statusCode, messageId, parameters);
+	}
+
+	public static WhiteListedNumberServiceException numberAlreadyWhiteListed(String mobileNumber)
+	{
+		return new WhiteListedNumberServiceException(HttpStatus.BAD_REQUEST, "error.number.already.white.listed", mobileNumber);
 	}
 
 	public static WhiteListedNumberServiceException numberNotWhiteListed(String mobileNumber)

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -45,6 +45,7 @@ error.user.exists.created.on.buddy.request=User with mobile number ''{0}'' alrea
 error.user.exists=User with mobile number ''{0}'' already exists
 error.user.maximum.number.reached=Reached the maximum number of users that is currently allowed
 
+error.number.already.white.listed=Mobile number ''{0}'' is already on the white list of allowed numbers
 error.number.not.white.listed=Mobile number ''{0}'' does not occur on the white list of allowed numbers
 
 error.useranonymizedid.not.found=Anonymized user ID ''{0}'' not found

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -45,7 +45,8 @@ error.user.exists.created.on.buddy.request=Gebruiker met mobiel nummer ''{0}'' b
 error.user.exists=Gebruiker met mobiel nummer ''{0}'' bestaat al
 error.user.maximum.number.reached=Het maximum toegestane gebruikersaantal is bereikt
 
-error.number.not.white.listed=Mobiel nummer ''{0}'' staat niet in de lijst van toegestane nummers
+error.number.already.white.listed=Mobiel nummer ''{0}'' staat al op de lijst van toegestane nummers
+error.number.not.white.listed=Mobiel nummer ''{0}'' staat niet op de lijst van toegestane nummers
 
 error.useranonymizedid.not.found=VPN login ID ''{0}'' niet gevonden
 


### PR DESCRIPTION
Removed messages.properties from admin service component, as it was hiding the common error messages resource in core.