### PR TITLE
YD-572 Fix NPE in BuddyMessage

### DIFF
--- a/core/src/main/java/nu/yona/server/messaging/entities/BuddyMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/BuddyMessage.java
@@ -147,8 +147,8 @@ public abstract class BuddyMessage extends Message
 
 		public static BuddyInfoParameters createInstance(Buddy buddy, UUID buddyUserAnonymizedId)
 		{
-			return new BuddyInfoParameters(buddyUserAnonymizedId, null, buddy.getFirstName(), buddy.getLastName(),
-					buddy.getNickname(), buddy.getUserPhotoId());
+			return new BuddyInfoParameters(buddyUserAnonymizedId, null, buddy.determineFirstName(Optional.empty()),
+					buddy.determineLastName(Optional.empty()), buddy.getNickname(), buddy.getUserPhotoId());
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -29,6 +29,7 @@ import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.service.MessageService.DtoManager;
 import nu.yona.server.messaging.service.MessageService.TheDtoManager;
 import nu.yona.server.rest.PolymorphicDto;
+import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyConnectionChangeMessage;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.BuddyConnectRequestMessageDto;
@@ -247,13 +248,13 @@ public abstract class MessageDto extends PolymorphicDto
 
 		private String determineFirstName(Optional<User> senderUser, BuddyConnectionChangeMessage buddyMessageEntity)
 		{
-			return BuddyUserPrivateDataDto.determineName(buddyMessageEntity::getFirstName, senderUser, User::getFirstName,
+			return Buddy.determineName(buddyMessageEntity::getFirstName, senderUser, User::getFirstName,
 					"message.alternative.first.name", buddyMessageEntity.getSenderNickname());
 		}
 
 		private String determineLastName(Optional<User> senderUser, BuddyConnectionChangeMessage buddyMessageEntity)
 		{
-			return BuddyUserPrivateDataDto.determineName(buddyMessageEntity::getLastName, senderUser, User::getLastName,
+			return Buddy.determineName(buddyMessageEntity::getLastName, senderUser, User::getLastName,
 					"message.alternative.last.name", buddyMessageEntity.getSenderNickname());
 		}
 

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -29,7 +29,6 @@ import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.service.MessageService.DtoManager;
 import nu.yona.server.messaging.service.MessageService.TheDtoManager;
 import nu.yona.server.rest.PolymorphicDto;
-import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyConnectionChangeMessage;
 import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.BuddyConnectRequestMessageDto;
@@ -237,25 +236,13 @@ public abstract class MessageDto extends PolymorphicDto
 		protected SenderInfo createSenderInfoForBuddyConnectionChangeMessage(Optional<User> senderUser,
 				BuddyConnectionChangeMessage buddyMessageEntity)
 		{
-			String firstName = determineFirstName(senderUser, buddyMessageEntity);
-			String lastName = determineLastName(senderUser, buddyMessageEntity);
+			String firstName = buddyMessageEntity.determineFirstName(senderUser);
+			String lastName = buddyMessageEntity.determineLastName(senderUser);
 
 			BuddyUserPrivateDataDto buddyUserPrivateData = BuddyUserPrivateDataDto.createInstance(firstName, lastName,
 					buddyMessageEntity.getSenderNickname(), buddyMessageEntity.getSenderUserPhotoId());
 			return senderInfoFactory.createInstanceForDetachedBuddy(
 					senderUser.map(u -> UserDto.createInstanceWithBuddyData(u, buddyUserPrivateData)), buddyUserPrivateData);
-		}
-
-		private String determineFirstName(Optional<User> senderUser, BuddyConnectionChangeMessage buddyMessageEntity)
-		{
-			return Buddy.determineName(buddyMessageEntity::getFirstName, senderUser, User::getFirstName,
-					"message.alternative.first.name", buddyMessageEntity.getSenderNickname());
-		}
-
-		private String determineLastName(Optional<User> senderUser, BuddyConnectionChangeMessage buddyMessageEntity)
-		{
-			return Buddy.determineName(buddyMessageEntity::getLastName, senderUser, User::getLastName,
-					"message.alternative.last.name", buddyMessageEntity.getSenderNickname());
 		}
 
 		protected SenderInfo createSenderInfoForSystem()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/Buddy.java
@@ -205,7 +205,7 @@ public class Buddy extends PrivateUserProperties
 	 */
 	public String determineFirstName(Optional<User> user)
 	{
-		return Buddy.determineName(this::getFirstName, user, User::getFirstName, "message.alternative.first.name", getNickname());
+		return determineName(this::getFirstName, user, User::getFirstName, "message.alternative.first.name", getNickname());
 	}
 
 	/**
@@ -216,7 +216,7 @@ public class Buddy extends PrivateUserProperties
 	 */
 	public String determineLastName(Optional<User> user)
 	{
-		return Buddy.determineName(this::getLastName, user, User::getLastName, "message.alternative.last.name", getNickname());
+		return determineName(this::getLastName, user, User::getLastName, "message.alternative.last.name", getNickname());
 	}
 
 	/**
@@ -228,12 +228,12 @@ public class Buddy extends PrivateUserProperties
 	 * @param buddyUserNameGetter Getter to fetch the name from the buddy entity or a message
 	 * @param user Optional user entity
 	 * @param userNameGetter Getter to fetch the name (first or last) from the user entity
-	 * @param messageId The ID of the translatable message to build the fallback string
+	 * @param fallbackMessageId The ID of the translatable message to build the fallback string
 	 * @param nickname The nickname to include in the fallback string
 	 * @return The name or a substitute for it (never null)
 	 */
 	public static String determineName(Supplier<String> buddyUserNameGetter, Optional<User> user,
-			Function<User, String> userNameGetter, String messageId, String nickname)
+			Function<User, String> userNameGetter, String fallbackMessageId, String nickname)
 	{
 		String name = buddyUserNameGetter.get();
 		if (name != null)
@@ -252,6 +252,6 @@ public class Buddy extends PrivateUserProperties
 		// We're apparently in a migration process to move first and last name to the private data
 		// The app will fetch the message, causing processing of all unprocessed messages. That'll fill in the first and last
 		// name in the buddy entity, so from then onward, the user will see the right data
-		return Translator.getInstance().getLocalizedMessage(messageId, nickname);
+		return Translator.getInstance().getLocalizedMessage(fallbackMessageId, nickname);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
@@ -4,6 +4,10 @@
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
@@ -58,5 +62,29 @@ public abstract class BuddyConnectionChangeMessage extends BuddyMessage
 	public String getLastName()
 	{
 		return lastName;
+	}
+
+	/**
+	 * Determines the first name (see {@link Buddy#determineName(Supplier, Optional, Function, String, String)}).
+	 * 
+	 * @param user Optional user
+	 * @return The first name or a substitute for it (never null)
+	 */
+	public String determineFirstName(Optional<User> senderUser)
+	{
+		return Buddy.determineName(this::getFirstName, senderUser, User::getFirstName, "message.alternative.first.name",
+				getSenderNickname());
+	}
+
+	/**
+	 * Determines the last name (see {@link Buddy#determineName(Supplier, Optional, Function, String, String)}).
+	 * 
+	 * @param user Optional user
+	 * @return The last name or a substitute for it (never null)
+	 */
+	public String determineLastName(Optional<User> senderUser)
+	{
+		return Buddy.determineName(this::getLastName, senderUser, User::getLastName, "message.alternative.last.name",
+				getSenderNickname());
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -217,9 +217,9 @@ public class BuddyService
 
 	private Buddy createBuddyEntity(BuddyConnectRequestMessage connectRequestMessageEntity)
 	{
-		Buddy buddy = Buddy.createInstance(connectRequestMessageEntity.getSenderUser().get().getId(),
-				connectRequestMessageEntity.getFirstName(), connectRequestMessageEntity.getLastName(),
-				connectRequestMessageEntity.getSenderNickname(),
+		Optional<User> senderUser = connectRequestMessageEntity.getSenderUser();
+		Buddy buddy = Buddy.createInstance(senderUser.get().getId(), connectRequestMessageEntity.determineFirstName(senderUser),
+				connectRequestMessageEntity.determineLastName(senderUser), connectRequestMessageEntity.getSenderNickname(),
 				connectRequestMessageEntity.requestingSending() ? Status.ACCEPTED : Status.NOT_REQUESTED,
 				connectRequestMessageEntity.requestingReceiving() ? Status.ACCEPTED : Status.NOT_REQUESTED);
 		buddy.setUserAnonymizedId(connectRequestMessageEntity.getRelatedUserAnonymizedId().get());

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDto.java
@@ -8,25 +8,17 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import org.springframework.core.annotation.Order;
-
-import nu.yona.server.Translator;
 import nu.yona.server.device.service.BuddyDeviceDto;
 import nu.yona.server.device.service.DeviceBaseDto;
 import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
 import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.service.migration.EncryptFirstAndLastName;
 
 public class BuddyUserPrivateDataDto extends UserPrivateDataBaseDto
 {
-	private static final int VERSION_OF_NAME_MIGRATION = EncryptFirstAndLastName.class.getAnnotation(Order.class).value() + 1;
-
 	BuddyUserPrivateDataDto(String firstName, String lastName, String nickname, Optional<UUID> userPhotoId)
 	{
 		super(firstName, lastName, nickname, userPhotoId, Optional.empty(), Optional.empty());
@@ -49,48 +41,13 @@ public class BuddyUserPrivateDataDto extends UserPrivateDataBaseDto
 			Set<DeviceBaseDto> devices = buddyEntity.getDevices().stream().map(BuddyDeviceDto::createInstance)
 					.collect(Collectors.toSet());
 			Optional<User> user = Optional.ofNullable(buddyEntity.getUser());
-			String firstName = determineFirstName(buddyEntity, user);
-			String lastName = determineLastName(buddyEntity, user);
+			String firstName = buddyEntity.determineFirstName(user);
+			String lastName = buddyEntity.determineLastName(user);
 			return new BuddyUserPrivateDataDto(firstName, lastName, buddyEntity.getNickname(), buddyEntity.getUserPhotoId(),
 					goals, devices);
 		}
 		return new BuddyUserPrivateDataDto(buddyEntity.getFirstName(), buddyEntity.getLastName(), buddyEntity.getNickname(),
 				buddyEntity.getUserPhotoId());
-	}
-
-	private static String determineLastName(Buddy buddyEntity, Optional<User> user)
-	{
-		return determineName(buddyEntity::getLastName, user, User::getLastName, "message.alternative.last.name",
-				buddyEntity.getNickname());
-	}
-
-	private static String determineFirstName(Buddy buddyEntity, Optional<User> user)
-	{
-		return determineName(buddyEntity::getFirstName, user, User::getFirstName,
-				"message.alternative.first.name", buddyEntity.getNickname());
-	}
-
-	public static String determineName(Supplier<String> buddyUserNameGetter, Optional<User> user,
-			Function<User, String> userNameGetter, String messageId, String nickname)
-	{
-		String name = buddyUserNameGetter.get();
-		if (name != null)
-		{
-			return name;
-		}
-		if ((user.isPresent()) && (user.get().getPrivateDataMigrationVersion() < VERSION_OF_NAME_MIGRATION))
-		{
-			// User is not deleted yet and not yet migrated, so get the name from the user entity
-			name = userNameGetter.apply(user.get());
-		}
-		if (name != null)
-		{
-			return name;
-		}
-		// We're apparently in a migration process to move first and last name to the private data
-		// The app will fetch the message, causing processing of all unprocessed messages. That'll fill in the first and last
-		// name in the buddy entity, so from then onward, the user will see the right data
-		return Translator.getInstance().getLocalizedMessage(messageId, nickname);
 	}
 
 	public static BuddyUserPrivateDataDto createInstance(String firstName, String lastName, String nickname,

--- a/core/src/test/java/nu/yona/server/messaging/entities/BuddyMessageTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/entities/BuddyMessageTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2018 Stichting Yona Foundation
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.messaging.entities;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.repository.Repository;
+
+import nu.yona.server.Translator;
+import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.entities.BuddyAnonymizedRepositoryMock;
+import nu.yona.server.entities.UserAnonymizedRepositoryMock;
+import nu.yona.server.entities.UserRepositoryMock;
+import nu.yona.server.messaging.entities.BuddyMessage.BuddyInfoParameters;
+import nu.yona.server.subscriptions.entities.Buddy;
+import nu.yona.server.subscriptions.entities.BuddyAnonymized;
+import nu.yona.server.subscriptions.entities.PrivateUserProperties;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.test.util.CryptoSessionRule;
+import nu.yona.server.test.util.JUnitUtil;
+
+public class BuddyMessageTest
+{
+	@RunWith(MockitoJUnitRunner.class)
+	public static class BuddyInfoParametersTest
+	{
+		private static final String FIRST_NAME_SUBSTITUTE = "FN BD";
+		private static final String LAST_NAME_SUBSTITUTE = "LN BD";
+		private static final String PASSWORD = "password";
+		private final Field translatorStaticField = JUnitUtil.getAccessibleField(Translator.class, "staticReference");
+		private final Field privateUserPropertiesFirstNameField = JUnitUtil.getAccessibleField(PrivateUserProperties.class,
+				"firstName");
+		private final Field privateUserPropertiesLastNameField = JUnitUtil.getAccessibleField(PrivateUserProperties.class,
+				"lastName");
+
+		@Rule
+		public MethodRule cryptoSession = new CryptoSessionRule(PASSWORD);
+
+		@Mock
+		private Translator translator;
+
+		private User richard;
+		private User bob;
+
+		@Before
+		public void setUpPerTest() throws Exception
+		{
+			translatorStaticField.set(null, translator);
+			Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+			repositoriesMap.put(User.class, new UserRepositoryMock());
+			repositoriesMap.put(UserAnonymized.class, new UserAnonymizedRepositoryMock());
+			repositoriesMap.put(BuddyAnonymized.class, new BuddyAnonymizedRepositoryMock());
+			JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
+
+			try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
+			{
+				richard = JUnitUtil.createRichard();
+				bob = JUnitUtil.createBob();
+				JUnitUtil.makeBuddies(richard, bob);
+			}
+
+			Object[] params = { bob.getNickname() };
+			when(translator.getLocalizedMessage("message.alternative.first.name", params)).thenReturn(FIRST_NAME_SUBSTITUTE);
+			when(translator.getLocalizedMessage("message.alternative.last.name", params)).thenReturn(LAST_NAME_SUBSTITUTE);
+		}
+
+		@Test
+		public void createInstance_buddyWithName_nameReturned()
+		{
+			Buddy buddy = richard.getBuddies().iterator().next();
+			BuddyInfoParameters buddyInfoParameters = BuddyMessage.BuddyInfoParameters.createInstance(buddy,
+					buddy.getBuddyAnonymizedId());
+
+			assertThat(buddyInfoParameters.firstName, equalTo(bob.getFirstName()));
+			assertThat(buddyInfoParameters.lastName, equalTo(bob.getLastName()));
+		}
+
+		@Test
+		public void createInstance_buddyWithoutName_substituteReturned() throws IllegalArgumentException, IllegalAccessException
+		{
+			Buddy buddy = richard.getBuddies().iterator().next();
+			privateUserPropertiesFirstNameField.set(buddy, null);
+			privateUserPropertiesLastNameField.set(buddy, null);
+			BuddyInfoParameters buddyInfoParameters = BuddyMessage.BuddyInfoParameters.createInstance(buddy,
+					buddy.getBuddyAnonymizedId());
+
+			assertThat(buddyInfoParameters.firstName, equalTo(FIRST_NAME_SUBSTITUTE));
+			assertThat(buddyInfoParameters.lastName, equalTo(LAST_NAME_SUBSTITUTE));
+		}
+	}
+}

--- a/core/src/test/java/nu/yona/server/subscriptions/entities/BuddyTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/entities/BuddyTest.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
-package nu.yona.server.subscriptions.service;
+package nu.yona.server.subscriptions.entities;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,14 +28,11 @@ import nu.yona.server.Translator;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.messaging.entities.MessageSource;
-import nu.yona.server.subscriptions.entities.PrivateUserProperties;
-import nu.yona.server.subscriptions.entities.User;
-import nu.yona.server.subscriptions.entities.UserPrivate;
 import nu.yona.server.test.util.CryptoSessionRule;
 import nu.yona.server.test.util.JUnitUtil;
 
 @RunWith(MockitoJUnitRunner.class)
-public class BuddyUserPrivateDataDtoTest
+public class BuddyTest
 {
 	private static final String PASSWORD = "PASSWORD";
 
@@ -81,7 +78,7 @@ public class BuddyUserPrivateDataDtoTest
 	{
 		String buddyName = "BuddyName";
 
-		String name = BuddyUserPrivateDataDto.determineName(() -> buddyName, null, null, null, null);
+		String name = Buddy.determineName(() -> buddyName, null, null, null, null);
 
 		assertThat(name, equalTo(buddyName));
 	}
@@ -94,8 +91,7 @@ public class BuddyUserPrivateDataDtoTest
 		User user = createUser("firstName", "lastName", nickname);
 		privateUserPropertiesFirstNameField.set(userUserPrivateField.get(user), null);
 
-		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, messageId,
-				nickname);
+		String name = Buddy.determineName(() -> null, Optional.of(user), User::getFirstName, messageId, nickname);
 
 		assertThat(name, equalTo(messageId + ":" + nickname));
 	}
@@ -108,8 +104,7 @@ public class BuddyUserPrivateDataDtoTest
 		User user = createUser("firstName", "lastName", nickname);
 		user.setPrivateDataMigrationVersion(9999);
 
-		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, messageId,
-				nickname);
+		String name = Buddy.determineName(() -> null, Optional.of(user), User::getFirstName, messageId, nickname);
 
 		assertThat(name, equalTo(messageId + ":" + nickname));
 	}
@@ -121,7 +116,7 @@ public class BuddyUserPrivateDataDtoTest
 		User user = createUser(userName, "lastName", "nickName");
 		user.setPrivateDataMigrationVersion(0);
 
-		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.of(user), User::getFirstName, null, null);
+		String name = Buddy.determineName(() -> null, Optional.of(user), User::getFirstName, null, null);
 
 		assertThat(name, equalTo(userName));
 	}
@@ -132,8 +127,7 @@ public class BuddyUserPrivateDataDtoTest
 		String nickname = "nickname";
 		String messageId = "message.id";
 
-		String name = BuddyUserPrivateDataDto.determineName(() -> null, Optional.empty(), User::getFirstName, messageId,
-				nickname);
+		String name = Buddy.determineName(() -> null, Optional.empty(), User::getFirstName, messageId, nickname);
 
 		assertThat(name, equalTo(messageId + ":" + nickname));
 	}

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -108,8 +108,8 @@ public class JUnitUtil
 
 	private static void addAsBuddy(User user, User buddyToBe)
 	{
-		Buddy buddy = Buddy.createInstance(buddyToBe.getId(), user.getFirstName(), user.getLastName(), buddyToBe.getNickname(),
-				Status.ACCEPTED, Status.ACCEPTED);
+		Buddy buddy = Buddy.createInstance(buddyToBe.getId(), buddyToBe.getFirstName(), buddyToBe.getLastName(),
+				buddyToBe.getNickname(), Status.ACCEPTED, Status.ACCEPTED);
 		buddy.setUserAnonymizedId(buddyToBe.getAnonymized().getId());
 		user.addBuddy(buddy);
 	}


### PR DESCRIPTION
This scenario failed:

* The user A signed up for at 1 Mar 2018
* The user invited B to join Yona 4 minutes after sign-up
* User B didn't respond to the invitation
* At 14 May 2018, user B signed up for Yona, thus overwriting the account that was created on buddy request
* At 9 Jun 2018, user A opened Yona again, triggering the logic in handleBuddyUsersRemovedWhileOffline. At that time, user B was not migrated yet, so user A didn't have their first or last name in the buddy entity, causing an NPE

The fix is to use the logic of determineName to determine the first and last name that's included in the BuddyInfoParameters. To enable that, the method is moved from BuddyUserPrivateDataDto to Buddy.