### PR TITLE
Kti helm healthchecks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
 				sh script: 'helm delete yona; kubectl delete -n yona configmaps --all; kubectl delete -n yona job --all; kubectl delete -n yona secrets --all; kubectl delete pvc -n yona --all', returnStatus: true
 				sh 'helm repo update'
 				sh 'helm upgrade --install --namespace yona --values /opt/ope-cloudbees/yona/k8s/helm/values.yaml --version 1.2.$BUILD_NUMBER_TO_DEPLOY yona yona/yona'
-				sh 'scripts/wait-for-services.sh k8s'
+				sh 'scripts/wait-for-services.sh k8snew'
 			}
 		}
 		stage('Run integration tests') {
@@ -83,7 +83,7 @@ pipeline {
 			steps {
 				sh 'helm repo update'
 				sh 'helm upgrade --install --namespace yona --set mariadb.mariadbUser=$YONA_DB_USR --set mariadb.mariadbPassword="$YONA_DB_PSW" --values /opt/ope-cloudbees/yona/k8s/helm/values.yaml --version 1.2.$BUILD_NUMBER_TO_DEPLOY yona yona/yona'
-				sh 'scripts/wait-for-services.sh k8s'
+				sh 'scripts/wait-for-services.sh k8snew'
 			}
 		}
 		stage('Decide deploy to acceptance test server') {
@@ -142,6 +142,7 @@ pipeline {
 			steps {
 				sh 'helm repo add yona https://jump.ops.yona.nu/helm-charts'
 				sh 'helm upgrade --install -f /config/values.yaml --namespace yona --version 1.2.${BUILD_NUMBER_TO_DEPLOY} yona yona/yona'
+				sh 'scripts/wait-for-services.sh k8snew'
 			}
 		}
 		stage('Decide deploy to production server') {
@@ -166,6 +167,7 @@ pipeline {
 			steps {
 				sh 'helm repo add yona https://jump.ops.yona.nu/helm-charts'
 				sh 'helm upgrade --install -f /config/values.yaml --namespace yona --version 1.2.${BUILD_NUMBER_TO_DEPLOY} yona yona/yona'
+				sh 'scripts/wait-for-services.sh k8snew'
 			}
 		}
 	}

--- a/k8s/00_rbac-helm-config.yaml
+++ b/k8s/00_rbac-helm-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/k8s/02_storage.yaml
+++ b/k8s/02_storage.yaml
@@ -7,13 +7,13 @@ metadata:
     type: local
 spec:
   storageClassName: default
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 3Gi
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/data/yona-persistentvolumes/pv0001"
+    path: "/tmp/.yona-persistentvolumes/pv0001"
 ---
 kind: PersistentVolume
 apiVersion: v1
@@ -23,13 +23,13 @@ metadata:
     type: local
 spec:
   storageClassName: default
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 3Gi
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/data/yona-persistentvolumes/pv0002"
+    path: "/tmp/.yona-persistentvolumes/pv0002"
 ---
 kind: PersistentVolume
 apiVersion: v1
@@ -39,10 +39,10 @@ metadata:
     type: local
 spec:
   storageClassName: default
-  persistentVolumeReclaimPolicy: Recycle
+  persistentVolumeReclaimPolicy: Delete
   capacity:
     storage: 3Gi
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: "/data/yona-persistentvolumes/pv0003"
+    path: "/tmp/.yona-persistentvolumes/pv0003"

--- a/k8s/02_storage.yaml
+++ b/k8s/02_storage.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     type: local
 spec:
-  storageClassName: yona-default
+  storageClassName: default
   persistentVolumeReclaimPolicy: Recycle
   capacity:
     storage: 3Gi
@@ -22,7 +22,7 @@ metadata:
   labels:
     type: local
 spec:
-  storageClassName: yona-default
+  storageClassName: default
   persistentVolumeReclaimPolicy: Recycle
   capacity:
     storage: 3Gi
@@ -38,7 +38,7 @@ metadata:
   labels:
     type: local
 spec:
-  storageClassName: yona-default
+  storageClassName: default
   persistentVolumeReclaimPolicy: Recycle
   capacity:
     storage: 3Gi

--- a/k8s/10_deployment_jnlp.yaml
+++ b/k8s/10_deployment_jnlp.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: yona-ops-jnlp
+  labels:
+    app: jnlp
+    stage: ops
+spec:
+  replicas: 1
+  strategy: 
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: admin
+        stage: ops
+    spec:
+      containers:
+        - name: jnlp-slave
+          image: yonadev/jnlp-slave-k8s-helm:latest
+          imagePullPolicy: IfNotPresent
+          env:       
+            - name: JENKINS_URL
+              value: http://127.0.0.1:1234
+            - name: JENKINS_SECRET
+              value: deadb33f
+            - name: JENKINS_AGENT_NAME
+              value: Dev

--- a/k8s/helm/yona/Chart.yaml
+++ b/k8s/helm/yona/Chart.yaml
@@ -1,6 +1,6 @@
 name: yona
 home: https://yona.nu/
-version: 0.0.5
+version: 0.0.6
 appVersion: _ReplaceWithBuildNumber_
 description: The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging
 sources:

--- a/k8s/helm/yona/Chart.yaml
+++ b/k8s/helm/yona/Chart.yaml
@@ -1,7 +1,7 @@
 name: yona
 home: https://yona.nu/
 version: 0.0.6
-appVersion: _ReplaceWithBuildNumber_
+appVersion: 713
 description: The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging
 sources:
   - https://github.com/yonadev/yona-server

--- a/k8s/helm/yona/Chart.yaml
+++ b/k8s/helm/yona/Chart.yaml
@@ -1,7 +1,7 @@
 name: yona
 home: https://yona.nu/
 version: 0.0.6
-appVersion: 713
+appVersion: _ReplaceWithBuildNumber_
 description: The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging
 sources:
   - https://github.com/yonadev/yona-server

--- a/k8s/helm/yona/requirements.yaml
+++ b/k8s/helm/yona/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository:  "https://kubernetes-charts.storage.googleapis.com"
     condition: support_infrastructure.enabled
   - name: ldap
-    version: 0.1.0
+    version: 0.1.1
     repository:  "https://jump.ops.yona.nu/helm-charts"
     condition: support_infrastructure.enabled

--- a/k8s/helm/yona/templates/01_configmap_properties.yaml
+++ b/k8s/helm/yona/templates/01_configmap_properties.yaml
@@ -39,7 +39,7 @@ data:
     {{- if .Values.ldap.url_override}}
     yona.ldap.url={{ .Values.ldap.url_override }}
     {{- else }}
-    yona.ldap.url=ldap://ldap.{{ .Release.Namespace }}.svc.cluster.local
+    yona.ldap.url=ldap://{{ .Values.ldap.hostname }}:{{ .Values.ldap.port }}
     {{- end }}
     yona.ldap.baseDn={{ .Values.ldap.dn | default "DC=example,DC=local" }}
     yona.ldap.accessUserDn={{ .Values.ldap.user_dn | default "cn=admin,dc=example,dc=local" }}

--- a/k8s/helm/yona/templates/03_job-liquibase.yaml
+++ b/k8s/helm/yona/templates/03_job-liquibase.yaml
@@ -12,8 +12,37 @@ metadata:
 spec:
   template:
     metadata:
+      labels:
+        app: liquibase
+        build: {{ .Chart.AppVersion | quote }}
+        stage: {{ .Values.global.stage | default "develop" }}
       name: {{ .Values.global.stage | default "develop" }}-yona-liquibase-update
     spec:
+      initContainers:
+        - name: validatedb
+          image: craftypenguins/k8s-init-mysql:latest
+          env:
+            - name: DBUSER
+              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+            - name: DBPASSWORD
+              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+            - name: DBHOST
+              value: {{ .Values.mariadb.mariadbHostname | quote }}
+            - name: DBNAME
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: TIMEOUT
+              value: "10s"
+        - name: validateldap
+          image: craftypenguins/k8s-init-ldap:latest
+          env:
+            - name: DN
+              value: {{ .Values.ldap.user_dn | default "cn=admin,dc=example,dc=local" | quote }}
+            - name: PASSWORD
+              value: {{ .Values.ldap.user_password | default "ldappassword" | quote }}
+            - name: LDAPHOST
+              value: "{{ .Values.ldap.hostname }}"
+            - name: LDAPPORT
+              value: "{{ .Values.ldap.port | default 389 }}"
       containers:
         - name: liquibase
           image: yonadev/yona-mariadb-liquibase-update:build-{{ .Chart.AppVersion }}
@@ -27,7 +56,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
             - name: RELEASE
               value: {{ .Chart.AppVersion | quote }}
@@ -38,7 +67,7 @@ spec:
               {{- if .Values.ldap.url_override}}
               value: {{ .Values.ldap.url_override | quote }}
               {{- else }}
-              value: "ldap://ldap.{{ .Release.Namespace }}.svc.cluster.local"
+              value: "ldap://{{ .Values.ldap.hostname }}:{{ .Values.ldap.port }}"
               {{- end }}
             - name: LDAP_DN
               value: {{ .Values.ldap.dn | default "DC=example,DC=local" | quote }}

--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -20,8 +20,23 @@ spec:
     metadata:
       labels:
         app: admin
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
+      initContainers:
+        - name: validatedb
+          image: craftypenguins/k8s-init-mysql:latest
+          env:
+            - name: DBUSER
+              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+            - name: DBPASSWORD
+              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+            - name: DBHOST
+              value: {{ .Values.mariadb.mariadbHostname | quote }}
+            - name: DBNAME
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: TIMEOUT
+              value: "10s"
       containers:
         - name: admin
           image: 'yonadev/adminservice:build-{{ .Chart.AppVersion }}'
@@ -35,7 +50,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
             - name: YONA_BATCH_SERVICE_SERVICE_URL
             {{- if .Values.batch.url_override }}
@@ -49,6 +64,14 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /opt/app/config
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: 9080
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
       volumes:
         - name: config-volume
           configMap:

--- a/k8s/helm/yona/templates/10_deployment_analysis.yaml
+++ b/k8s/helm/yona/templates/10_deployment_analysis.yaml
@@ -20,13 +20,28 @@ spec:
     metadata:
       labels:
         app: analysis
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
+      initContainers:
+        - name: validatedb
+          image: craftypenguins/k8s-init-mysql:latest
+          env:
+            - name: DBUSER
+              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+            - name: DBPASSWORD
+              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+            - name: DBHOST
+              value: {{ .Values.mariadb.mariadbHostname | quote }}
+            - name: DBNAME
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: TIMEOUT
+              value: "10s"
       containers:
         - name: analysis
           image: 'yonadev/analysisservice:build-{{ .Chart.AppVersion }}'
           imagePullPolicy: Always
-          env:       
+          env:
             - name: YONA_DB_USER_NAME
               value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
             - name: YONA_DB_PASSWORD
@@ -35,7 +50,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
           ports:
             - containerPort: 8080
@@ -43,6 +58,13 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /opt/app/config
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: 9080
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config-volume
           configMap:

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -20,8 +20,23 @@ spec:
     metadata:
       labels:
         app: app
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
+      initContainers:
+        - name: validatedb
+          image: craftypenguins/k8s-init-mysql:latest
+          env:
+            - name: DBUSER
+              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+            - name: DBPASSWORD
+              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+            - name: DBHOST
+              value: {{ .Values.mariadb.mariadbHostname | quote }}
+            - name: DBNAME
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: TIMEOUT
+              value: "10s"
       containers:
         - name: app
           image: 'yonadev/appservice:build-{{ .Chart.AppVersion }}'
@@ -35,7 +50,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
             - name: YONA_ANALYSIS_SERVICE_SERVICE_URL
             {{- if hasKey .Values.analysis "url_override" }}
@@ -59,6 +74,13 @@ spec:
               mountPath: /opt/app/resources
             - name: apple-resources
               mountPath: /opt/app/apple
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: 9080
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config-volume
           configMap:

--- a/k8s/helm/yona/templates/10_deployment_batch.yaml
+++ b/k8s/helm/yona/templates/10_deployment_batch.yaml
@@ -20,8 +20,23 @@ spec:
     metadata:
       labels:
         app: batch
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
+      initContainers:
+        - name: validatedb
+          image: craftypenguins/k8s-init-mysql:latest
+          env:
+            - name: DBUSER
+              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+            - name: DBPASSWORD
+              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+            - name: DBHOST
+              value: {{ .Values.mariadb.mariadbHostname | quote }}
+            - name: DBNAME
+              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+            - name: TIMEOUT
+              value: "10s"
       containers:
         - name: batch
           image: 'yonadev/batchservice:build-{{ .Chart.AppVersion }}'
@@ -35,7 +50,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
           ports:
             - containerPort: 8080
@@ -43,6 +58,13 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /opt/app/config
+          livenessProbe:
+            httpGet:
+              path: /health/
+              port: 9080
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            timeoutSeconds: 5
       volumes:
         - name: config-volume
           configMap:

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -147,8 +147,8 @@ ldap:
   user_dn: "cn=admin,dc=example,dc=local"
   user_password: "ldappassword"
   config_password: "config"
-  storage_class_name_ldap: default
-  storage_class_name_sldap: default
+  storage_class_name_ldap: standard
+  storage_class_name_sldap: standard
 
 sms:
   enabled: false
@@ -174,7 +174,7 @@ mariadb:
   mariadbPassword: develop
   mariadbDatabase: yona
   persistence:
-    storageClass: default
+    storageClass: standard
     size: 2Gi
   user: develop
   password: develop

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -141,10 +141,14 @@ ldap:
   org: "Yona Development"
   domain: "example.local"
   #url_override: "ldap://ldap.yona.svc.cluster.local:389"
+  hostname: ldap.yona.svc.cluster.local
+  port: 389
   dn: "dc=example,dc=local"
   user_dn: "cn=admin,dc=example,dc=local"
   user_password: "ldappassword"
   config_password: "config"
+  storage_class_name_ldap: default
+  storage_class_name_sldap: default
 
 sms:
   enabled: false
@@ -170,12 +174,12 @@ mariadb:
   mariadbPassword: develop
   mariadbDatabase: yona
   persistence:
-    storageClass: yona-default
+    storageClass: default
     size: 2Gi
   user: develop
   password: develop
-  #nameOverride: develop
   #url_override: "jdbc:mariadb://db.default.svc.cluster.local/yona"
+  mariadbHostname: yona-mariadb.yona.svc.cluster.local
 
 admin:
   act_categories_json_file : productionActivityCategories.json

--- a/k8s/hostpath_provisioner/01_provisioner-rbac.yaml
+++ b/k8s/hostpath_provisioner/01_provisioner-rbac.yaml
@@ -1,0 +1,35 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: hostpath-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hostpath-provisioner
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system

--- a/k8s/hostpath_provisioner/02_provisioner-deployment.yaml
+++ b/k8s/hostpath_provisioner/02_provisioner-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hostpath-provisioner
+  labels:
+    k8s-app: hostpath-provisioner
+  namespace: kube-system
+
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+
+  selector:
+    matchLabels:
+      k8s-app: hostpath-provisioner
+
+  template:
+    metadata:
+      labels:
+        k8s-app: hostpath-provisioner
+
+    spec:
+      containers:
+        - name: hostpath-provisioner
+          image: mazdermind/hostpath-provisioner:latest
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: PV_DIR
+              value: /tmp/hostpath-provisioner
+          volumeMounts:
+            - name: pv-volume
+              mountPath: /tmp/hostpath-provisioner
+      volumes:
+        - name: pv-volume
+          hostPath:
+            path: /tmp/hostpath-provisioner

--- a/k8s/hostpath_provisioner/03_provisioner-sc.yaml
+++ b/k8s/hostpath_provisioner/03_provisioner-sc.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: hostpath

--- a/k8s/hostpath_provisioner/README.md
+++ b/k8s/hostpath_provisioner/README.md
@@ -1,0 +1,10 @@
+# Hostpath Provisioner for Kubeadm based test clusters
+
+The helm yona setup should work out of the box for Minikube
+but if being run against a system without any storage class/provisioner
+setup the persistent volume claims will need to be pre-setup or 
+the tooling here will need to be setup
+
+- Create a /tmp/hostpath-provisioner directory on the host or edit provisioner-deployment.yaml with alternative
+- kubectl create in order the entries in this directory
+

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e # Fail on error
 
+_NAMESPACE=${NAMESPACE:-yona}
+
 function waitTillGetWorks() {
 	duration=600
 	sleepTime=5
@@ -21,6 +23,26 @@ function waitTillGetWorks() {
 	return 0
 }
 
+function waitTillK8SInstanceWorks() {
+	duration=${3:-1200}
+	sleepTime=${4:-5}
+	iterations=$[$duration / $sleepTime]
+	n=0
+  echo "Waiting for ${1}-${BUILD_NUMBER_TO_DEPLOY} to become ${2}"
+	until [ $n -ge $iterations ]
+	do
+    kubectl get pods -a --selector=app=${1},build=${BUILD_NUMBER_TO_DEPLOY} -n ${_NAMESPACE} -o jsonpath='{.items[*].status.phase}' | grep -q ${2} && echo -e "\n - Success\n" && break
+    echo -n '.'
+		n=$[$n + 1]
+		sleep $sleepTime
+	done
+	if [ $n -ge $iterations ]
+	then
+		echo "Container ${BUILD_NUMBER_TO_DEPLOY}-${1} failed to become ${2} within timeout ($duration seconds)"
+		return 1
+	fi
+}
+
 # Temporarily use a different approach for Kubernetes
 if [ "$1" == "k8s" ]
 then
@@ -39,6 +61,13 @@ then
 		echo "Failed to get URL $1 within timeout ($duration seconds)"
 		return 1
 	fi
+elif [ "$1" == "k8snew" ]
+then
+	waitTillK8SInstanceWorks liquibase Succeeded 1200 5
+	waitTillK8SInstanceWorks admin Running 60
+	waitTillK8SInstanceWorks analysis Running 60
+	waitTillK8SInstanceWorks app Running 60
+	waitTillK8SInstanceWorks batch Running 60
 else
 	echo "Waiting for the admin service to start"
 	waitTillGetWorks http://127.0.0.1:8080/activityCategories/


### PR DESCRIPTION
- Added some new support files (helm rbac, jenkins slave example)
- Added new profile to wait-for-services script called k8snew.  This should work well with the new health checks and init containers in the pod specs.
- Containers are health checked against /health/ for the springboot containers.
- Containers are prefixed with an init container for DB and LDAP as needed (ldap only on liquibase for now)
- Changed the default storage handling to work faster and with less bootstrap code when using Minikube, and to use more common naming convention for other clusters.  Will still need to see how this impacts dev-build (might need to upgrade k8s there, and add a proper provisioner)
- Most dramatic change is the new values.yaml setup to break the ldap and db out from the Java URL references to be used by the init containers.  New values will need to be setup for the environments if not using the defaults.
- Increased the ldap package version required (new ldap helm version already deployed)
