### PR TITLE
YD-580 Message action handling now transactional

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityCommentMessageDto.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
 
@@ -93,7 +93,7 @@ public class ActivityCommentMessageDto extends BuddyMessageLinkedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageDto.Manager
+	static class Manager extends BuddyMessageDto.Manager
 	{
 
 		@Autowired

--- a/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
@@ -139,7 +139,7 @@ public class GoalConflictMessageDto extends MessageDto
 	}
 
 	@Component
-	private static class Manager extends MessageDto.Manager
+	static class Manager extends MessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalChangeMessageDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.service;
@@ -73,7 +73,7 @@ public class GoalChangeMessageDto extends BuddyMessageLinkedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageDto.Manager
+	static class Manager extends BuddyMessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
@@ -99,7 +99,7 @@ public class DisclosureRequestMessageDto extends BuddyMessageLinkedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageDto.Manager
+	static class Manager extends BuddyMessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureResponseMessageDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
@@ -80,7 +80,7 @@ public class DisclosureResponseMessageDto extends BuddyMessageLinkedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageDto.Manager
+	static class Manager extends BuddyMessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -165,6 +166,7 @@ public abstract class MessageDto extends PolymorphicDto
 		private SenderInfo.Factory senderInfoFactory;
 
 		@Override
+		@Transactional
 		public MessageActionDto handleAction(UserDto actingUser, Message messageEntity, String action,
 				MessageActionDto requestPayload)
 		{

--- a/core/src/main/java/nu/yona/server/messaging/service/SystemMessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/SystemMessageDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
@@ -53,7 +53,7 @@ public class SystemMessageDto extends MessageDto
 	}
 
 	@Component
-	private static class Manager extends MessageDto.Manager
+	static class Manager extends MessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyConnectRequestMessageDto.java
@@ -91,7 +91,7 @@ public class BuddyConnectRequestMessageDto extends BuddyMessageEmbeddedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageEmbeddedUserDto.Manager
+	static class Manager extends BuddyMessageEmbeddedUserDto.Manager
 	{
 		private static final Logger logger = LoggerFactory.getLogger(Manager.class);
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyDisconnectMessageDto.java
@@ -84,7 +84,7 @@ public class BuddyDisconnectMessageDto extends BuddyMessageEmbeddedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageEmbeddedUserDto.Manager
+	static class Manager extends BuddyMessageEmbeddedUserDto.Manager
 	{
 		private static final Logger logger = LoggerFactory.getLogger(Manager.class);
 		@Autowired

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyInfoChangeMessageDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyInfoChangeMessageDto.java
@@ -73,7 +73,7 @@ public class BuddyInfoChangeMessageDto extends BuddyMessageLinkedUserDto
 	}
 
 	@Component
-	private static class Manager extends BuddyMessageDto.Manager
+	static class Manager extends BuddyMessageDto.Manager
 	{
 		@Autowired
 		private TheDtoManager theDtoFactory;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -160,7 +160,7 @@ public class BuddyService
 
 		logger.info(
 				"User with mobile number '{}' and ID '{}' sent buddy connect message to {} user with mobile number '{}' and ID '{}' as buddy",
-				requestingUser.getMobileNumber(), requestingUser.getId(), (buddyUserExists) ? "new" : "existing",
+				requestingUser.getMobileNumber(), requestingUser.getId(), (buddyUserExists) ? "existing" : "new",
 				buddy.getUser().getMobileNumber(), buddy.getUser().getId());
 
 		return savedBuddy;


### PR DESCRIPTION
Till now, DtoManager.handleAction was not marked with @transactional. Due to that, the services calls from implementations (also in subtypes) were individually starting a transaction, so the handling wasn't atomic. This is fixed now.

Along with this corrected the logging of buddy connect requests. The values "new" and "existing" were interchanged, so existing users where logged as new and vice versa.