### PR TITLE
YD-551 Workaround for double encoding of invite URL

### DIFF
--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 import org.springframework.hateoas.hal.CurieProvider;
@@ -189,7 +190,19 @@ public class BuddyController extends ControllerBase
 
 	public String getInviteUrl(UUID newUserId, String tempPassword)
 	{
-		return UserController.getUserSelfLinkWithTempPassword(newUserId, tempPassword).getHref();
+		// getUserSelfLinkWithTempPassword should actually call expand, s we don't need to strip template parameters
+		// This is not being done because of https://github.com/spring-projects/spring-hateoas/issues/703
+		return stripTemplateParameters(UserController.getUserSelfLinkWithTempPassword(newUserId, tempPassword));
+	}
+
+	private String stripTemplateParameters(Link link)
+	{
+		String linkString = link.getHref();
+		if (link.isTemplated())
+		{
+			return linkString.substring(0, linkString.indexOf("{"));
+		}
+		return linkString;
 	}
 
 	private BuddyResourceAssembler createResourceAssembler(UUID userId)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -397,7 +397,8 @@ public class UserController extends ControllerBase
 	{
 		ControllerLinkBuilder linkBuilder = linkTo(
 				methodOn(UserController.class).getUser(Optional.empty(), tempPassword, userId.toString(), null, null, userId));
-		return linkBuilder.withSelfRel().expand(OMITTED_PARAMS);
+		// Should call expand, but that's not done because of https://github.com/spring-projects/spring-hateoas/issues/703
+		return linkBuilder.withSelfRel();
 	}
 
 	private static Link getConfirmMobileLink(UUID userId, Optional<UUID> requestingDeviceId)


### PR DESCRIPTION
Due to issue spring-projects/spring-hateoas#703, the URL was encoded three times. A workaround is implemented now.