### PR TITLE
YD-514 Corrected photo links

### DIFF
--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1529,7 +1529,7 @@ definitions:
   UserPhotoLink:
     type: object
     properties:
-      edit:
+      "yona:userPhoto":
         type: object
         required:
           - href
@@ -1540,7 +1540,7 @@ definitions:
   EditUserPhotoLink:
     type: object
     properties:
-      edit:
+      "yona:editUserPhoto":
         type: object
         required:
           - href


### PR DESCRIPTION
The definitions for ``UserPhotoLink`` and ``EditUserPhotoLink`` define the ``edit`` link instead of respectively ``yona:userPhoto`` and ``yona:editUserPhoto``.