### PR TITLE
K8S API Changes do not allow for mutable labels on containers

### DIFF
--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         app: admin
-        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:

--- a/k8s/helm/yona/templates/10_deployment_analysis.yaml
+++ b/k8s/helm/yona/templates/10_deployment_analysis.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         app: analysis
-        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         app: app
-        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:

--- a/k8s/helm/yona/templates/10_deployment_batch.yaml
+++ b/k8s/helm/yona/templates/10_deployment_batch.yaml
@@ -20,7 +20,6 @@ spec:
     metadata:
       labels:
         app: batch
-        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -31,7 +31,11 @@ function waitTillK8SInstanceWorks() {
   echo "Waiting for ${1}-${BUILD_NUMBER_TO_DEPLOY} to become ${2}"
 	until [ $n -ge $iterations ]
 	do
-    kubectl get pods -a --selector=app=${1},build=${BUILD_NUMBER_TO_DEPLOY} -n ${_NAMESPACE} -o jsonpath='{.items[*].status.phase}' | grep -q ${2} && echo -e "\n - Success\n" && break
+    if [ "$2" == "Succeeded" ]; then  #Hack because we can't have labels in deployments that change over releases
+      kubectl get pods -a --selector=app=${1},build=${BUILD_NUMBER_TO_DEPLOY} -n ${_NAMESPACE} -o jsonpath='{.items[*].status.phase}' | grep -q ${2} && echo -e "\n - Success\n" && break
+    else
+      kubectl get pods -a --selector=app=${1} -n ${_NAMESPACE} -o jsonpath='{.items[*].status.phase}' | grep -q ${2} && echo -e "\n - Success\n" && break
+    fi
     echo -n '.'
 		n=$[$n + 1]
 		sleep $sleepTime


### PR DESCRIPTION
Due to changes that seem to affect us now at the beta 1.9.4 level of k8s, combined with new helm, we can no longer use the dynamic manifest labels because they are immutable now.  It makes logical sense, but it make for tracking a specific pod release when used with rolling upgrades harder.  We have to rely on the rolling upgrade system to keep track of that.
This restriction is not on the Job containers, and since that leads our process, we can still watch for that first in the wait-for-service checks.