### PR TITLE
YD-558 Add unit test for BuddyUserPrivateDataDtoTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Yona Server
 
 The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging.
 
-=======
+==================================
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fyonadev%2Fyona-server.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fyonadev%2Fyona-server?ref=badge_large)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
@@ -21,7 +21,6 @@ import javax.persistence.Table;
 import org.hibernate.annotations.Type;
 
 import nu.yona.server.crypto.seckey.DateTimeFieldEncryptor;
-import nu.yona.server.crypto.seckey.StringFieldEncryptor;
 import nu.yona.server.crypto.seckey.UUIDFieldEncryptor;
 import nu.yona.server.device.entities.BuddyDevice;
 import nu.yona.server.entities.RepositoryProvider;
@@ -30,7 +29,7 @@ import nu.yona.server.util.TimeUtil;
 
 @Entity
 @Table(name = "BUDDIES")
-public class Buddy extends EntityWithUuidAndTouchVersion
+public class Buddy extends PrivateUserProperties
 {
 	@Type(type = "uuid-char")
 	@Column(name = "owning_user_private_id")
@@ -42,20 +41,8 @@ public class Buddy extends EntityWithUuidAndTouchVersion
 	@Convert(converter = UUIDFieldEncryptor.class)
 	private UUID buddyAnonymizedId;
 
-	@Convert(converter = StringFieldEncryptor.class)
-	private String firstName;
-
-	@Convert(converter = StringFieldEncryptor.class)
-	private String lastName;
-
-	@Convert(converter = StringFieldEncryptor.class)
-	private String nickname;
-
 	@Convert(converter = DateTimeFieldEncryptor.class)
 	private LocalDateTime lastStatusChangeTime;
-
-	@Convert(converter = UUIDFieldEncryptor.class)
-	private UUID userPhotoId;
 
 	/**
 	 * The BuddyAnonymized entities owned by this user
@@ -66,16 +53,13 @@ public class Buddy extends EntityWithUuidAndTouchVersion
 	// Default constructor is required for JPA
 	public Buddy()
 	{
-		super(null);
+		super();
 	}
 
 	private Buddy(UUID id, UUID userId, String firstName, String lastName, String nickname, UUID buddyAnonymizedId)
 	{
-		super(id);
+		super(id, firstName, lastName, Objects.requireNonNull(nickname));
 		this.userId = Objects.requireNonNull(userId);
-		this.firstName = Objects.requireNonNull(firstName);
-		this.lastName = Objects.requireNonNull(lastName);
-		this.nickname = Objects.requireNonNull(nickname);
 		this.buddyAnonymizedId = Objects.requireNonNull(buddyAnonymizedId);
 		this.devices = new HashSet<>();
 
@@ -107,46 +91,6 @@ public class Buddy extends EntityWithUuidAndTouchVersion
 				+ buddyAnonymizedId;
 
 		return buddyAnonymized;
-	}
-
-	public String getFirstName()
-	{
-		return firstName;
-	}
-
-	public void setFirstName(String firstName)
-	{
-		this.firstName = firstName;
-	}
-
-	public String getLastName()
-	{
-		return lastName;
-	}
-
-	public void setLastName(String lastName)
-	{
-		this.lastName = lastName;
-	}
-
-	public String getNickname()
-	{
-		return nickname;
-	}
-
-	public void setNickname(String nickname)
-	{
-		this.nickname = nickname;
-	}
-
-	public Optional<UUID> getUserPhotoId()
-	{
-		return Optional.ofNullable(userPhotoId);
-	}
-
-	public void setUserPhotoId(Optional<UUID> userPhotoId)
-	{
-		this.userPhotoId = userPhotoId.orElse(null);
 	}
 
 	public UUID getUserId()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/PrivateUserProperties.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/PrivateUserProperties.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.entities;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.persistence.Convert;
+import javax.persistence.MappedSuperclass;
+
+import nu.yona.server.crypto.seckey.StringFieldEncryptor;
+import nu.yona.server.crypto.seckey.UUIDFieldEncryptor;
+
+@MappedSuperclass
+public abstract class PrivateUserProperties extends EntityWithUuidAndTouchVersion
+{
+
+	@Convert(converter = StringFieldEncryptor.class)
+	private String firstName;
+
+	@Convert(converter = StringFieldEncryptor.class)
+	private String lastName;
+
+	@Convert(converter = StringFieldEncryptor.class)
+	private String nickname;
+
+	@Convert(converter = UUIDFieldEncryptor.class)
+	private UUID userPhotoId;
+
+	// Default constructor is required for JPA
+	public PrivateUserProperties()
+	{
+		super(null);
+	}
+
+	public PrivateUserProperties(UUID id, String firstName, String lastName, String nickname)
+	{
+		super(id);
+		this.firstName = Objects.requireNonNull(firstName);
+		this.lastName = Objects.requireNonNull(lastName);
+		this.nickname = nickname;
+	}
+
+	public String getFirstName()
+	{
+		return firstName;
+	}
+
+	public void setFirstName(String firstName)
+	{
+		this.firstName = firstName;
+	}
+
+	public String getLastName()
+	{
+		return lastName;
+	}
+
+	public void setLastName(String lastName)
+	{
+		this.lastName = lastName;
+	}
+
+	public String getNickname()
+	{
+		return nickname;
+	}
+
+	public void setNickname(String nickname)
+	{
+		this.nickname = nickname;
+	}
+
+	public Optional<UUID> getUserPhotoId()
+	{
+		return Optional.ofNullable(userPhotoId);
+	}
+
+	public void setUserPhotoId(Optional<UUID> userPhotoId)
+	{
+		this.userPhotoId = userPhotoId.orElse(null);
+	}
+}

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -32,21 +32,12 @@ import nu.yona.server.messaging.entities.MessageSource;
 
 @Entity
 @Table(name = "USERS_PRIVATE")
-public class UserPrivate extends EntityWithUuidAndTouchVersion
+public class UserPrivate extends PrivateUserProperties
 {
 	private static final String DECRYPTION_CHECK_STRING = "Decrypted properly#";
 
 	@Convert(converter = StringFieldEncryptor.class)
 	private String decryptionCheck;
-
-	@Convert(converter = StringFieldEncryptor.class)
-	private String firstName;
-
-	@Convert(converter = StringFieldEncryptor.class)
-	private String lastName;
-
-	@Convert(converter = StringFieldEncryptor.class)
-	private String nickname;
 
 	@Convert(converter = UUIDFieldEncryptor.class)
 	private UUID userAnonymizedId;
@@ -66,9 +57,6 @@ public class UserPrivate extends EntityWithUuidAndTouchVersion
 	@Convert(converter = StringFieldEncryptor.class)
 	private String vpnPassword;
 
-	@Convert(converter = UUIDFieldEncryptor.class)
-	private UUID userPhotoId;
-
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
 	@JoinColumn(name = "user_private_id", referencedColumnName = "id")
 	@Fetch(FetchMode.JOIN)
@@ -77,17 +65,14 @@ public class UserPrivate extends EntityWithUuidAndTouchVersion
 	// Default constructor is required for JPA
 	public UserPrivate()
 	{
-		super(null);
+		super();
 	}
 
 	private UserPrivate(UUID id, String firstName, String lastName, String nickname, UUID userAnonymizedId,
 			UUID anonymousMessageSourceId, UUID namedMessageSourceId)
 	{
-		super(id);
-		this.firstName = firstName;
-		this.lastName = lastName;
+		super(id, firstName, lastName, nickname);
 		this.decryptionCheck = buildDecryptionCheck();
-		this.nickname = nickname;
 		this.userAnonymizedId = userAnonymizedId;
 		this.buddies = new HashSet<>();
 		this.anonymousMessageSourceId = anonymousMessageSourceId;
@@ -110,36 +95,6 @@ public class UserPrivate extends EntityWithUuidAndTouchVersion
 	public boolean isDecryptedProperly()
 	{
 		return isDecrypted() && decryptionCheck.startsWith(DECRYPTION_CHECK_STRING);
-	}
-
-	public String getFirstName()
-	{
-		return firstName;
-	}
-
-	public void setFirstName(String firstName)
-	{
-		this.firstName = firstName;
-	}
-
-	public String getLastName()
-	{
-		return lastName;
-	}
-
-	public void setLastName(String lastName)
-	{
-		this.lastName = lastName;
-	}
-
-	public String getNickname()
-	{
-		return nickname;
-	}
-
-	public void setNickname(String nickname)
-	{
-		this.nickname = nickname;
 	}
 
 	UserAnonymized getUserAnonymized()
@@ -220,16 +175,6 @@ public class UserPrivate extends EntityWithUuidAndTouchVersion
 	public void setLastMonitoredActivityDate(LocalDate lastMonitoredActivityDate)
 	{
 		getUserAnonymized().setLastMonitoredActivityDate(lastMonitoredActivityDate);
-	}
-
-	public Optional<UUID> getUserPhotoId()
-	{
-		return Optional.ofNullable(userPhotoId);
-	}
-
-	public void setUserPhotoId(Optional<UUID> userPhotoId)
-	{
-		this.userPhotoId = userPhotoId.orElse(null);
 	}
 
 	public Set<UserDevice> getDevices()

--- a/core/src/main/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationService.java
@@ -9,6 +9,8 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 import javax.transaction.Transactional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,6 +25,8 @@ public class PrivateUserDataMigrationService
 		void upgrade(User userEntity);
 	}
 
+	private static final Logger logger = LoggerFactory.getLogger(PrivateUserDataMigrationService.class);
+
 	@Autowired
 	private List<MigrationStep> migrationSteps;
 
@@ -36,6 +40,8 @@ public class PrivateUserDataMigrationService
 	void upgrade(User userEntity)
 	{
 		int originalVersion = userEntity.getPrivateDataMigrationVersion();
+		logger.info("Migrating private user data of user with ID {} from {} to {}", userEntity.getId(), originalVersion,
+				getCurrentVersion());
 		for (int fromVersion = originalVersion; fromVersion < getCurrentVersion(); fromVersion++)
 		{
 			getMigrationStepInstance(fromVersion).upgrade(userEntity);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.service;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import nu.yona.server.Translator;
+import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.messaging.entities.MessageDestination;
+import nu.yona.server.messaging.entities.MessageSource;
+import nu.yona.server.subscriptions.entities.PrivateUserProperties;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserPrivate;
+import nu.yona.server.test.util.CryptoSessionRule;
+import nu.yona.server.test.util.JUnitUtil;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BuddyUserPrivateDataDtoTest
+{
+	private static final String PASSWORD = "PASSWORD";
+
+	private final Field translatorStaticField = JUnitUtil.getAccessibleField(Translator.class, "staticReference");
+	private final Field userUserPrivateField = JUnitUtil.getAccessibleField(User.class, "userPrivate");
+	private final Field privateUserPropertiesFirstNameField = JUnitUtil.getAccessibleField(PrivateUserProperties.class,
+			"firstName");
+
+	@Mock
+	private Translator translator;
+
+	@Mock
+	private MessageSource messageSource;
+
+	@Mock
+	private MessageDestination messageDestination;
+
+	@Rule
+	public MethodRule cryptoSession = new CryptoSessionRule(PASSWORD);
+
+	@Before
+	public void setUpPerTest() throws Exception
+	{
+		translatorStaticField.set(null, translator);
+
+		when(messageSource.getId()).thenReturn(UUID.randomUUID());
+		when(translator.getLocalizedMessage(any(String.class), anyVararg())).thenAnswer(new Answer<String>() {
+			@Override
+			public String answer(InvocationOnMock invocation) throws Throwable
+			{
+				Object[] args = invocation.getArguments();
+				assert args.length == 2;
+				String messageId = (String) args[0];
+				String insertion = (String) args[1];
+				return messageId + ":" + insertion;
+			}
+		});
+
+	}
+
+	@Test
+	public void determineName_buddyNameAvailable_buddyName()
+	{
+		String buddyName = "BuddyName";
+
+		String name = BuddyUserPrivateDataDto.determineName(() -> buddyName, null, null, null, null);
+
+		assertThat(name, equalTo(buddyName));
+	}
+
+	@Test
+	public void determineName_nameNotAvailableInUser_translationUsed() throws IllegalArgumentException, IllegalAccessException
+	{
+		String nickname = "nickname";
+		String messageId = "message.id";
+		User user = createUser("firstName", "lastName", nickname);
+		privateUserPropertiesFirstNameField.set(userUserPrivateField.get(user), null);
+
+		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, messageId,
+				nickname);
+
+		assertThat(name, equalTo(messageId + ":" + nickname));
+	}
+
+	@Test
+	public void determineName_userTooNewToContainName_translationUsed()
+	{
+		String nickname = "nickname";
+		String messageId = "message.id";
+		User user = createUser("firstName", "lastName", nickname);
+		user.setPrivateDataMigrationVersion(9999);
+
+		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, messageId,
+				nickname);
+
+		assertThat(name, equalTo(messageId + ":" + nickname));
+	}
+
+	@Test
+	public void determineName_userNameAvailable_userName()
+	{
+		String userName = "UserName";
+		User user = createUser(userName, "lastName", "nickName");
+
+		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, null, null);
+
+		assertThat(name, equalTo(userName));
+	}
+
+	@Test
+	public void determineName_userNotAvailable_translationUsed()
+	{
+		String nickname = "nickname";
+		String messageId = "message.id";
+
+		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.empty(), User::getFirstName, messageId,
+				nickname);
+
+		assertThat(name, equalTo(messageId + ":" + nickname));
+	}
+
+	private User createUser(String firstName, String lastName, String nickname)
+	{
+		byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
+		UserPrivate userPrivate = UserPrivate.createInstance(firstName, lastName, nickname, UUID.randomUUID(), UUID.randomUUID(),
+				messageSource);
+		return new User(UUID.randomUUID(), initializationVector, "+31123456", userPrivate, messageDestination);
+	}
+}

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
@@ -115,7 +115,7 @@ public class BuddyUserPrivateDataDtoTest
 	}
 
 	@Test
-	public void determineName_userNameAvailable_userName()
+	public void determineName_firstNameAvailable_firstName()
 	{
 		String userName = "UserName";
 		User user = createUser(userName, "lastName", "nickName");

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/EncryptFirstAndLastNameTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/EncryptFirstAndLastNameTest.java
@@ -45,8 +45,8 @@ import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
 import nu.yona.server.subscriptions.entities.BuddyInfoChangeMessage;
+import nu.yona.server.subscriptions.entities.PrivateUserProperties;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserPrivate;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
@@ -84,8 +84,8 @@ public class EncryptFirstAndLastNameTest extends BaseSpringIntegrationTest
 	private static final String PASSWORD = "password";
 	private static final Field firstNameUserField = JUnitUtil.getAccessibleField(User.class, "firstName");
 	private static final Field lastNameUserField = JUnitUtil.getAccessibleField(User.class, "lastName");
-	private static final Field firstNameUserPrivateField = JUnitUtil.getAccessibleField(UserPrivate.class, "firstName");
-	private static final Field lastNameUserPrivateField = JUnitUtil.getAccessibleField(UserPrivate.class, "lastName");
+	private static final Field firstNameUserPrivateField = JUnitUtil.getAccessibleField(PrivateUserProperties.class, "firstName");
+	private static final Field lastNameUserPrivateField = JUnitUtil.getAccessibleField(PrivateUserProperties.class, "lastName");
 	private static final Field userPrivateField = JUnitUtil.getAccessibleField(User.class, "userPrivate");
 	private User richard;
 


### PR DESCRIPTION
The method to determine the name given some alternatives moved from BuddyConnectionChangeMessage to BuddyUserPrivateDataDtoTest, so a unit test was added for that.

Along with this:
* Moved the common properties of UserPrivate and Buddy to PrivateUserProperties
* Added a logging statement to PrivateUserDataMigrationService, so we can see when the migrations happened. If concurrent migrations happen (which I actually suspect), we get proof through the logging.