### PR TITLE
YD-549 Support Firebase instance ID

### DIFF
--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
@@ -159,7 +159,7 @@ public class ActivityUpdateServiceTest
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown", Optional.empty());
 		deviceAnonId = deviceAnonEntity.getId();
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -211,7 +211,7 @@ public class AnalysisEngineServiceTest
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.IOS, "Unknown", Optional.empty());
 		deviceAnonId = deviceAnonEntity.getId();
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineService_determineRelevantGoalsTest.java
@@ -107,7 +107,7 @@ public class AnalysisEngineService_determineRelevantGoalsTest
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(
 				Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal, shoppingGoalHistoryItem));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown", Optional.empty());
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		userAnonDto = UserAnonymizedDto.createInstance(userAnonEntity);

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
@@ -141,7 +141,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		when:
 		def newDeviceName = "My iPhone"
 		def newDeviceOs = "ANDROID"
-		def response = appService.registerNewDevice(registerUrl, "Wrong password", newDeviceName, newDeviceOs, "0.1", null)
+		def response = appService.registerNewDevice(registerUrl, "Wrong password", newDeviceName, newDeviceOs, "0.1")
 
 		then:
 		assertResponseStatus(response, 400)
@@ -160,7 +160,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		when:
 		def newDeviceName = "My iPhone"
 		def newDeviceOs = "ANDROID"
-		def response = appService.registerNewDevice(registerUrl, "Wrong password", newDeviceName, newDeviceOs, "0.1", null)
+		def response = appService.registerNewDevice(registerUrl, "Wrong password", newDeviceName, newDeviceOs, "0.1")
 
 		then:
 		assertResponseStatus(response, 400)

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
@@ -13,7 +13,6 @@ import groovy.json.*
 import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.Device
 import nu.yona.server.test.User
-import spock.lang.IgnoreRest
 
 class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 {
@@ -333,7 +332,6 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(bob)
 	}
 
-	@IgnoreRest
 	def 'Richard updates his device firebase instance id; device is updated but not disclosed to Bob'()
 	{
 		given:

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -91,6 +91,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		assert johnAfterNumberConfirmation.devices[0].operatingSystem == operatingSystem
 		assert johnAfterNumberConfirmation.devices[0].sslRootCertCn == "smoothwall003.yona"
 		assert johnAfterNumberConfirmation.devices[0].sslRootCertUrl
+		assert johnAfterNumberConfirmation.devices[0].firebaseInstanceId == null
 		assertEquals(johnAfterNumberConfirmation.devices[0].appLastOpenedDate, YonaServer.now.toLocalDate())
 
 		def responseSslRootCert = appService.yonaServer.restClient.get(path: johnAfterNumberConfirmation.devices[0].sslRootCertUrl)

--- a/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
@@ -172,7 +172,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def registerUrl = getResponseAfter.responseData._links."yona:registerDevice".href
 
-		def registerResponse = appService.registerNewDevice(registerUrl, newDeviceRequestPassword, newDeviceName, newDeviceOs, Device.SUPPORTED_APP_VERSION)
+		def registerResponse = appService.registerNewDevice(registerUrl, newDeviceRequestPassword, newDeviceName, newDeviceOs, Device.SUPPORTED_APP_VERSION, null)
 		assertResponseStatusCreated(registerResponse)
 
 		def devices = registerResponse.responseData._embedded."yona:devices"._embedded."yona:devices"

--- a/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
@@ -172,7 +172,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def registerUrl = getResponseAfter.responseData._links."yona:registerDevice".href
 
-		def registerResponse = appService.registerNewDevice(registerUrl, newDeviceRequestPassword, newDeviceName, newDeviceOs, Device.SUPPORTED_APP_VERSION, null)
+		def registerResponse = appService.registerNewDevice(registerUrl, newDeviceRequestPassword, newDeviceName, newDeviceOs, Device.SUPPORTED_APP_VERSION)
 		assertResponseStatusCreated(registerResponse)
 
 		def devices = registerResponse.responseData._embedded."yona:devices"._embedded."yona:devices"

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -463,6 +463,17 @@ public class DeviceController extends ControllerBase
 			return isRequestingDevice;
 		}
 
+		@JsonProperty("firebaseInstanceId")
+		@JsonInclude(Include.NON_EMPTY)
+		public Optional<String> getFirebaseInstanceId()
+		{
+			if (getContent() instanceof UserDeviceDto)
+			{
+				return ((UserDeviceDto) getContent()).getFirebaseInstanceId();
+			}
+			return Optional.empty();
+		}
+
 		@JsonProperty("sslRootCertCN")
 		@JsonInclude(Include.NON_EMPTY)
 		public Optional<String> getSslRootCertCn()
@@ -472,7 +483,6 @@ public class DeviceController extends ControllerBase
 				return Optional.of(sslRootCertificateCn);
 			}
 			return Optional.empty();
-
 		}
 
 		@JsonInclude(Include.NON_EMPTY)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -475,6 +475,7 @@ public class UserController extends ControllerBase
 				@JsonProperty(value = "deviceName", required = false) String deviceName,
 				@JsonProperty(value = "deviceOperatingSystem", required = false) String deviceOperatingSystem,
 				@JsonProperty(value = "deviceAppVersion", required = false) String deviceAppVersion,
+				@JsonProperty(value = "deviceFirebaseInstanceId", required = false) String deviceFirebaseInstanceId,
 				@JsonProperty("_links") Object ignored1, @JsonProperty("yonaPassword") Object ignored2)
 		{
 			this.firstName = firstName;
@@ -482,7 +483,8 @@ public class UserController extends ControllerBase
 			this.mobileNumber = mobileNumber;
 			this.nickname = nickname;
 			this.deviceRegistration = deviceName == null ? Optional.empty()
-					: Optional.of(new DeviceRegistrationRequestDto(deviceName, deviceOperatingSystem, deviceAppVersion));
+					: Optional.of(new DeviceRegistrationRequestDto(deviceName, deviceOperatingSystem, deviceAppVersion,
+							deviceFirebaseInstanceId));
 		}
 
 		Optional<UserDeviceDto> getDevice()

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -475,7 +475,6 @@ public class UserController extends ControllerBase
 				@JsonProperty(value = "deviceName", required = false) String deviceName,
 				@JsonProperty(value = "deviceOperatingSystem", required = false) String deviceOperatingSystem,
 				@JsonProperty(value = "deviceAppVersion", required = false) String deviceAppVersion,
-				@JsonProperty(value = "deviceFirebaseInstanceId", required = false) String deviceFirebaseInstanceId,
 				@JsonProperty("_links") Object ignored1, @JsonProperty("yonaPassword") Object ignored2)
 		{
 			this.firstName = firstName;
@@ -484,7 +483,7 @@ public class UserController extends ControllerBase
 			this.nickname = nickname;
 			this.deviceRegistration = deviceName == null ? Optional.empty()
 					: Optional.of(new DeviceRegistrationRequestDto(deviceName, deviceOperatingSystem, deviceAppVersion,
-							deviceFirebaseInstanceId));
+							Optional.empty()));
 		}
 
 		Optional<UserDeviceDto> getDevice()

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1907,6 +1907,9 @@ definitions:
         type: string
         description: The version of the Yona app running on this device, in semver-compatible format
         example: 1.0.0
+      firebaseInstanceId:
+        type: string
+        description: The Instance ID provided by Firebase to the app
     required:
       - name
       - operatingSystem
@@ -1918,6 +1921,9 @@ definitions:
         type: string
         description: Name of the device running the Yona app. The name must be at most 20 characters and should not contain a colon
         example: My S8
+      firebaseInstanceId:
+        type: string
+        description: The Instance ID provided by Firebase to the app
     required:
       - name
   DeviceBase:
@@ -2048,6 +2054,9 @@ definitions:
             type: string
             description: The version of the Yona app running on this device, in semver-compatible format
             example: 1.0.0
+          deviceFirebaseInstanceId:
+            type: string
+            description: The Instance ID provided by Firebase to the app
   UserWithPrivateData:
     allOf:
       - $ref: '#/definitions/BaseUser'

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1965,6 +1965,9 @@ definitions:
             example: "smoothwall003.yona"
           vpnProfile:
             $ref: '#/definitions/VPNProfile'
+          firebaseInstanceId:
+            type: string
+            description: The Instance ID provided by Firebase to the app, if known to the server.
           _links:
             allOf:
               - $ref: '#/definitions/Curies'
@@ -2054,9 +2057,6 @@ definitions:
             type: string
             description: The version of the Yona app running on this device, in semver-compatible format
             example: 1.0.0
-          deviceFirebaseInstanceId:
-            type: string
-            description: The Instance ID provided by Firebase to the app
   UserWithPrivateData:
     allOf:
       - $ref: '#/definitions/BaseUser'

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
@@ -69,7 +69,7 @@ public class DeviceAnonymized extends EntityWithUuid
 		this.deviceIndex = deviceIndex;
 		this.operatingSystem = operatingSystem;
 		this.appVersion = Objects.requireNonNull(appVersion);
-		this.firebaseInstanceId = Objects.requireNonNull(firebaseInstanceId).orElse(null);
+		this.firebaseInstanceId = firebaseInstanceId.orElse(null);
 	}
 
 	public static DeviceAnonymized createInstance(int deviceIndex, OperatingSystem operatingSystem, String appVersion,

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
@@ -159,8 +159,8 @@ public class DeviceAnonymized extends EntityWithUuid
 		return Optional.ofNullable(firebaseInstanceId);
 	}
 
-	public void setFirebaseInstanceId(Optional<String> firebaseInstanceId)
+	public void setFirebaseInstanceId(String firebaseInstanceId)
 	{
-		this.firebaseInstanceId = firebaseInstanceId.orElse(null);
+		this.firebaseInstanceId = firebaseInstanceId;
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
@@ -46,6 +46,8 @@ public class DeviceAnonymized extends EntityWithUuid
 
 	private String appVersion;
 
+	private String firebaseInstanceId;
+
 	@OneToMany(mappedBy = "deviceAnonymized", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	private Set<VpnStatusChangeEvent> vpnStatusChangeEvents;
 
@@ -60,17 +62,20 @@ public class DeviceAnonymized extends EntityWithUuid
 		super(null);
 	}
 
-	private DeviceAnonymized(UUID id, int deviceIndex, OperatingSystem operatingSystem, String appVersion)
+	private DeviceAnonymized(UUID id, int deviceIndex, OperatingSystem operatingSystem, String appVersion,
+			Optional<String> firebaseInstanceId)
 	{
 		super(id);
 		this.deviceIndex = deviceIndex;
 		this.operatingSystem = operatingSystem;
 		this.appVersion = Objects.requireNonNull(appVersion);
+		this.firebaseInstanceId = Objects.requireNonNull(firebaseInstanceId).orElse(null);
 	}
 
-	public static DeviceAnonymized createInstance(int deviceIndex, OperatingSystem operatingSystem, String appVersion)
+	public static DeviceAnonymized createInstance(int deviceIndex, OperatingSystem operatingSystem, String appVersion,
+			Optional<String> firebaseInstanceId)
 	{
-		return new DeviceAnonymized(UUID.randomUUID(), deviceIndex, operatingSystem, appVersion);
+		return new DeviceAnonymized(UUID.randomUUID(), deviceIndex, operatingSystem, appVersion, firebaseInstanceId);
 	}
 
 	public static DeviceAnonymizedRepository getRepository()
@@ -147,5 +152,15 @@ public class DeviceAnonymized extends EntityWithUuid
 	public Optional<VpnStatusChangeEvent> getLastVpnStatusChangeEvent()
 	{
 		return Optional.ofNullable(lastVpnStatusChangeEvent);
+	}
+
+	public Optional<String> getFirebaseInstanceId()
+	{
+		return Optional.ofNullable(firebaseInstanceId);
+	}
+
+	public void setFirebaseInstanceId(Optional<String> firebaseInstanceId)
+	{
+		this.firebaseInstanceId = firebaseInstanceId.orElse(null);
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceRegistrationRequestDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceRegistrationRequestDto.java
@@ -1,11 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
+
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,13 +14,16 @@ public class DeviceRegistrationRequestDto
 	final String name;
 	final String operatingSystemStr;
 	final String appVersion;
+	final Optional<String> firebaseInstanceId;
 
 	@JsonCreator
 	public DeviceRegistrationRequestDto(@JsonProperty("name") String name,
-			@JsonProperty("operatingSystem") String operatingSystemStr, @JsonProperty("appVersion") String appVersion)
+			@JsonProperty("operatingSystem") String operatingSystemStr, @JsonProperty("appVersion") String appVersion,
+			@JsonProperty("firebaseInstanceId") String firebaseInstanceId)
 	{
 		this.name = name;
 		this.operatingSystemStr = operatingSystemStr;
 		this.appVersion = appVersion;
+		this.firebaseInstanceId = Optional.ofNullable(firebaseInstanceId);
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceRegistrationRequestDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceRegistrationRequestDto.java
@@ -19,11 +19,11 @@ public class DeviceRegistrationRequestDto
 	@JsonCreator
 	public DeviceRegistrationRequestDto(@JsonProperty("name") String name,
 			@JsonProperty("operatingSystem") String operatingSystemStr, @JsonProperty("appVersion") String appVersion,
-			@JsonProperty("firebaseInstanceId") String firebaseInstanceId)
+			@JsonProperty("firebaseInstanceId") Optional<String> firebaseInstanceId)
 	{
 		this.name = name;
 		this.operatingSystemStr = operatingSystemStr;
 		this.appVersion = appVersion;
-		this.firebaseInstanceId = Optional.ofNullable(firebaseInstanceId);
+		this.firebaseInstanceId = firebaseInstanceId;
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -104,7 +104,7 @@ public class DeviceService
 		assertAcceptableDeviceName(userEntity, deviceDto.getName());
 		assertValidAppVersion(deviceDto.getOperatingSystem(), deviceDto.getAppVersion());
 		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(findFirstFreeDeviceIndex(userEntity),
-				deviceDto.getOperatingSystem(), deviceDto.getAppVersion());
+				deviceDto.getOperatingSystem(), deviceDto.getAppVersion(), deviceDto.getFirebaseInstanceId());
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		UserDevice deviceEntity = userDeviceRepository
 				.save(UserDevice.createInstance(deviceDto.getName(), deviceAnonymized.getId(), userService.generatePassword()));
@@ -192,6 +192,9 @@ public class DeviceService
 			assertAcceptableDeviceName(userEntity, changeRequest.name);
 			deviceEntity.setName(changeRequest.name);
 			userDeviceRepository.save(deviceEntity);
+			DeviceAnonymized deviceAnonymized = deviceEntity.getDeviceAnonymized();
+			deviceAnonymized.setFirebaseInstanceId(changeRequest.firebaseInstanceId);
+			deviceAnonymizedRepository.save(deviceAnonymized);
 			sendDeviceChangeMessageToBuddies(DeviceChange.RENAME, userEntity, Optional.of(oldName),
 					Optional.of(changeRequest.name), deviceEntity.getDeviceAnonymized().getId());
 		});
@@ -201,7 +204,7 @@ public class DeviceService
 	public UserDeviceDto createDefaultUserDeviceDto()
 	{
 		return new UserDeviceDto(translator.getLocalizedMessage("default.device.name"), OperatingSystem.UNKNOWN,
-				ANDROID_MIN_APP_VERSION);
+				ANDROID_MIN_APP_VERSION, Optional.empty());
 	}
 
 	private int findFirstFreeDeviceIndex(User userEntity)

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -197,9 +197,9 @@ public class DeviceService
 
 			DeviceAnonymized deviceAnonymized = deviceEntity.getDeviceAnonymized();
 			Optional<String> oldFirebaseInstanceId = deviceAnonymized.getFirebaseInstanceId();
-			if (!oldFirebaseInstanceId.equals(changeRequest.firebaseInstanceId))
+			if (changeRequest.firebaseInstanceId.isPresent() && !oldFirebaseInstanceId.equals(changeRequest.firebaseInstanceId))
 			{
-				deviceAnonymized.setFirebaseInstanceId(changeRequest.firebaseInstanceId);
+				deviceAnonymized.setFirebaseInstanceId(changeRequest.firebaseInstanceId.get());
 				deviceAnonymizedRepository.save(deviceAnonymized);
 			}
 		});

--- a/core/src/main/java/nu/yona/server/device/service/DeviceUpdateRequestDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceUpdateRequestDto.java
@@ -15,9 +15,10 @@ public class DeviceUpdateRequestDto
 	final Optional<String> firebaseInstanceId;
 
 	@JsonCreator
-	public DeviceUpdateRequestDto(@JsonProperty("name") String name, @JsonProperty("name") String firebaseInstanceId)
+	public DeviceUpdateRequestDto(@JsonProperty("name") String name,
+			@JsonProperty("firebaseInstanceId") Optional<String> firebaseInstanceId)
 	{
 		this.name = name;
-		this.firebaseInstanceId = Optional.ofNullable(firebaseInstanceId);
+		this.firebaseInstanceId = firebaseInstanceId;
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceUpdateRequestDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceUpdateRequestDto.java
@@ -1,11 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
+
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,10 +12,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class DeviceUpdateRequestDto
 {
 	final String name;
+	final Optional<String> firebaseInstanceId;
 
 	@JsonCreator
-	public DeviceUpdateRequestDto(@JsonProperty("name") String name)
+	public DeviceUpdateRequestDto(@JsonProperty("name") String name, @JsonProperty("name") String firebaseInstanceId)
 	{
 		this.name = name;
+		this.firebaseInstanceId = Optional.ofNullable(firebaseInstanceId);
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/UserDeviceDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/UserDeviceDto.java
@@ -34,6 +34,11 @@ public class UserDeviceDto extends DeviceBaseDto
 	private final UUID deviceAnonymizedId;
 	private final VPNProfileDto vpnProfile;
 
+	public UserDeviceDto(String name, OperatingSystem operatingSystem, String appVersion)
+	{
+		this(name, operatingSystem, appVersion, Optional.empty());
+	}
+
 	public UserDeviceDto(String name, OperatingSystem operatingSystem, String appVersion, Optional<String> firebaseInstanceId)
 	{
 		this(null, name, operatingSystem, appVersion, firebaseInstanceId, true, LocalDateTime.now(), LocalDate.now(), null, null);

--- a/core/src/test/java/nu/yona/server/analysis/entities/ActivityTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/ActivityTest.java
@@ -35,7 +35,7 @@ public class ActivityTest
 	@Before
 	public void setUp()
 	{
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown", Optional.empty());
 	}
 
 	@Test

--- a/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
 
@@ -59,7 +59,7 @@ public abstract class IntervalActivityTestBase
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(Arrays.asList(budgetGoal));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown", Optional.empty());
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 	}

--- a/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
@@ -139,7 +139,7 @@ public class ActivityServiceTest
 		MessageDestination anonMessageDestinationEntity = MessageDestination
 				.createInstance(PublicKeyUtil.generateKeyPair().getPublic());
 		Set<Goal> goals = new HashSet<>(Arrays.asList(gamblingGoal, gamingGoal, socialGoal, shoppingGoal));
-		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown");
+		deviceAnonEntity = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "Unknown", Optional.empty());
 		userAnonEntity = UserAnonymized.createInstance(anonMessageDestinationEntity, goals);
 		userAnonEntity.addDeviceAnonymized(deviceAnonEntity);
 		UserAnonymizedDto userAnon = UserAnonymizedDto.createInstance(userAnonEntity);

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -407,7 +407,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 		assertThat(richard.getDevices().size(), equalTo(1));
 
 		String newName = "New name";
-		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(newName);
+		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(newName, Optional.empty());
 		service.updateDevice(richard.getId(), device.getId(), changeRequest);
 		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
 
@@ -440,7 +440,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 
 		String newName = "ORIGINAL".toLowerCase();
 		assertThat(oldName, not(sameInstance(newName)));
-		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(newName);
+		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(newName, Optional.empty());
 		service.updateDevice(richard.getId(), device.getId(), changeRequest);
 		assertThat(deviceAnonymizedRepository.count(), equalTo(1L));
 
@@ -469,7 +469,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 
 		assertThat(richard.getDevices().size(), equalTo(2));
 
-		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(firstDeviceName);
+		DeviceUpdateRequestDto changeRequest = new DeviceUpdateRequestDto(firstDeviceName, Optional.empty());
 		service.updateDevice(richard.getId(), device.getId(), changeRequest);
 	}
 
@@ -897,7 +897,8 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 
 	private UserDevice createDevice(int deviceIndex, String deviceName, OperatingSystem operatingSystem, String appVersion)
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(deviceIndex, operatingSystem, appVersion);
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(deviceIndex, operatingSystem, appVersion,
+				Optional.empty());
 		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		userDeviceRepository.save(device);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
@@ -303,7 +303,7 @@ public class BuddyDeviceChangeMessageDtoTest extends BaseSpringIntegrationTest
 
 	private UserDevice addDevice(User user, String deviceName, OperatingSystem operatingSystem)
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown");
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown", Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
 		user.addDevice(device);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -166,7 +167,8 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 		// Add device
 		String deviceName = "Testing";
 		OperatingSystem operatingSystem = OperatingSystem.ANDROID;
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, SUPPORTED_APP_VERSION);
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, SUPPORTED_APP_VERSION,
+				Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
 		richard.addDevice(device);

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
@@ -145,7 +145,8 @@ public class MoveVpnPasswordToDeviceTest extends BaseSpringIntegrationTest
 
 	private UserDevice createDevice()
 	{
-		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "1.0.0");
+		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "1.0.0",
+				Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		return UserDevice.createInstance("Testing", deviceAnonymized.getId(), "toBeOverwritten");
 	}

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -432,12 +432,13 @@ class AppService extends Service
 		yonaServer.getResource("$NEW_DEVICE_REQUESTS_PATH$mobileNumber", ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
 	}
 
-	def registerNewDevice(url, newDeviceRequestPassword, name, operatingSystem, appVersion)
+	def registerNewDevice(url, newDeviceRequestPassword, name, operatingSystem, appVersion, firebaseInstanceId)
 	{
 		def json = """{
 				"name": "$name",
 				"operatingSystem": "$operatingSystem",
-				"appVersion": "$appVersion"
+				"appVersion": "$appVersion",
+				"firebaseInstanceId": "$firebaseInstanceId"
 				}"""
 		yonaServer.postJson(url, json, ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
 	}
@@ -455,7 +456,7 @@ class AppService extends Service
 		def getResponse = getNewDeviceRequest(user.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusSuccess(getResponse)
 
-		def registerResponse = registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, name, operatingSystem, appVersion)
+		def registerResponse = registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, name, operatingSystem, appVersion, null)
 		assertResponseStatusSuccess(registerResponse)
 
 		new User(registerResponse.responseData)

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -432,13 +432,14 @@ class AppService extends Service
 		yonaServer.getResource("$NEW_DEVICE_REQUESTS_PATH$mobileNumber", ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
 	}
 
-	def registerNewDevice(url, newDeviceRequestPassword, name, operatingSystem, appVersion, firebaseInstanceId)
+	def registerNewDevice(url, newDeviceRequestPassword, name, operatingSystem, appVersion, firebaseInstanceId = null)
 	{
+		def firebaseInstanceIdString = firebaseInstanceId ? "\"$firebaseInstanceId\"" : "null"
 		def json = """{
 				"name": "$name",
 				"operatingSystem": "$operatingSystem",
 				"appVersion": "$appVersion",
-				"firebaseInstanceId": "$firebaseInstanceId"
+				"firebaseInstanceId": $firebaseInstanceIdString
 				}"""
 		yonaServer.postJson(url, json, ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
 	}
@@ -456,7 +457,7 @@ class AppService extends Service
 		def getResponse = getNewDeviceRequest(user.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusSuccess(getResponse)
 
-		def registerResponse = registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, name, operatingSystem, appVersion, null)
+		def registerResponse = registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, name, operatingSystem, appVersion)
 		assertResponseStatusSuccess(registerResponse)
 
 		new User(registerResponse.responseData)

--- a/core/src/testUtils/groovy/nu/yona/server/test/Device.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Device.groovy
@@ -29,6 +29,7 @@ class Device
 	final String appActivityUrl
 	final String postVpnStatusEventUrl
 	final String sslRootCertUrl
+	final String firebaseInstanceId
 	final String appleMobileConfig
 	Device(password, json)
 	{
@@ -48,6 +49,7 @@ class Device
 		this.postVpnStatusEventUrl = json._links?."yona:postVpnStatusEvent"?.href
 		this.sslRootCertUrl = json._links?."yona:sslRootCert"?.href
 		this.appleMobileConfig = json._links?."yona:appleMobileConfig"?.href
+		this.firebaseInstanceId = json.firebaseInstanceId
 	}
 
 	def postOpenAppEvent(AppService appService, operatingSystem = this.operatingSystem, appVersion = Device.SUPPORTED_APP_VERSION)

--- a/dbinit/src/main/liquibase/updates/changelog-0016-yd-549.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0016-yd-549.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+- changeSet:
+    id: 1530642397545-1
+    author: avdijk (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: firebase_instance_id
+            type: varchar(255)
+        tableName: devices_anonymized

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0015-yd-513.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0016-yd-549.yml


### PR DESCRIPTION
- Support to pass the Firebase instance ID when registering a new device
- Support to set or update the Firebase instance ID of an existing device
- Returning the Firebase instance ID with the own user devices