### PR TITLE
YD-568 Make error logging "alertable"

### DIFF
--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -1,10 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -15,6 +19,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -24,7 +29,58 @@ import org.springframework.stereotype.Component;
 @Component
 public class ErrorLoggingFilter implements Filter
 {
+	@FunctionalInterface
+	public interface LogMethod
+	{
+		void log(String format, Object... insertions);
+	}
+
+	public static class LoggingContext implements AutoCloseable
+	{
+
+		private static final String CORRELATION_ID = "yona.correlation.id";
+		private static final String TRACE_ID_HEADER = "x-b3-traceid";
+
+		private LoggingContext()
+		{
+			// Nothing to do here
+		}
+
+		@Override
+		public void close()
+		{
+			MDC.remove(CORRELATION_ID);
+		}
+
+		public static LoggingContext createInstance(HttpServletRequest request)
+		{
+			MDC.put(CORRELATION_ID, getCorrelationId(request));
+			return new LoggingContext();
+		}
+
+		private static String getCorrelationId(HttpServletRequest request)
+		{
+			String traceIdHeader = request.getHeader(TRACE_ID_HEADER);
+			if (traceIdHeader == null)
+			{
+				return UUID.randomUUID().toString();
+			}
+			return traceIdHeader;
+		}
+
+	}
+
 	private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingFilter.class);
+	private static final Map<Series, LogMethod> seriesToLoggerMap;
+	static
+	{
+		Map<Series, LogMethod> map = new EnumMap<>(Series.class);
+		map.put(Series.INFORMATIONAL, logger::info);
+		map.put(Series.REDIRECTION, logger::info);
+		map.put(Series.CLIENT_ERROR, logger::warn);
+		map.put(Series.SERVER_ERROR, logger::error);
+		seriesToLoggerMap = Collections.unmodifiableMap(map);
+	}
 
 	@Override
 	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
@@ -33,14 +89,27 @@ public class ErrorLoggingFilter implements Filter
 		HttpServletRequest request = (HttpServletRequest) servletRequest;
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-		chain.doFilter(request, response);
-
-		if (HttpStatus.Series.valueOf(response.getStatus()) == Series.SUCCESSFUL)
+		try (LoggingContext loggingContext = LoggingContext.createInstance(request))
 		{
-			return;
-		}
+			chain.doFilter(request, response);
+			Series responseStatus = HttpStatus.Series.valueOf(response.getStatus());
+			if (responseStatus == Series.SUCCESSFUL)
+			{
+				return;
+			}
 
-		logger.warn("Status {} returned from {}", response.getStatus(), GlobalExceptionMapping.buildRequestInfo(request));
+			logResponseStatus(request, response, responseStatus);
+		}
+	}
+
+	private void logResponseStatus(HttpServletRequest request, HttpServletResponse response, Series responseStatus)
+	{
+		LogMethod logMethod = seriesToLoggerMap.get(responseStatus);
+		if (logMethod == null)
+		{
+			throw new IllegalStateException("Status " + responseStatus + " is not supported");
+		}
+		logMethod.log("Status {} returned from {}", response.getStatus(), GlobalExceptionMapping.buildRequestInfo(request));
 	}
 
 	@Override

--- a/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
+++ b/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import nu.yona.server.Translator;
 import nu.yona.server.exceptions.YonaException;
@@ -63,6 +64,25 @@ public class GlobalExceptionMapping
 		ErrorResponseDto responseMessage = new ErrorResponseDto(exception.getMessageId(), exception.getMessage());
 
 		return new ResponseEntity<>(responseMessage, exception.getStatusCode());
+	}
+
+	/**
+	 * This method argument mismatches. They indicate that the caller passed a wrong parameter, e.g. an invalid UUID. They result
+	 * in a 400 (BAD REQUEST).
+	 * 
+	 * @param exception The exception.
+	 * @return The response object to return.
+	 */
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ResponseBody
+	public ErrorResponseDto handleArgumentTypeMismatchException(MethodArgumentTypeMismatchException exception,
+			HttpServletRequest request)
+	{
+		logUnhandledException("Request {0} completed with argument type mismatch exception: {1}", buildRequestInfo(request),
+				exception);
+
+		return new ErrorResponseDto(null, exception.getMessage());
 	}
 
 	private void logUnhandledException(String message, String requestInfo, Exception exception)


### PR DESCRIPTION
* Only 500 statuses result in an *error* of the kind "Status 500 returned from GET on URL /users/80861e33-d292-4c37-8771-bc912224513c/activity/weeks/?size=3&page=0"
* Other response statuses result in info or warning messages
* An invalid parameter error now results in a 400 (BAD REQUEST) instead of a 500 (INTERNAL SERVER ERROR)