### PR TITLE
YD-559 Fixed invalid lock mode error

### DIFF
--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -133,6 +133,11 @@ public class User extends EntityWithUuid
 
 	public String getFirstName()
 	{
+		if (firstName != null)
+		{
+			// Name not moved to private user yet, so return it
+			return firstName;
+		}
 		return getUserPrivate().getFirstName();
 	}
 
@@ -143,6 +148,11 @@ public class User extends EntityWithUuid
 
 	public String getLastName()
 	{
+		if (lastName != null)
+		{
+			// Name not moved to private user yet, so return it
+			return lastName;
+		}
 		return getUserPrivate().getLastName();
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserLockChecker.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserLockChecker.java
@@ -1,11 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
+
+import java.util.Objects;
 
 import javax.persistence.EntityManager;
 import javax.persistence.LockModeType;
@@ -13,10 +12,41 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.PreUpdate;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
 public class UserLockChecker
 {
+	static class IdentityKey
+	{
+		private Object object;
+
+		public IdentityKey(Object object)
+		{
+			this.object = Objects.requireNonNull(object);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return System.identityHashCode(object);
+		}
+
+		@Override
+		public boolean equals(Object that)
+		{
+			if (this == that)
+			{
+				return true;
+			}
+			if (!(that instanceof IdentityKey))
+			{
+				return false;
+			}
+			return this.object == ((IdentityKey) that).object;
+		}
+	}
+
 	private static EntityManager entityManager;
 
 	@PersistenceContext
@@ -28,10 +58,30 @@ public class UserLockChecker
 	@PreUpdate
 	void onPreUpdate(User user)
 	{
+		if (isFlushedAlready(user))
+		{
+			return;
+		}
 		LockModeType lockMode = entityManager.getLockMode(user);
 		if (lockMode != LockModeType.PESSIMISTIC_WRITE)
 		{
 			throw new IllegalStateException("Invalid lock mode: " + lockMode);
 		}
+		registerAsFlushedAlready(user);
+	}
+
+	private boolean isFlushedAlready(User user)
+	{
+		return TransactionSynchronizationManager.hasResource(buildResourceKey(user));
+	}
+
+	private void registerAsFlushedAlready(User user)
+	{
+		TransactionSynchronizationManager.bindResource(buildResourceKey(user), Boolean.TRUE);
+	}
+
+	private IdentityKey buildResourceKey(User user)
+	{
+		return new IdentityKey(user);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDto.java
@@ -12,15 +12,20 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.springframework.core.annotation.Order;
+
 import nu.yona.server.device.service.BuddyDeviceDto;
 import nu.yona.server.device.service.DeviceBaseDto;
 import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.service.migration.EncryptFirstAndLastName;
 
 public class BuddyUserPrivateDataDto extends UserPrivateDataBaseDto
 {
+	private static final int VERSION_OF_NAME_MIGRATION = EncryptFirstAndLastName.class.getAnnotation(Order.class).value();
+
 	BuddyUserPrivateDataDto(String firstName, String lastName, String nickname, Optional<UUID> userPhotoId)
 	{
 		super(firstName, lastName, nickname, userPhotoId, Optional.empty(), Optional.empty());
@@ -59,9 +64,9 @@ public class BuddyUserPrivateDataDto extends UserPrivateDataBaseDto
 		{
 			return name;
 		}
-		if (user != null)
+		if ((user != null) && (user.getPrivateDataMigrationVersion() < VERSION_OF_NAME_MIGRATION))
 		{
-			// User is not deleted yet, so try getting the name from the user entity
+			// User is not deleted yet and not yet migrated, so get the name from the user entity
 			name = userNameGetter.apply(user);
 		}
 		if (name != null)


### PR DESCRIPTION
This is fixed by making the UserLockChecker resilient for intermediate flushes.

Along with this, improved the logic in User and BuddyUserPrivateDataDto to fetch the user name from the user entity when that is not migrated yet.