### PR TITLE
YD-547 Fixed disappearing user photo link

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
@@ -397,10 +397,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def multipartEntity = MultipartEntityBuilder.create()
-				.addPart("file", new InputStreamBody(new ByteArrayInputStream(Base64.getDecoder().decode(EXAMPLE_PNG_DATA_BASE64)), "image/png", "MyPhoto.png"))
-				.build()
-		assertResponseStatusOk(appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity))
+		uploadUserPhoto(richard)
 
 		when:
 		def newNickname = "NewNickName"

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
@@ -189,7 +189,6 @@ public class UserDto
 		originalUserEntity.setLastName(lastName);
 		originalUserEntity.setMobileNumber(mobileNumber);
 		originalUserEntity.setNickname(privateData.getNickname());
-		originalUserEntity.setUserPhotoId(privateData.getUserPhotoId());
 	}
 
 	/**


### PR DESCRIPTION
The UserDto class accidentally updated the user photo ID. This was wrong, as updating the user photo link is done differently.