### PR TITLE
YD-540 New Smootwall places urlcategory differently

### DIFF
--- a/scripts/smoothwall/HandleDansGuardianLog.pl
+++ b/scripts/smoothwall/HandleDansGuardianLog.pl
@@ -57,12 +57,12 @@ sub transform_log_record ($) {
 		log_warning "No user name";
 		return undef;
 	}
-	if (!$log_message->{'requesttags'}->{'urlcategory'}) {
+	if (!$log_message->{'tagset'}->{'urlcategory'}) {
 		# Unclassified request. Probably an HTTPS site
 		return undef;
 	}
 
-	my @url_categories_logged = keys $log_message->{'requesttags'}->{'urlcategory'};
+	my @url_categories_logged = keys $log_message->{'tagset'}->{'urlcategory'};
 	my @relevant_url_categories_logged = filter_relevant_url_categories \@url_categories_logged;
 	if (!@relevant_url_categories_logged) {
 		# Categories are not relevant


### PR DESCRIPTION
Earlier versions of Smoothwall placed the urlcategory under requesttags. The current version puts it under tagset. Updated the Perl script accordingly.