### PR TITLE
YD-561 Fixed "Not available" issue

### DIFF
--- a/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/BuddyMessageEmbeddedUserDto.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import nu.yona.server.messaging.entities.BuddyMessage;
 import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.subscriptions.entities.BuddyConnectionChangeMessage;
+import nu.yona.server.subscriptions.service.BuddyDto;
 
 public abstract class BuddyMessageEmbeddedUserDto extends BuddyMessageDto
 {
@@ -43,6 +44,12 @@ public abstract class BuddyMessageEmbeddedUserDto extends BuddyMessageDto
 	@Component
 	public abstract static class Manager extends BuddyMessageDto.Manager
 	{
+		@Override
+		protected SenderInfo createSenderInfoForBuddy(BuddyDto buddy, Message messageEntity)
+		{
+			return getSenderInfoExtensionPoint(messageEntity);
+		}
+
 		@Override
 		protected SenderInfo getSenderInfoExtensionPoint(Message messageEntity)
 		{

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
@@ -7,7 +7,6 @@ package nu.yona.server.subscriptions.entities;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
-import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.SecretKeyUtil;
 import nu.yona.server.messaging.entities.BuddyMessage;
 
@@ -53,16 +52,11 @@ public abstract class BuddyConnectionChangeMessage extends BuddyMessage
 
 	public String getFirstName()
 	{
-		return (firstName == null) ? getTranslation("message.alternative.first.name", getSenderNickname()) : firstName;
+		return firstName;
 	}
 
 	public String getLastName()
 	{
-		return (lastName == null) ? getTranslation("message.alternative.last.name", getSenderNickname()) : lastName;
-	}
-
-	private String getTranslation(String messageId, String nickname)
-	{
-		return Translator.getInstance().getLocalizedMessage(messageId, nickname);
+		return lastName;
 	}
 }


### PR DESCRIPTION
The first and last name were reported as "Not available, even though the buddy user wasn't migrated yet. This was caused by an off-by-one error on the private data migration version. This fixed now and along with this, message with an embedded user now embed the user with buddy data instead of only public data (i.e. now without first and last name). Finally, the first and last name now fall back to "<nickname>" rather than "Not available", so people get more information in such a case.