### PR TITLE
YD-575 Postpone user anonymized creation

### DIFF
--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -158,10 +157,10 @@ public class ActivityUpdateServiceTest
 		// Set up UserAnonymized instance.
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
-		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
 		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown");
 		deviceAnonId = deviceAnonEntity.getId();
-		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity);
+		Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal).stream().forEach(g -> userAnonEntity.addGoal(g));
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);
 		deviceAnonDto = DeviceAnonymizedDto.createInstance(deviceAnonEntity);

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -210,10 +210,10 @@ public class AnalysisEngineServiceTest
 		// Set up UserAnonymized instance.
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
-		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
 		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown");
 		deviceAnonId = deviceAnonEntity.getId();
-		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity);
+		Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal).stream().forEach(g -> userAnonEntity.addGoal(g));
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);
 		deviceAnonDto = DeviceAnonymizedDto.createInstance(deviceAnonEntity);

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
@@ -105,10 +105,10 @@ public class AnalysisEngineService_determineRelevantGoalsTest
 		// Set up UserAnonymized instance.
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
-		Set<Goal> goals = new HashSet<>(
-				Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal, shoppingGoalHistoryItem));
 		deviceAnonEntity = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown");
-		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity);
+		Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal, shoppingGoalHistoryItem).stream()
+				.forEach(g -> userAnonEntity.addGoal(g));
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);
 		deviceAnonDto = DeviceAnonymizedDto.createInstance(deviceAnonEntity);

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -164,7 +164,7 @@ public class DeviceController extends ControllerBase
 				() -> userService.canAccessPrivateData(userId)))
 		{
 			UserDeviceDto newDevice = deviceService.addDeviceToUser(userId,
-					UserDeviceDto.createDeviceRegistrationInstance(request));
+					UserDeviceDto.createDeviceRegistrationInstance(request), true);
 			return createResponse(userService.getPrivateUser(userId, false), HttpStatus.CREATED,
 					userController.createResourceAssemblerForOwnUser(userId, Optional.of(newDevice.getId())));
 		}
@@ -480,7 +480,8 @@ public class DeviceController extends ControllerBase
 		{
 			if (getContent() instanceof UserDeviceDto)
 			{
-				return createVpnProfileResource(((UserDeviceDto) getContent()).getVpnProfile());
+				VPNProfileDto vpnProfile = ((UserDeviceDto) getContent()).getVpnProfile();
+				return createVpnProfileResource(vpnProfile);
 			}
 			return null;
 		}

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceBase.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceBase.java
@@ -40,7 +40,7 @@ public abstract class DeviceBase extends EntityWithUuidAndTouchVersion
 	{
 		super(id);
 		this.name = Objects.requireNonNull(name);
-		this.deviceAnonymizedId = Objects.requireNonNull(deviceAnonymizedId);
+		this.deviceAnonymizedId = deviceAnonymizedId;
 	}
 
 	public String getName()
@@ -66,14 +66,33 @@ public abstract class DeviceBase extends EntityWithUuidAndTouchVersion
 		return deviceAnonymizedId;
 	}
 
+	protected void setDeviceAnonymizeId(UUID deviceAnonymizedId)
+	{
+		assert this.deviceAnonymizedId == null;
+		this.deviceAnonymizedId = deviceAnonymizedId;
+	}
+
 	public DeviceAnonymized getDeviceAnonymized()
 	{
+		if (deviceAnonymizedId == null)
+		{
+			return null; // Device anonymized not created yet
+		}
 		return getDeviceAnonymizedIfExisting()
 				.orElseThrow(() -> new IllegalStateException("DeviceAnonymized with ID " + deviceAnonymizedId + " not found"));
 	}
 
+	public void clearDeviceAnonymized()
+	{
+		deviceAnonymizedId = null;
+	}
+
 	private Optional<DeviceAnonymized> getDeviceAnonymizedIfExisting()
 	{
+		if (deviceAnonymizedId == null)
+		{
+			return Optional.empty();
+		}
 		return Optional.ofNullable(DeviceAnonymized.getRepository().findOne(deviceAnonymizedId));
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
+++ b/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Type;
 import nu.yona.server.crypto.seckey.DateFieldEncryptor;
 import nu.yona.server.crypto.seckey.DateTimeFieldEncryptor;
 import nu.yona.server.crypto.seckey.StringFieldEncryptor;
+import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
 import nu.yona.server.util.TimeUtil;
 
 @Entity
@@ -40,22 +41,28 @@ public class UserDevice extends DeviceBase
 	@Convert(converter = DateFieldEncryptor.class)
 	private LocalDate appLastOpenedDate;
 
+	private OperatingSystem operatingSystem;
+
+	private String appVersion;
+
 	// Default constructor is required for JPA
 	public UserDevice()
 	{
 	}
 
-	private UserDevice(UUID id, String name, UUID deviceAnonymizedId, String vpnPassword)
+	private UserDevice(UUID id, String name, OperatingSystem operatingSystem, String appVersion, String vpnPassword)
 	{
-		super(id, name, deviceAnonymizedId);
+		super(id, name, null);
+		this.operatingSystem = operatingSystem;
+		this.appVersion = appVersion;
 		this.vpnPassword = Objects.requireNonNull(vpnPassword);
 		this.registrationTime = TimeUtil.utcNow();
 		this.appLastOpenedDate = TimeUtil.utcNow().toLocalDate(); // The user registers this device, so the app is open now
 	}
 
-	public static UserDevice createInstance(String name, UUID deviceAnonymizedId, String vpnPassword)
+	public static UserDevice createInstance(String name, OperatingSystem operatingSystem, String appVersion, String vpnPassword)
 	{
-		return new UserDevice(UUID.randomUUID(), name, deviceAnonymizedId, vpnPassword);
+		return new UserDevice(UUID.randomUUID(), name, operatingSystem, appVersion, vpnPassword);
 	}
 
 	public UUID getUserPrivateId()
@@ -76,6 +83,16 @@ public class UserDevice extends DeviceBase
 	public boolean isLegacyVpnAccount()
 	{
 		return isLegacyVpnAccount;
+	}
+
+	public OperatingSystem getOperatingSystem()
+	{
+		return (operatingSystem == null) ? getDeviceAnonymized().getOperatingSystem() : operatingSystem;
+	}
+
+	public String getAppVersion()
+	{
+		return (appVersion == null) ? getDeviceAnonymized().getAppVersion() : appVersion;
 	}
 
 	public String getVpnPassword()
@@ -107,5 +124,12 @@ public class UserDevice extends DeviceBase
 	public void setAppLastOpenedDate(LocalDate appLastOpenedDate)
 	{
 		this.appLastOpenedDate = Objects.requireNonNull(appLastOpenedDate);
+	}
+
+	public void attachDeviceAnonymized(DeviceAnonymized deviceAnonymized)
+	{
+		setDeviceAnonymizeId(deviceAnonymized.getId());
+		operatingSystem = null;
+		appVersion = null;
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/UserDeviceDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/UserDeviceDto.java
@@ -86,10 +86,11 @@ public class UserDeviceDto extends DeviceBaseDto
 
 	public static UserDeviceDto createInstance(UserDevice deviceEntity)
 	{
-		return new UserDeviceDto(deviceEntity.getId(), deviceEntity.getName(),
-				deviceEntity.getDeviceAnonymized().getOperatingSystem(), deviceEntity.getDeviceAnonymized().getAppVersion(),
-				deviceEntity.isVpnConnected(), deviceEntity.getRegistrationTime(), deviceEntity.getAppLastOpenedDate(),
-				deviceEntity.getDeviceAnonymizedId(), VPNProfileDto.createInstance(deviceEntity));
+		UUID deviceAnonymizedId = deviceEntity.getDeviceAnonymizedId();
+		VPNProfileDto vpnProfile = (deviceAnonymizedId == null) ? null : VPNProfileDto.createInstance(deviceEntity);
+		return new UserDeviceDto(deviceEntity.getId(), deviceEntity.getName(), deviceEntity.getOperatingSystem(),
+				deviceEntity.getAppVersion(), deviceEntity.isVpnConnected(), deviceEntity.getRegistrationTime(),
+				deviceEntity.getAppLastOpenedDate(), deviceAnonymizedId, vpnProfile);
 	}
 
 	public static UserDeviceDto createDeviceRegistrationInstance(DeviceRegistrationRequestDto deviceRegistration)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -270,6 +270,11 @@ public class User extends EntityWithUuid
 		return getUserPrivate().getAnonymousMessageSourceId();
 	}
 
+	public void setAnonymousMessageSourceId(UUID anonymousMessageSourceId)
+	{
+		getUserPrivate().setAnonymousMessageSourceId(anonymousMessageSourceId);
+	}
+
 	public Set<Buddy> getBuddies()
 	{
 		return getUserPrivate().getBuddies();
@@ -287,6 +292,11 @@ public class User extends EntityWithUuid
 	public UserAnonymized getAnonymized()
 	{
 		return getUserPrivate().getUserAnonymized();
+	}
+
+	public void setAnonymized(UserAnonymized userAnonymized)
+	{
+		getUserPrivate().setUserAnonymized(userAnonymized);
 	}
 
 	public User touch()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
@@ -62,11 +62,11 @@ public class UserAnonymized extends EntityWithUuid
 		super(null);
 	}
 
-	private UserAnonymized(UUID id, MessageDestination anonymousDestination, Set<Goal> goals)
+	private UserAnonymized(UUID id, MessageDestination anonymousDestination)
 	{
 		super(id);
 		this.anonymousDestination = anonymousDestination;
-		this.goals = new HashSet<>(goals);
+		this.goals = new HashSet<>();
 		this.buddiesAnonymized = new HashSet<>();
 		this.devicesAnonymized = new HashSet<>();
 	}
@@ -76,9 +76,9 @@ public class UserAnonymized extends EntityWithUuid
 		return (UserAnonymizedRepository) RepositoryProvider.getRepository(UserAnonymized.class, UUID.class);
 	}
 
-	public static UserAnonymized createInstance(MessageDestination anonymousDestination, Set<Goal> goals)
+	public static UserAnonymized createInstance(MessageDestination anonymousDestination)
 	{
-		return new UserAnonymized(UUID.randomUUID(), anonymousDestination, goals);
+		return new UserAnonymized(UUID.randomUUID(), anonymousDestination);
 	}
 
 	public Optional<LocalDate> getLastMonitoredActivityDate()

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
@@ -216,14 +216,16 @@ public class UserDto
 
 	public static UserDto createInstanceWithPrivateData(User userEntity, Set<BuddyDto> buddies)
 	{
+		UUID userAnonymizedId = userEntity.getUserAnonymizedId();
+		Set<GoalDto> goals = (userAnonymizedId == null) ? Collections.emptySet()
+				: UserAnonymizedDto.getGoalsIncludingHistoryItems(userEntity.getAnonymized());
+		Optional<VPNProfileDto> vpnProfile = (userAnonymizedId == null) ? Optional.empty() : createVpnProfileDto(userEntity);
 		return new UserDto(userEntity.getId(), userEntity.getCreationTime(), userEntity.getAppLastOpenedDate(),
 				userEntity.getLastMonitoredActivityDate(), userEntity.getFirstName(), userEntity.getLastName(),
 				CryptoSession.getCurrent().getKeyString(), userEntity.getNickname(), userEntity.getUserPhotoId(),
 				userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(), userEntity.isCreatedOnBuddyRequest(),
-				userEntity.getNamedMessageSourceId(), userEntity.getAnonymousMessageSourceId(),
-				UserAnonymizedDto.getGoalsIncludingHistoryItems(userEntity.getAnonymized()), buddies,
-				userEntity.getUserAnonymizedId(), createVpnProfileDto(userEntity),
-				userEntity.getDevices().stream().map(UserDeviceDto::createInstance).collect(Collectors.toSet()));
+				userEntity.getNamedMessageSourceId(), userEntity.getAnonymousMessageSourceId(), goals, buddies, userAnonymizedId,
+				vpnProfile, userEntity.getDevices().stream().map(UserDeviceDto::createInstance).collect(Collectors.toSet()));
 	}
 
 	// YD-541: Remove this method

--- a/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/migration/AddFirstDevice.java
@@ -40,7 +40,7 @@ public class AddFirstDevice implements MigrationStep
 
 	private void createInitialDevice(User user)
 	{
-		deviceService.addDeviceToUser(user, deviceService.createDefaultUserDeviceDto());
+		deviceService.addDeviceToUser(user, deviceService.createDefaultUserDeviceDto(), true);
 	}
 
 	private void addDevicesAnonymizedToUserAnonymizedIfNotDoneYet(User user)

--- a/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
 
@@ -15,11 +15,9 @@ import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Before;
@@ -29,7 +27,6 @@ import nu.yona.server.device.entities.DeviceAnonymized;
 import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
 import nu.yona.server.goals.entities.ActivityCategory;
 import nu.yona.server.goals.entities.BudgetGoal;
-import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.entities.TimeZoneGoal;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
@@ -58,9 +55,9 @@ public abstract class IntervalActivityTestBase
 		// Set up UserAnonymized instance.
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
-		Set<Goal> goals = new HashSet<>(Arrays.asList(budgetGoal));
 		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
-		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity);
+		userAnonEntity.addGoal(budgetGoal);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 	}
 

--- a/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
@@ -138,9 +138,9 @@ public class ActivityServiceTest
 		// Set up UserAnonymized instance.
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
-		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
 		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
-		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
+		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity);
+		Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal).stream().forEach(g -> userAnonEntity.addGoal(g));
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		UserAnonymizedDto userAnon = UserAnonymizedDto.createInstance(userAnonEntity);
 		userAnonZone = userAnon.getTimeZone();

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -199,7 +199,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
 		LocalDateTime startTime = TimeUtil.utcNow();
 		UserDeviceDto deviceDto = new UserDeviceDto(deviceName, operatingSystem, SUPPORTED_APP_VERSION);
-		service.addDeviceToUser(richard, deviceDto);
+		service.addDeviceToUser(richard, deviceDto, true);
 
 		verify(userDeviceRepository, times(1)).save(any(UserDevice.class));
 		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
@@ -219,12 +219,12 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		String deviceName1 = "First";
 		OperatingSystem operatingSystem1 = OperatingSystem.ANDROID;
 		LocalDateTime startTime = TimeUtil.utcNow();
-		richard.addDevice(createDevice(0, deviceName1, operatingSystem1, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(0, deviceName1, operatingSystem1, SUPPORTED_APP_VERSION));
 
 		String deviceName2 = "Second";
 		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
 		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName2, operatingSystem2, SUPPORTED_APP_VERSION);
-		service.addDeviceToUser(richard, deviceDto2);
+		service.addDeviceToUser(richard, deviceDto2, true);
 
 		verify(userDeviceRepository, times(2)).save(any(UserDevice.class));
 		assertThat(deviceAnonymizedRepository.count(), equalTo(2L));
@@ -252,10 +252,10 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		expectedException.expect(hasMessageId("error.device.name.already.exists"));
 
 		String deviceName = "First";
-		richard.addDevice(createDevice(0, deviceName, OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(0, deviceName, OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
 
 		UserDeviceDto deviceDto2 = new UserDeviceDto(deviceName, OperatingSystem.IOS, SUPPORTED_APP_VERSION);
-		service.addDeviceToUser(richard, deviceDto2);
+		service.addDeviceToUser(richard, deviceDto2, true);
 	}
 
 	@Test
@@ -264,11 +264,11 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		LocalDateTime startTime = TimeUtil.utcNow();
 		String deviceName = "First";
 		UserDevice device1 = createDevice(0, deviceName, OperatingSystem.ANDROID, SUPPORTED_APP_VERSION);
-		richard.addDevice(device1);
+		addDeviceToRichard(device1);
 
 		String deviceName2 = "Second";
 		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
-		richard.addDevice(createDevice(1, deviceName2, operatingSystem2, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(1, deviceName2, operatingSystem2, SUPPORTED_APP_VERSION));
 
 		assertThat(richard.getDevices().size(), equalTo(2));
 
@@ -298,14 +298,14 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		LocalDateTime startTime = TimeUtil.utcNow();
 		String deviceName2 = "Second";
 		OperatingSystem operatingSystem2 = OperatingSystem.IOS;
-		richard.addDevice(createDevice(1, deviceName2, operatingSystem2, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(1, deviceName2, operatingSystem2, SUPPORTED_APP_VERSION));
 
 		assertThat(richard.getDevices().size(), equalTo(1));
 
 		String deviceName3 = "Third";
 		OperatingSystem operatingSystem3 = OperatingSystem.IOS;
 		UserDeviceDto deviceDto3 = new UserDeviceDto(deviceName3, operatingSystem3, SUPPORTED_APP_VERSION);
-		service.addDeviceToUser(richard, deviceDto3);
+		service.addDeviceToUser(richard, deviceDto3, true);
 
 		Set<UserDevice> devices = richard.getDevices();
 		assertThat(devices.size(), equalTo(2));
@@ -328,7 +328,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
 		LocalDateTime startTime = TimeUtil.utcNow();
 		UserDeviceDto deviceDto = new UserDeviceDto(deviceName, operatingSystem, SUPPORTED_APP_VERSION);
-		service.addDeviceToUser(richard.getId(), deviceDto);
+		service.addDeviceToUser(richard.getId(), deviceDto, true);
 
 		verify(userDeviceRepository, times(1)).save(any(UserDevice.class));
 		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
@@ -346,7 +346,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		expectedException.expect(DeviceServiceException.class);
 		expectedException.expect(hasMessageId("error.device.cannot.delete.last.one"));
 
-		richard.addDevice(createDevice(0, "Testing", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(0, "Testing", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
 
 		assertThat(richard.getDevices().size(), equalTo(1));
 
@@ -361,7 +361,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		expectedException.expect(DeviceServiceException.class);
 		expectedException.expect(hasMessageId("error.device.not.found.id"));
 
-		richard.addDevice(createDevice(0, "First", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
+		addDeviceToRichard(createDevice(0, "First", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION));
 		UserDevice notAddedDevice = createDevice(1, "NotAddedDevice", OperatingSystem.IOS, SUPPORTED_APP_VERSION);
 
 		assertThat(richard.getDevices().size(), equalTo(1));
@@ -388,7 +388,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	public void getDefaultDeviceId_oneDevice_deviceReturned()
 	{
 		UserDevice device = createDevice(0, "First", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION);
-		richard.addDevice(device);
+		addDeviceToRichard(device);
 
 		UUID defaultDeviceId = service.getDefaultDeviceId(createRichardUserDto());
 
@@ -402,7 +402,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		String oldName = "Original name";
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
 		UserDevice device = createDevice(0, oldName, operatingSystem, "1.0.0");
-		richard.addDevice(device);
+		addDeviceToRichard(device);
 
 		assertThat(richard.getDevices().size(), equalTo(1));
 
@@ -434,7 +434,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		String oldName = "original";
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
 		UserDevice device = createDevice(0, oldName, operatingSystem, "1.0.0");
-		richard.addDevice(device);
+		addDeviceToRichard(device);
 
 		assertThat(richard.getDevices().size(), equalTo(1));
 
@@ -461,11 +461,11 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 
 		String firstDeviceName = "First";
 		UserDevice device1 = createDevice(0, firstDeviceName, OperatingSystem.ANDROID, "Unknown");
-		richard.addDevice(device1);
+		addDeviceToRichard(device1);
 
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
 		UserDevice device = createDevice(0, "Original name", operatingSystem, "1.0.0");
-		richard.addDevice(device);
+		addDeviceToRichard(device);
 
 		assertThat(richard.getDevices().size(), equalTo(2));
 
@@ -477,9 +477,9 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	public void getDefaultDeviceId_twoDevices_firstDeviceReturned()
 	{
 		UserDevice device1 = createDevice(0, "First", OperatingSystem.ANDROID, SUPPORTED_APP_VERSION);
-		richard.addDevice(device1);
+		addDeviceToRichard(device1);
 		UserDevice device2 = createDevice(1, "Second", OperatingSystem.IOS, SUPPORTED_APP_VERSION);
-		richard.addDevice(device2);
+		addDeviceToRichard(device2);
 
 		UUID defaultDeviceId = service.getDefaultDeviceId(createRichardUserDto());
 
@@ -897,11 +897,19 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 
 	private UserDevice createDevice(int deviceIndex, String deviceName, OperatingSystem operatingSystem, String appVersion)
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(deviceIndex, operatingSystem, appVersion);
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		UserDevice device = UserDevice.createInstance(deviceName, operatingSystem, appVersion, "topSecret");
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(deviceIndex, device.getOperatingSystem(),
+				device.getAppVersion());
 		deviceAnonymizedRepository.save(deviceAnonymized);
+		device.attachDeviceAnonymized(deviceAnonymized);
 		userDeviceRepository.save(device);
 		return device;
+	}
+
+	private void addDeviceToRichard(UserDevice device)
+	{
+		richard.addDevice(device);
+		richard.getAnonymized().addDeviceAnonymized(device.getDeviceAnonymized());
 	}
 
 	private UserDto createRichardUserDto()
@@ -917,7 +925,8 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	private UserDevice addDeviceToRichard(int deviceIndex, String deviceName, OperatingSystem operatingSystem, String appVersion)
 	{
 		UserDevice deviceEntity = createDevice(deviceIndex, deviceName, operatingSystem, appVersion);
-		richard.addDevice(deviceEntity);
+		addDeviceToRichard(deviceEntity);
+		richard.getAnonymized().addDeviceAnonymized(deviceEntity.getDeviceAnonymized());
 		return deviceEntity;
 	}
 

--- a/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
@@ -27,7 +27,7 @@ public class UserTest
 		{
 			byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
 			MessageSource namedMessageSource = MessageSource.createInstance();
-			UserPrivate userPrivate = UserPrivate.createInstance("John", "Doe", "jd", null, null, namedMessageSource);
+			UserPrivate userPrivate = UserPrivate.createInstance("John", "Doe", "jd", namedMessageSource);
 			john = new User(UUID.randomUUID(), initializationVector, "+31612345678", userPrivate,
 					namedMessageSource.getDestination());
 		}

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
@@ -303,10 +303,13 @@ public class BuddyDeviceChangeMessageDtoTest extends BaseSpringIntegrationTest
 
 	private UserDevice addDevice(User user, String deviceName, OperatingSystem operatingSystem)
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown");
+		UserDevice device = UserDevice.createInstance(deviceName, operatingSystem, "Unknown", "topSecret");
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, device.getOperatingSystem(),
+				device.getAppVersion());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		device.attachDeviceAnonymized(deviceAnonymized);
 		user.addDevice(device);
+		user.getAnonymized().addDeviceAnonymized(device.getDeviceAnonymized());
 
 		return device;
 	}

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyUserPrivateDataDtoTest.java
@@ -141,8 +141,7 @@ public class BuddyUserPrivateDataDtoTest
 	private User createUser(String firstName, String lastName, String nickname)
 	{
 		byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
-		UserPrivate userPrivate = UserPrivate.createInstance(firstName, lastName, nickname, UUID.randomUUID(), UUID.randomUUID(),
-				messageSource);
+		UserPrivate userPrivate = UserPrivate.createInstance(firstName, lastName, nickname, messageSource);
 		return new User(UUID.randomUUID(), initializationVector, "+31123456", userPrivate, messageDestination);
 	}
 }

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -63,6 +63,7 @@ import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.LDAPUserService;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
+import nu.yona.server.subscriptions.service.UserAnonymizedService;
 import nu.yona.server.subscriptions.service.UserService;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.CryptoSessionRule;
@@ -127,6 +128,9 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 	private UserService mockUserService;
 
 	@MockBean
+	private UserAnonymizedService mockAnonymizedUserService;
+
+	@MockBean
 	private LDAPUserService mockLdapUserService;
 
 	@MockBean
@@ -166,9 +170,11 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 		// Add device
 		String deviceName = "Testing";
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, SUPPORTED_APP_VERSION);
+		UserDevice device = UserDevice.createInstance(deviceName, operatingSystem, SUPPORTED_APP_VERSION, "topSecret");
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, device.getOperatingSystem(),
+				device.getAppVersion());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		device.attachDeviceAnonymized(deviceAnonymized);
 		richard.addDevice(device);
 
 		// Verify device is present

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
@@ -145,8 +145,6 @@ public class MoveVpnPasswordToDeviceTest extends BaseSpringIntegrationTest
 
 	private UserDevice createDevice()
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "1.0.0");
-		deviceAnonymizedRepository.save(deviceAnonymized);
-		return UserDevice.createInstance("Testing", deviceAnonymized.getId(), "toBeOverwritten");
+		return UserDevice.createInstance("Testing", OperatingSystem.ANDROID, "1.0.0", "toBeOverwritten");
 	}
 }

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
@@ -87,16 +86,16 @@ public class JUnitUtil
 	public static User createUserEntity(String firstName, String lastName, String mobileNumber, String nickname)
 	{
 		MessageSource anonymousMessageSource = MessageSource.createInstance();
-		UserAnonymized johnAnonymized = UserAnonymized.createInstance(anonymousMessageSource.getDestination(),
-				Collections.emptySet());
-		UserAnonymized.getRepository().save(johnAnonymized);
+		UserAnonymized userAnonymized = UserAnonymized.createInstance(anonymousMessageSource.getDestination());
+		UserAnonymized.getRepository().save(userAnonymized);
 
 		byte[] initializationVector = CryptoSession.getCurrent().generateInitializationVector();
 		MessageSource namedMessageSource = MessageSource.createInstance();
-		UserPrivate userPrivate = UserPrivate.createInstance(firstName, lastName, nickname, johnAnonymized.getId(),
-				anonymousMessageSource.getId(), namedMessageSource);
+		UserPrivate userPrivate = UserPrivate.createInstance(firstName, lastName, nickname, namedMessageSource);
 		User user = new User(UUID.randomUUID(), initializationVector, mobileNumber, userPrivate,
 				namedMessageSource.getDestination());
+		user.setAnonymized(userAnonymized);
+		user.setAnonymousMessageSourceId(anonymousMessageSource.getId());
 		return User.getRepository().save(user);
 	}
 

--- a/dbinit/src/main/liquibase/updates/changelog-0016-yd-575.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0016-yd-575.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+- changeSet:
+    id: 1528746764942-1
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: app_version
+            type: varchar(255)
+        tableName: user_devices
+- changeSet:
+    id: 1528746764942-2
+    author: Bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: operating_system
+            type: integer
+        tableName: user_devices

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0015-yd-513.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0016-yd-575.yml


### PR DESCRIPTION
# Note
This PR is for global feedback only, not for detailed feedback (yet). The question is: do we want to go down this path and make it nice and good (and more complex) or do we accept that the system gets polluted with ``UserAnonymized`` entities that are cleaned up late?

The PR proves that it is possible, as everything works as before, but it also proves that there is quite an added complexity.

# Description
By creating the user anonymized and its related entities till the moment the user confirmed their mobile number, we can simplify the user cleanup mechanism.

User entities are created when the user themselves signs up or when a user invites a new one as buddy. In many such cases, the actual user sign up never happens, either because they initially entered a wrong phone number and don't get past the confirmation process or because the invited buddy does not respond.

For such cases, we need to run a clean-up job with rules like:
* User didn't confirm mobile number in 7 days
* User didn't accept invitation in 30 days

Such a clean-up currently can be done only partially: we can remove the user entity with what belongs to it (UserPrivate, UserDevice, etc.), but we cannot remove the UserAnonymized, the goals, etc. as we cannot correlate them to the user being removed. So for UserAnonymized and related entities, we need another clean-up process, based on inactivity (e.g. the user didn't do anything for the past 6 months). This inevitably is much slower-paced, as we don't want to force users to be active "frequently".

This could be simplified by deferring the creation of the UserAnonymized and related entities till the moment the user confirmed their mobile number. Then we know we have a serious user.