### PR TITLE
YD-576 Allow deleting goal with activities with comments

### DIFF
--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;
@@ -117,7 +117,7 @@ public class GoalController extends ControllerBase
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.canAccessPrivateData(userId)))
 		{
-			goalService.removeGoal(userId, goalId, Optional.ofNullable(messageStr));
+			goalService.deleteGoalAndInformBuddies(userId, goalId, Optional.ofNullable(messageStr));
 		}
 	}
 

--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
@@ -738,6 +738,23 @@ public class ActivityService
 		UUID targetUserAnonymizedId = repliedMessage.getRelatedUserAnonymizedId().get();
 		return sendMessagePair(sendingUser, targetUserAnonymizedId, repliedMessage.getIntervalActivity(),
 				Optional.of(repliedMessage), Optional.of(repliedMessage.getSenderCopyMessage()), message);
+	}
+
+	@Transactional
+	public void deleteAllDayActivityCommentMessages(Goal goal)
+	{
+		goal.getWeekActivities().forEach(wa -> messageService
+				.deleteMessagesForIntervalActivities(wa.getDayActivities().stream().collect(Collectors.toList())));
+
+		goal.getPreviousVersionOfThisGoal().ifPresent(this::deleteAllDayActivityCommentMessages);
+	}
+
+	@Transactional
+	public void deleteAllWeekActivityCommentMessages(Goal goal)
+	{
+		messageService.deleteMessagesForIntervalActivities(goal.getWeekActivities().stream().collect(Collectors.toList()));
+
+		goal.getPreviousVersionOfThisGoal().ifPresent(this::deleteAllWeekActivityCommentMessages);
 	}
 
 	@FunctionalInterface

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
@@ -7,11 +7,11 @@ package nu.yona.server.messaging.entities;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -37,14 +37,13 @@ public interface MessageRepository extends CrudRepository<Message, Long>
 	Page<Message> findByIntervalActivity(@Param("destinationId") UUID destinationId,
 			@Param("intervalActivity") IntervalActivity intervalActivityEntity, Pageable pageable);
 
+	@Query("select m from Message m where m.intervalActivity in :intervalActivities")
+	Set<Message> findByIntervalActivity(@Param("intervalActivities") Collection<IntervalActivity> intervalActivities);
+
 	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m.creationTime >= :earliestDateTime and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
 	Page<Message> findReceivedMessagesFromDestinationSinceDate(@Param("destinationId") UUID destinationId,
 			@Param("earliestDateTime") LocalDateTime earliestDateTime, Pageable pageable);
 
 	@Query("select m.id from Message m, MessageDestination d where d.id = :destinationId and m.isProcessed = false and m member of d.messages order by m.id asc")
 	List<Long> findUnprocessedMessagesFromDestination(@Param("destinationId") UUID destinationId);
-
-	@Modifying
-	@Query("delete from Message m where m.intervalActivity in :intervalActivities")
-	void deleteMessagesForIntervalActivities(@Param("intervalActivities") Collection<IntervalActivity> intervalActivities);
 }

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -29,6 +29,7 @@ import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.exceptions.InvalidMessageActionException;
 import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.messaging.entities.MessageDestination;
+import nu.yona.server.messaging.entities.MessageRepository;
 import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.messaging.entities.MessageSourceRepository;
 import nu.yona.server.subscriptions.entities.User;
@@ -59,6 +60,9 @@ public class MessageService
 
 	@Autowired
 	private MessageSourceRepository messageSourceRepository;
+
+	@Autowired(required = false)
+	private MessageRepository messageRepository;
 
 	@Transactional
 	public Page<MessageDto> getReceivedMessages(UserDto user, boolean onlyUnreadMessages, Pageable pageable)
@@ -340,6 +344,6 @@ public class MessageService
 		{
 			return;
 		}
-		Message.getRepository().deleteMessagesForIntervalActivities(intervalActivities);
+		deleteMessages(messageRepository.findByIntervalActivity(intervalActivities));
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -32,7 +31,6 @@ import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
 
-import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.crypto.CryptoUtil;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.device.service.DeviceService;
@@ -47,9 +45,9 @@ import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.service.ActivityCategoryDto;
 import nu.yona.server.goals.service.ActivityCategoryService;
 import nu.yona.server.goals.service.GoalDto;
+import nu.yona.server.goals.service.GoalService;
 import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.messaging.entities.MessageSourceRepository;
-import nu.yona.server.messaging.service.MessageService;
 import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.sms.SmsService;
 import nu.yona.server.sms.SmsTemplate;
@@ -122,7 +120,7 @@ public class UserService
 	private ActivityCategoryService activityCategoryService;
 
 	@Autowired(required = false)
-	private MessageService messageService;
+	private GoalService goalService;
 
 	@Autowired(required = false)
 	private WhiteListedNumberService whiteListedNumberService;
@@ -618,11 +616,9 @@ public class UserService
 
 		UUID userAnonymizedId = userEntity.getUserAnonymizedId();
 		UserAnonymized userAnonymizedEntity = userAnonymizedService.getUserAnonymizedEntity(userAnonymizedId);
+		deleteGoals(userAnonymizedEntity);
 		User updatedUserEntity = deleteMessageSources(userEntity, userAnonymizedEntity);
 
-		Set<Goal> allGoalsIncludingHistoryItems = getAllGoalsIncludingHistoryItems(updatedUserEntity);
-		deleteActivitiesWithTheirComments(userAnonymizedEntity, allGoalsIncludingHistoryItems);
-		deleteGoals(userAnonymizedEntity, allGoalsIncludingHistoryItems);
 		deleteDevices(userEntity);
 
 		userAnonymizedService.deleteUserAnonymized(userAnonymizedId);
@@ -650,17 +646,10 @@ public class UserService
 				.forEach(d -> deviceService.deleteDeviceWithoutBuddyNotification(userEntity, d));
 	}
 
-	private void deleteGoals(UserAnonymized userAnonymizedEntity, Set<Goal> allGoalsIncludingHistoryItems)
+	private void deleteGoals(UserAnonymized userAnonymizedEntity)
 	{
-		allGoalsIncludingHistoryItems.forEach(Goal::removeAllWeekActivities);
-		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
-	}
-
-	private void deleteActivitiesWithTheirComments(UserAnonymized userAnonymizedEntity, Set<Goal> allGoalsIncludingHistoryItems)
-	{
-		deleteAllWeekActivityCommentMessages(allGoalsIncludingHistoryItems);
-		deleteAllDayActivitiesWithTheirCommentMessages(allGoalsIncludingHistoryItems);
-		userAnonymizedService.updateUserAnonymized(userAnonymizedEntity);
+		Set<Goal> goals = new HashSet<>(userAnonymizedEntity.getGoals()); // Copy to prevent ConcurrentModificationException
+		goals.forEach(g -> goalService.deleteGoal(userAnonymizedEntity, g));
 	}
 
 	private User deleteMessageSources(User userEntity, UserAnonymized userAnonymizedEntity)
@@ -676,40 +665,6 @@ public class UserService
 		messageSourceRepository.delete(namedMessageSource);
 		messageSourceRepository.flush();
 		return updatedUserEntity;
-	}
-
-	private void deleteAllDayActivitiesWithTheirCommentMessages(Set<Goal> allGoalsIncludingHistoryItems)
-	{
-		allGoalsIncludingHistoryItems.forEach(g -> g.getWeekActivities().forEach(wa -> {
-			// Other users might have commented on the activities being deleted. Delete these messages.
-			messageService.deleteMessagesForIntervalActivities(wa.getDayActivities().stream().collect(Collectors.toList()));
-			wa.removeAllDayActivities();
-		}));
-	}
-
-	private void deleteAllWeekActivityCommentMessages(Set<Goal> allGoalsIncludingHistoryItems)
-	{
-		// Other users might have commented on the activities being deleted. Delete these messages.
-		List<IntervalActivity> allWeekActivities = allGoalsIncludingHistoryItems.stream()
-				.flatMap(g -> g.getWeekActivities().stream()).collect(Collectors.toList());
-		messageService.deleteMessagesForIntervalActivities(allWeekActivities);
-	}
-
-	private Set<Goal> getAllGoalsIncludingHistoryItems(User userEntity)
-	{
-		Set<Goal> allGoals = new HashSet<>(userEntity.getGoals());
-		Set<Goal> historyItems = new HashSet<>();
-		for (Goal goal : allGoals)
-		{
-			Optional<Goal> historyItem = goal.getPreviousVersionOfThisGoal();
-			while (historyItem.isPresent())
-			{
-				historyItems.add(historyItem.get());
-				historyItem = historyItem.get().getPreviousVersionOfThisGoal();
-			}
-		}
-		allGoals.addAll(historyItems);
-		return allGoals;
 	}
 
 	@Transactional


### PR DESCRIPTION
This used to fail with a referential integrity error. This didn't fail when deleting a user. The fix is now to move the more elaborate message clean up of user deletion to the goal service, as part of the goal deletion.