### PR TITLE
YD-555 omit the confirmMobileNumber link for users created on buddy r…

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -59,7 +59,9 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertEmail()
+		def inviteUrl = getInviteUrl()
 
 		when:
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
@@ -68,7 +70,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		bob.firstName == "Bob"
 		bob.lastName == "Dunn"
 		bob.mobileNumber == mobileNumberBob
-		bob.mobileNumberConfirmationUrl != null
+		bob.mobileNumberConfirmationUrl == null
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -80,7 +82,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
 		when:
@@ -123,7 +126,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 
 		when:
@@ -153,7 +157,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -182,7 +187,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -213,7 +219,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -246,7 +253,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -291,7 +299,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		def bob = appService.getUser(CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataCreatedOnBuddyRequest, inviteUrl, true, null)
 		def newNickname = "Bobby"
 		def newPassword = "B o b"
@@ -352,7 +361,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
+		def inviteUrl = getInviteUrl()
 
 		when:
 		def response = appService.getResource(YonaServer.stripQueryString(inviteUrl), [:], ["tempPassword": "hack", "requestingUserId": richard.getId()])
@@ -370,7 +380,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		def richard = addRichard()
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, makeMobileNumber(timestamp)))
+		def inviteUrl = getInviteUrl()
 
 		when:
 		def response = appService.updateResource(YonaServer.stripQueryString(inviteUrl), """{
@@ -452,7 +463,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 
 		when:
 		def response = appService.requestOverwriteUser(mobileNumberBob)
@@ -501,7 +513,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		def richard = addRichard()
 		def mobileNumberBob = makeMobileNumber(timestamp)
-		def inviteUrl = buildInviteUrl(sendBuddyRequestForBob(richard, mobileNumberBob))
+		assertResponseStatusCreated(sendBuddyRequestForBob(richard, mobileNumberBob))
+		def inviteUrl = getInviteUrl()
 		appService.requestOverwriteUser(mobileNumberBob)
 		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "Bob Changed",
 				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
@@ -571,8 +584,22 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		}""", user.password)
 	}
 
-	String buildInviteUrl(def response)
+	void assertEmail()
 	{
-		YonaServer.stripQueryString(response.responseData._embedded."yona:user"._links.self.href) + "?tempPassword=" + dummyTempPassword
+		def response = appService.getLastEmail()
+		assertResponseStatusOk(response)
+		assert response.responseData.from == "Richard Quinn <noreply@yona.nu>"
+		assert response.responseData.to == "Bob Dunn <bobdunn325@gmail.com>"
+		assert response.responseData.subject == "Become my friend on Yona!"
+		assert response.responseData.body ==~ /(?s).*Return to this mail and click <a href=\"http.*/
+	}
+
+	String getInviteUrl()
+	{
+		def response = appService.getLastEmail()
+		assertResponseStatusOk(response)
+		def matcher = response.responseData.body =~ /(?s).*Return to this mail and click <a href=\"([^\"]*)\".*/
+		assert matcher.matches()
+		matcher[0][1]
 	}
 }

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -190,7 +190,7 @@ public class BuddyController extends ControllerBase
 
 	public String getInviteUrl(UUID newUserId, String tempPassword)
 	{
-		// getUserSelfLinkWithTempPassword should actually call expand, s we don't need to strip template parameters
+		// getUserSelfLinkWithTempPassword should actually call expand, so we don't need to strip template parameters
 		// This is not being done because of https://github.com/spring-projects/spring-hateoas/issues/703
 		return stripTemplateParameters(UserController.getUserSelfLinkWithTempPassword(newUserId, tempPassword));
 	}

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import nu.yona.server.email.EmailService;
+import nu.yona.server.email.EmailService.EmailDto;
+import nu.yona.server.rest.ControllerBase;
+import nu.yona.server.subscriptions.rest.EmailTestController.EmailResource;
+
+/**
+ * This controller is only created for integration tests. When the email service is configured for testing, it doesn't send email
+ * but stores the last one in a field. This controller fetches that field.
+ */
+@Controller
+@ExposesResourceFor(EmailResource.class)
+@RequestMapping(value = "/emails", produces = { MediaType.APPLICATION_JSON_VALUE })
+public class EmailTestController extends ControllerBase
+{
+	@Autowired
+	private EmailService emailService;
+
+	/**
+	 * This method returns the last e-mail that was prepared to be sent (but not sent because e-mail was disabled).
+	 * 
+	 * @param password The Yona password as passed on in the header of the request.
+	 * @param userId The ID of the user. This is part of the URL.
+	 * @return the list of buddies for the current user
+	 */
+	@RequestMapping(value = "/last", method = RequestMethod.GET)
+	@ResponseBody
+	public HttpEntity<EmailResource> getLast()
+	{
+		return createOkResponse(emailService.getLastEmail(), createResourceAssembler());
+	}
+
+	private EmailResourceAssembler createResourceAssembler()
+	{
+		return new EmailResourceAssembler();
+	}
+
+	static class EmailResource extends Resource<EmailDto>
+	{
+		public EmailResource(EmailDto email)
+		{
+			super(email);
+		}
+
+	}
+
+	static class EmailResourceAssembler extends ResourceAssemblerSupport<EmailDto, EmailResource>
+	{
+		public EmailResourceAssembler()
+		{
+			super(EmailTestController.class, EmailResource.class);
+		}
+
+		@Override
+		public EmailResource toResource(EmailDto email)
+		{
+			return instantiateResource(email);
+		}
+
+		@Override
+		protected EmailResource instantiateResource(EmailDto email)
+		{
+			return new EmailResource(email);
+		}
+	}
+}

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -636,8 +636,11 @@ public class UserController extends ControllerBase
 			if (representation.includeOwnUserNumNotConfirmedContent.apply(user))
 			{
 				addEditLink(userResource);
-				addConfirmMobileNumberLink(userResource);
-				addResendMobileNumberConfirmationLink(userResource);
+				if (!user.isCreatedOnBuddyRequest())
+				{
+					addConfirmMobileNumberLink(userResource);
+					addResendMobileNumberConfirmationLink(userResource);
+				}
 			}
 			if (representation.includeOwnUserNumConfirmedContent.apply(user))
 			{

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedService.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import javax.transaction.Transactional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
@@ -32,6 +34,7 @@ public class UserAnonymizedService
 	}
 
 	@Cacheable
+	@Transactional
 	public UserAnonymizedDto getUserAnonymized(UUID userAnonymizedId)
 	{
 		UserAnonymized entity = userAnonymizedRepository.findOne(userAnonymizedId);

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -439,7 +439,7 @@ public class UserService
 	}
 
 	@Transactional
-	User addUserCreatedOnBuddyRequest(UserDto buddyUserResource)
+	UserDto addUserCreatedOnBuddyRequest(UserDto buddyUserResource)
 	{
 		assertUserIsAllowed(buddyUserResource.getMobileNumber(), UserSignUp.INVITED);
 		User newUser = createUserEntity(buddyUserResource, UserSignUp.INVITED);
@@ -448,7 +448,7 @@ public class UserService
 		User savedUser = userRepository.save(newUser);
 		logger.info("User with mobile number '{}' and ID '{}' created on buddy request", savedUser.getMobileNumber(),
 				savedUser.getId());
-		return savedUser;
+		return createUserDtoWithPrivateData(savedUser);
 	}
 
 	@Transactional
@@ -621,7 +621,8 @@ public class UserService
 		allGoalsIncludingHistoryItems.forEach(Goal::removeAllWeekActivities);
 		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
 
-		new ArrayList<>(userEntity.getDevices()).stream().forEach(d -> deviceService.deleteDeviceWithoutBuddyNotification(userEntity, d));
+		new ArrayList<>(userEntity.getDevices()).stream()
+				.forEach(d -> deviceService.deleteDeviceWithoutBuddyNotification(userEntity, d));
 
 		userAnonymizedService.deleteUserAnonymized(userAnonymizedId);
 		userRepository.delete(updatedUserEntity);

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -19,6 +19,7 @@ class AppService extends Service
 	static final NEW_DEVICE_REQUESTS_PATH = "/newDeviceRequests/"
 	static final USERS_PATH = "/users/"
 	static final OVERWRITE_USER_REQUEST_PATH = "/admin/requestUserOverwrite/"
+	static final LAST_EMAIL_PATH = "/emails/last"
 
 	JsonSlurper jsonSlurper = new JsonSlurper()
 
@@ -521,5 +522,10 @@ class AppService extends Service
 
 	def composeActivityCategoryUrl(def activityCategoryId) {
 		"$yonaServer.restClient.uri$ACTIVITY_CATEGORIES_PATH$activityCategoryId"
+	}
+
+	def getLastEmail()
+	{
+		getResource(LAST_EMAIL_PATH)
 	}
 }

--- a/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
@@ -138,7 +138,11 @@ class CommonAssertions extends Service
 		 */
 		if (user instanceof User)
 		{
-			mobileNumberToBeConfirmed = ((boolean) user.mobileNumberConfirmationUrl)
+			mobileNumberToBeConfirmed = userCreatedOnBuddyRequest || ((boolean) user.mobileNumberConfirmationUrl)
+			if (userCreatedOnBuddyRequest)
+			{
+				assert user.mobileNumberConfirmationUrl == null
+			}
 			assert user.password.startsWith("AES:128:")
 			assert mobileNumberToBeConfirmed ^ ((boolean) user.buddiesUrl)
 			assert mobileNumberToBeConfirmed ^ ((boolean) user.messagesUrl)
@@ -147,11 +151,15 @@ class CommonAssertions extends Service
 		}
 		else
 		{
-			mobileNumberToBeConfirmed = ((boolean) user._links?."yona:confirmMobileNumber"?.href)
+			mobileNumberToBeConfirmed = userCreatedOnBuddyRequest || ((boolean) user._links?."yona:confirmMobileNumber"?.href)
 			assert user.yonaPassword.startsWith("AES:128:")
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:buddies"?._links?.self?.href)
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:goals"?._links?.self?.href)
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._embedded?."yona:devices"?._links?.self?.href)
+			if (userCreatedOnBuddyRequest)
+			{
+				assert user._links?."yona:confirmMobileNumber"?.href == null
+			}
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:messages")
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:newDeviceRequest")
 			assert mobileNumberToBeConfirmed ^ ((boolean) user._links?."yona:appActivity")


### PR DESCRIPTION
…equest

The confirmation SMS is only sent after the user updated their status (and thus canceled the "created on buddy request" status), so the link only adds confusion in that state.

Along with this:
* Corrected a spelling error on BuddyController.java
* Extended the integration test to include testing the email (from/to/subject and the URL in the body)
* Tagged UserAnonymizedService.getUserAnonymized with @Transactional, as that method might call out to Hibernate, resulting in a "no session" error otherwise
* UserService.addUserCreatedOnBuddyRequest now returns a UserDto rather than an entity. Passing an entity from one transaction to another is tricky business and should not be done.