### PR TITLE
KTI_Hazelcast_Breakout

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,6 +22,8 @@ artifacts {
 }
 
 dependencies {
+	compile "com.hazelcast:hazelcast-client"
+	compile 'com.hazelcast:hazelcast-kubernetes:1.1.0'
 	compile "org.springframework.boot:spring-boot-starter-hateoas"
 	compile "org.springframework.boot:spring-boot-starter-data-jpa"
 	compile "org.springframework.boot:spring-boot-starter-web"

--- a/core/src/main/java/nu/yona/server/properties/YonaProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/YonaProperties.java
@@ -46,6 +46,8 @@ public class YonaProperties
 
 	private String appleAppId;
 
+	private String hazelcastConfigFilePath;
+
 	private int maxUsers;
 
 	private boolean isWhiteListActiveFreeSignUp;
@@ -118,6 +120,16 @@ public class YonaProperties
 	public String getAppleAppId()
 	{
 		return appleAppId;
+	}
+
+	public String getHazelcastConfigFilePath()
+	{
+		return hazelcastConfigFilePath;
+	}
+
+	public void setHazelcastConfigFilePath(String hazelcastConfigFilePath)
+	{
+		this.hazelcastConfigFilePath = hazelcastConfigFilePath;
 	}
 
 	public int getMaxUsers()

--- a/core/src/main/java/nu/yona/server/properties/YonaProperties.java
+++ b/core/src/main/java/nu/yona/server/properties/YonaProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.properties;

--- a/k8s/helm/yona/README.md
+++ b/k8s/helm/yona/README.md
@@ -12,6 +12,11 @@ This chart will do the following:
 * 2 x Yona Admin, Analysis, App, and Batch services
 * All using Kubernetes Deployments
 
+## Chart dependencies
+Pull down the dependant charts (ldap, mariadb, hazelcast)
+
+helm dependency update
+
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:

--- a/k8s/helm/yona/requirements.yaml
+++ b/k8s/helm/yona/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
     version: 0.1.1
     repository:  "https://jump.ops.yona.nu/helm-charts"
     condition: support_infrastructure.enabled
+  - name: hazelcast
+    version: 0.1.0
+    repository:  "https://jump.ops.yona.nu/helm-charts"
+    condition: support_infrastructure.enabled

--- a/k8s/helm/yona/templates/01_configmap_properties.yaml
+++ b/k8s/helm/yona/templates/01_configmap_properties.yaml
@@ -11,6 +11,15 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
 data:
   application.properties: |
+    {{- if .Values.spring.hazelcast.loglevel}}
+    logging.level.com.hazelcast={{ .Values.spring.hazelcast.loglevel | default "info" }}
+    {{- end }}
+    {{- if .Values.spring.loglevel}}
+    logging.level.org.springframework={{ .Values.spring.loglevel | default "info" }}
+    {{- end }}
+    #spring.hazelcast.config={{ .Values.spring.hazelcast.config }}
+    #hazelcast.client.config={{ .Values.spring.hazelcast.config }}
+    yona.hazelcastConfigFilePath={{ .Values.spring.hazelcast.config }}
     yona.maxUsers={{ .Values.app.max_users | default "100" }}
     yona.enableHibernateStatsAllowed={{ .Values.app.enable_hibernate_stats_allowed| default "false" }}
     yona.whiteListActiveFreeSignUp={{ required "True or False required for app.whitelist.active_free_signup" .Values.app.whitelist.active_free_signup }}
@@ -56,4 +65,27 @@ data:
     yona.appleMobileConfig.signingKeyStorePassword = {{ .Values.apple.keystore_password | default "DummyPwd" }}
     yona.appleMobileConfig.caCertificateFile={{ .Values.apple.ca_certificate_file | default "apple/AppleWWDRCA.cer" }}
     yona.appleMobileConfig.signingAlias = {{ .Values.apple.alias | default "dummy" }}
+  hazelcast-client.xml: |
+      <hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.6.xsd"
+                        xmlns="http://www.hazelcast.com/schema/client-config"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <properties>
+              <property name="hazelcast.discovery.enabled">true</property>
+          </properties>
+          <network>
+              <aws enabled="false"/>
+              <smart-routing>true</smart-routing>
+              <redo-operation>true</redo-operation>
+              <discovery-strategies>
+                <discovery-strategy enabled="true"
+                    class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+                  <properties>
+                    <!-- configure discovery service API lookup -->
+                    <property name="service-name">hazelcast</property>
+                    <property name="namespace">{{ .Release.Namespace }}</property>
+                  </properties>
+                </discovery-strategy>
+              </discovery-strategies>
+          </network>
+      </hazelcast-client>
 

--- a/k8s/helm/yona/templates/03_job-liquibase.yaml
+++ b/k8s/helm/yona/templates/03_job-liquibase.yaml
@@ -45,7 +45,7 @@ spec:
               value: "{{ .Values.ldap.port | default 389 }}"
       containers:
         - name: liquibase
-          image: yonadev/yona-mariadb-liquibase-update:build-{{ .Chart.AppVersion }}
+          image: {{ .Values.global.imagebase | default "yonadev" }}/yona-mariadb-liquibase-update:build-{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
           env:       
             - name: USER
@@ -59,7 +59,11 @@ spec:
               value: "jdbc:mariadb://{{ .Values.mariadb.mariadbHostname }}/{{ .Values.mariadb.mariadbDatabase }}"
             {{- end }}
             - name: RELEASE
+            {{- if .Values.mariadb.seed_release}}
+              value: {{ .Values.mariadb.seed_release | quote }}
+            {{- else }}
               value: {{ .Chart.AppVersion | quote }}
+            {{- end }}
             - name: MAX_TRIES
               value: {{ .Values.seed_max_tries | default "3" | quote }}
             {{- if .Values.ldap.enabled }}

--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -20,7 +20,8 @@ spec:
     metadata:
       labels:
         app: admin
-        stage: {{ .Values.global.stage | default "develop" }}
+        build: {{.Chart.AppVersion | quote}}
+        stage: {{.Values.global.stage | default "develop"}}
     spec:
       initContainers:
         - name: validatedb
@@ -38,8 +39,7 @@ spec:
               value: "10s"
       containers:
         - name: admin
-          image: 'yonadev/adminservice:build-{{ .Chart.AppVersion }}'
-          imagePullPolicy: Always
+          image: '{{ .Values.global.imagebase | default "yonadev" }}/adminservice:build-{{ .Chart.AppVersion }}'
           env:       
             - name: YONA_DB_USER_NAME
               value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}

--- a/k8s/helm/yona/templates/10_deployment_analysis.yaml
+++ b/k8s/helm/yona/templates/10_deployment_analysis.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         app: analysis
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:
@@ -38,8 +39,8 @@ spec:
               value: "10s"
       containers:
         - name: analysis
-          image: 'yonadev/analysisservice:build-{{ .Chart.AppVersion }}'
-          imagePullPolicy: Always
+          image: '{{ .Values.global.imagebase | default "yonadev" }}/analysisservice:build-{{ .Chart.AppVersion }}'
+          #imagePullPolicy: Always
           env:
             - name: YONA_DB_USER_NAME
               value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         app: app
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:
@@ -38,8 +39,7 @@ spec:
               value: "10s"
       containers:
         - name: app
-          image: 'yonadev/appservice:build-{{ .Chart.AppVersion }}'
-          imagePullPolicy: Always
+          image: '{{ .Values.global.imagebase | default "yonadev" }}/appservice:build-{{ .Chart.AppVersion }}'
           env:       
             - name: YONA_DB_USER_NAME
               value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
@@ -90,5 +90,3 @@ spec:
         - name: apple-resources
           secret:
             secretName: {{ .Chart.AppVersion }}-{{ .Values.global.stage | default "develop" }}-apple-bundle
-
-

--- a/k8s/helm/yona/templates/10_deployment_batch.yaml
+++ b/k8s/helm/yona/templates/10_deployment_batch.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         app: batch
+        build: {{ .Chart.AppVersion | quote }}
         stage: {{ .Values.global.stage | default "develop" }}
     spec:
       initContainers:
@@ -38,8 +39,8 @@ spec:
               value: "10s"
       containers:
         - name: batch
-          image: 'yonadev/batchservice:build-{{ .Chart.AppVersion }}'
-          imagePullPolicy: Always
+          image: '{{ .Values.global.imagebase | default "yonadev" }}/batchservice:build-{{ .Chart.AppVersion }}'
+          #imagePullPolicy: Always
           env:       
             - name: YONA_DB_USER_NAME
               value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
@@ -68,6 +69,3 @@ spec:
         - name: config-volume
           configMap:
             name: {{ .Chart.AppVersion }}-{{ .Values.global.stage | default "develop" }}-springboot
-
-
-

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -9,6 +9,7 @@ support_infrastructure:
 global:
 
   stage: develop
+  imagebase: yonadev
 
 # Attempt tries in seed/update container before exit.  Not k8s job retry
 # This just reduces the 'failed' jobs spam in pod list until services
@@ -180,6 +181,12 @@ mariadb:
   password: develop
   #url_override: "jdbc:mariadb://db.default.svc.cluster.local/yona"
   mariadbHostname: yona-mariadb.yona.svc.cluster.local
+
+spring:
+  loglevel: debug
+  hazelcast:
+    loglevel: debug
+    config: /opt/app/config/hazelcast-client.xml
 
 admin:
   act_categories_json_file : productionActivityCategories.json


### PR DESCRIPTION
PR for the separation of Hazelcast out of the springboot and into a dedicated cluster.
To support local development a cluster will also be deployed via the Yona helm chart just like with MariaDB and LDAP if the infrastructure flag is enabled.