### PR TITLE
YD-562 Use pessimistic update lock

### DIFF
--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -6,7 +6,6 @@ package nu.yona.server;
 
 import java.io.IOException;
 import java.util.Properties;
-import java.util.UUID;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +46,6 @@ import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.rest.JsonRootRelProvider;
 import nu.yona.server.rest.RestClientErrorHandler;
-import nu.yona.server.util.LockPool;
 
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 @EnableSpringDataWebSupport
@@ -193,11 +191,5 @@ public class CoreConfiguration extends CachingConfigurerSupport
 	public CacheManager localCache()
 	{
 		return new ConcurrentMapCacheManager();
-	}
-
-	@Bean
-	public LockPool<UUID> userSynchronizer()
-	{
-		return new LockPool<>();
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -110,12 +110,12 @@ public class UserPrivate extends PrivateUserProperties
 
 	public void addBuddy(Buddy buddy)
 	{
-		buddies.add(buddy);
+		buddies.add(Objects.requireNonNull(buddy));
 	}
 
 	public void removeBuddy(Buddy buddy)
 	{
-		buddies.remove(buddy);
+		buddies.remove(Objects.requireNonNull(buddy));
 	}
 
 	public UUID getAnonymousMessageSourceId()


### PR DESCRIPTION
* Reverted the locking strategy back to SQL pessimistic locking (SELECT ... FOR UPDATE)
* Implemented a multithreaded integration test to test concurrent message processing. The test never failed, but logging showed that the next thread started working before the previous thread committed, thus causing concurrency issues. The new doPreparationsAndCheckCanAccessPrivateData approach allong with the pessimistic locking we used earlier resolves these issues.

Along with this added a defensive check to UserPrivate.