### PR TITLE
Convert hard coded IPs in Jenkinsfile to DNS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
 		stage('Run integration tests') {
 			agent { label 'yona' }
 			steps {
-				sh './gradlew -Pyona_adminservice_url=http://185.3.209.132:31000 -Pyona_analysisservice_url=http://185.3.209.132:31001 -Pyona_appservice_url=http://185.3.209.132:31002 -Pyona_batchservice_url=http://185.3.209.132:31003 intTest'
+				sh './gradlew -Pyona_adminservice_url=http://build.dev.yona.nu:31000 -Pyona_analysisservice_url=http://build.dev.yona.nu:31001 -Pyona_appservice_url=http://build.dev.yona.nu:31002 -Pyona_batchservice_url=http://build.dev.yona.nu:31003 intTest'
 			}
 			post {
 				always {


### PR DESCRIPTION
Integration tests are hard coded IPs to the old build server.
Switched to DNS.   (DNS entry still points to old server as of this message for external queries, but is a localhost alias for the new build server)
