### PR TITLE
YD-522 Fixed multidevice activity issue

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/ActivityCacheService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/ActivityCacheService.java
@@ -24,7 +24,7 @@ import nu.yona.server.analysis.entities.DayActivity;
 @CacheConfig(cacheManager = "localCache", cacheNames = "lastActivity")
 public class ActivityCacheService
 {
-	@Cacheable(key = "{#userAnonymizedId,#goalId}")
+	@Cacheable(key = "{#userAnonymizedId,#deviceAnonymizedId,#goalId}")
 	@Transactional
 	public ActivityDto fetchLastActivityForUser(UUID userAnonymizedId, UUID deviceAnonymizedId, UUID goalId)
 	{
@@ -39,7 +39,7 @@ public class ActivityCacheService
 		return lastActivity == null ? null : ActivityDto.createInstance(lastActivity);
 	}
 
-	@CachePut(key = "{#userAnonymizedId,#goalId}")
+	@CachePut(key = "{#userAnonymizedId,#deviceAnonymizedId,#goalId}")
 	public ActivityDto updateLastActivityForUser(UUID userAnonymizedId, UUID deviceAnonymizedId, UUID goalId,
 			ActivityDto activity)
 	{

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1450,7 +1450,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		// Activities on second device
 		reportAppActivity(richardIphone, "NU.nl", "W-1 Mon 04:10", "W-1 Mon 04:20") // Partial overlap
-		// TODO YD-522 reportAppActivity(richardIphone, "NU.nl", "W-1 Mon 05:20", "W-1 Mon 05:30") // Full overlap
+		reportAppActivity(richardIphone, "NU.nl", "W-1 Mon 05:20", "W-1 Mon 05:30") // Full overlap
 		reportAppActivity(richardIphone, "NU.nl", "W-1 Mon 06:15", "W-1 Mon 06:35") // No overlap at all
 
 		def expectedValuesRichardLastWeek = [
@@ -1485,11 +1485,11 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 				"endTime": "W-1 Mon 04:20",
 				"app": "NU.nl",
 				"deviceName": iphoneDeviceName
-			], /* TODO YD-522 [	"startTime": "W-1 Mon 05:20",
-			 "endTime": "W-1 Mon 05:30",
-			 "app": "NU.nl",
-			 "deviceName": iphoneDeviceName
-			 ],*/ [	"startTime": "W-1 Mon 06:15",
+			], [	"startTime": "W-1 Mon 05:20",
+				"endTime": "W-1 Mon 05:30",
+				"app": "NU.nl",
+				"deviceName": iphoneDeviceName
+			], [	"startTime": "W-1 Mon 06:15",
 				"endTime": "W-1 Mon 06:35",
 				"app": "NU.nl",
 				"deviceName": iphoneDeviceName


### PR DESCRIPTION
The ActivityCacheService didn't specify the device anonymized ID as part of the cache key. Due to that, activities of different devices were considered irrelevant because they overlapped.