### PR TITLE
YD-570 Reload user after each message processing

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
@@ -1,15 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server
 
-import groovy.json.*
-import nu.yona.server.test.User
 import static nu.yona.server.test.CommonAssertions.*
+
+import groovy.json.*
 import nu.yona.server.test.CommonAssertions
+import nu.yona.server.test.User
 
 class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 {
@@ -75,6 +76,53 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 
 		User richardAfterProcess = appService.reloadUser(richard)
 		richardAfterProcess.buddies[0].nickname == "BD"
+
+		cleanup:
+		appService.deleteUser(richard)
+		appService.deleteUser(bob)
+	}
+
+	def 'Richard can receive Bob\'s buddy info change message along with his acceptance'()
+	{
+		given:
+		User richard = addRichard()
+		User bob = addBob()
+		User bobby = makeUserForBuddyRequest(bob, "bob@dunn.net", "Bobby", "Dun")
+		appService.sendBuddyConnectRequest(richard, bobby)
+		def acceptUrl = appService.fetchBuddyConnectRequestMessage(bob).acceptUrl
+		appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password)
+
+		def updatedBobJson = bob.convertToJson()
+		updatedBobJson.firstName = "Robert"
+		updatedBobJson.lastName = "Dunstan"
+		updatedBobJson.nickname = "RD"
+		User bobAfterUpdate = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson))
+
+		when:
+		def response = appService.getMessages(richard)
+
+		then:
+		assertResponseStatusOk(response)
+
+		def richardWithBuddy = appService.reloadUser(richard)
+		richardWithBuddy.buddies != null
+		richardWithBuddy.buddies.size() == 1
+		richardWithBuddy.buddies[0].user.firstName == updatedBobJson.firstName
+		richardWithBuddy.buddies[0].user.nickname == updatedBobJson.nickname
+		richardWithBuddy.buddies[0].nickname == updatedBobJson.nickname
+
+		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll
+		{ it."@type" == "BuddyConnectResponseMessage" }
+		buddyConnectResponseMessages.size() == 1
+		buddyConnectResponseMessages[0].nickname == updatedBobJson.nickname
+		buddyConnectResponseMessages[0].status == "ACCEPTED"
+
+
+		def buddyInfoUpdateMessages = response.responseData._embedded."yona:messages".findAll
+		{ it."@type" == "BuddyInfoChangeMessage" }
+		buddyInfoUpdateMessages.size() == 1
+		buddyInfoUpdateMessages[0].nickname == updatedBobJson.nickname
+		buddyInfoUpdateMessages[0]._links."yona:buddy".href == richardWithBuddy.buddies[0].url
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -155,10 +155,10 @@ public class MessageService
 	{
 		List<Long> idsOfUnprocessedMessages = getUnprocessedMessages(user);
 
-		UserDto userDto = userService.getPrivateUser(user.getId());
 		MessageActionDto emptyPayload = new MessageActionDto(Collections.emptyMap());
 		for (long id : idsOfUnprocessedMessages)
 		{
+			UserDto userDto = userService.getPrivateUser(user.getId()); // Inside loop, as message processing might change it
 			handleMessageAction(userDto, id, "process", emptyPayload);
 		}
 	}


### PR DESCRIPTION
The failure scenario is this:
* Richard sends a buddy request to Bob
* Bob accepts it and then changes his personal information
* Richard fetches his messages, which results in automatically processing all to-be-processed MessageService
* The first messages is the buddy acceptance; that succeeds and adds the user anonymized to the buddy
* Given that the user wasn't reloaded after the message was processed, the second one failed as it couldn't find the user anonymized ID on the buddy

The user is now fetched for each message. This will be a little slower when users have multiple messages to be processed, but this is extremely rare and thus not relevant. An integration test is added that reproduced the issue and now guards this scenario.