### PR TITLE
YD-582 Include correlation ID in error response

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -28,6 +28,7 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
+		errorResponse.data.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == "en-US"
 	}
 
@@ -47,6 +48,7 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "Het mobiele nummer '$wrongNumber' is ongeldig. Het moet beginnen met een +-teken, zonder spaties tussen de tekens"
+		errorResponse.data.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == "nl-NL"
 	}
 
@@ -66,6 +68,7 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatus(errorResponse, 400)
 		errorResponse.data.code == "error.user.mobile.number.invalid"
 		errorResponse.data.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
+		errorResponse.data.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == "en-US"
 	}
 }

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -3219,6 +3219,10 @@ definitions:
         type: string
         description: A localized error message
         example: The mobile number ''+31 6 12345678'' is invalid. It must start with a + sign, with no spaces between the digits
+      correlationId:
+        type: string
+        description: ID that correlates the server log messages to this error
+        example: 463ac35c9f6413ad48485a3953bb6124
   ConfirmationError:
     allOf:
       - $ref: '#/definitions/Error'

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -37,7 +37,6 @@ public class ErrorLoggingFilter implements Filter
 
 	public static class LoggingContext implements AutoCloseable
 	{
-
 		private static final String CORRELATION_ID = "yona.correlation.id";
 		private static final String TRACE_ID_HEADER = "x-b3-traceid";
 
@@ -56,6 +55,11 @@ public class ErrorLoggingFilter implements Filter
 		{
 			MDC.put(CORRELATION_ID, getCorrelationId(request));
 			return new LoggingContext();
+		}
+
+		public static String getCorrelationId()
+		{
+			return (String) MDC.get(CORRELATION_ID);
 		}
 
 		private static String getCorrelationId(HttpServletRequest request)

--- a/core/src/main/java/nu/yona/server/rest/ErrorResponseDto.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorResponseDto.java
@@ -1,43 +1,78 @@
 /*******************************************************************************
- * Copyright (c) 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
- * This DTO is used to communicate error messages or other type of messages to the client.
+ * This error response is used to return the error details to the client.
  */
 public class ErrorResponseDto
 {
-	/** Holds the actual message */
-	private String message;
+	/** The textual error message */
+	private final String message;
 
-	/** Holds the message code. */
-	private String code;
+	/** The error code. */
+	private final String code;
+
+	/** ID that correlates the server log messages to this error */
+	private final String correlationId;
 
 	/**
-	 * Default constructor
+	 * Creates a new error response based on the given message and code.
+	 * 
+	 * @param code The error code.
+	 * @param message The textual error message.
 	 */
-	public ErrorResponseDto()
+	protected ErrorResponseDto(String code, String message)
 	{
+		this(code, message, null);
 	}
 
 	/**
-	 * Creates a new DTO based on the given message.
+	 * Creates a new error response based on the given message, code and correlation ID.
 	 * 
-	 * @param type The type of message.
-	 * @param message The actual message to display.
+	 * @param code The error code.
+	 * @param message The textual error message.
+	 * @param correlationId The ID that correlates the server log messages to this error.
 	 */
-	public ErrorResponseDto(String code, String message)
+	@JsonCreator
+	public ErrorResponseDto(@JsonProperty("code") String code, @JsonProperty("message") String message,
+			@JsonProperty("correlationId") String correlationId)
 	{
 		this.code = code;
 		this.message = message;
+		this.correlationId = correlationId;
 	}
 
 	/**
-	 * This method gets the message code.
+	 * Creates a new error response based on the given message and code.
 	 * 
-	 * @return The message code.
+	 * @param code The error code.
+	 * @param message The textual error message.
+	 */
+	public static ErrorResponseDto createInstance(String code, String message)
+	{
+		return new ErrorResponseDto(code, message, ErrorLoggingFilter.LoggingContext.getCorrelationId());
+	}
+
+	/**
+	 * Creates a new error response based on the given message.
+	 * 
+	 * @param message The textual error message.
+	 */
+	public static ErrorResponseDto createInstance(String message)
+	{
+		return new ErrorResponseDto(null, message, ErrorLoggingFilter.LoggingContext.getCorrelationId());
+	}
+
+	/**
+	 * Returns the error code.
+	 * 
+	 * @return The error code.
 	 */
 	public String getCode()
 	{
@@ -45,19 +80,9 @@ public class ErrorResponseDto
 	}
 
 	/**
-	 * This method sets the message code.
+	 * Returns the textual error message.
 	 * 
-	 * @param code The message code.
-	 */
-	public void setCode(String code)
-	{
-		this.code = code;
-	}
-
-	/**
-	 * This method gets the actual message.
-	 * 
-	 * @return The actual message.
+	 * @return The textual error message.
 	 */
 	public String getMessage()
 	{
@@ -65,12 +90,12 @@ public class ErrorResponseDto
 	}
 
 	/**
-	 * This method sets the actual message.
+	 * Returns the ID that correlates the server log messages to this error.
 	 * 
-	 * @param message The actual message.
+	 * @return The ID that correlates the server log messages to this error.
 	 */
-	public void setMessage(String message)
+	public String getCorrelationId()
 	{
-		this.message = message;
+		return correlationId;
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/ErrorResponseDto.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorResponseDto.java
@@ -7,38 +7,19 @@ package nu.yona.server.rest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * This error response is used to return the error details to the client.
- */
 public class ErrorResponseDto
 {
-	/** The textual error message */
 	private final String message;
 
-	/** The error code. */
 	private final String code;
 
-	/** ID that correlates the server log messages to this error */
 	private final String correlationId;
 
-	/**
-	 * Creates a new error response based on the given message and code.
-	 * 
-	 * @param code The error code.
-	 * @param message The textual error message.
-	 */
 	protected ErrorResponseDto(String code, String message)
 	{
 		this(code, message, null);
 	}
 
-	/**
-	 * Creates a new error response based on the given message, code and correlation ID.
-	 * 
-	 * @param code The error code.
-	 * @param message The textual error message.
-	 * @param correlationId The ID that correlates the server log messages to this error.
-	 */
 	@JsonCreator
 	public ErrorResponseDto(@JsonProperty("code") String code, @JsonProperty("message") String message,
 			@JsonProperty("correlationId") String correlationId)
@@ -48,52 +29,26 @@ public class ErrorResponseDto
 		this.correlationId = correlationId;
 	}
 
-	/**
-	 * Creates a new error response based on the given message and code.
-	 * 
-	 * @param code The error code.
-	 * @param message The textual error message.
-	 */
 	public static ErrorResponseDto createInstance(String code, String message)
 	{
 		return new ErrorResponseDto(code, message, ErrorLoggingFilter.LoggingContext.getCorrelationId());
 	}
 
-	/**
-	 * Creates a new error response based on the given message.
-	 * 
-	 * @param message The textual error message.
-	 */
 	public static ErrorResponseDto createInstance(String message)
 	{
 		return new ErrorResponseDto(null, message, ErrorLoggingFilter.LoggingContext.getCorrelationId());
 	}
 
-	/**
-	 * Returns the error code.
-	 * 
-	 * @return The error code.
-	 */
 	public String getCode()
 	{
 		return code;
 	}
 
-	/**
-	 * Returns the textual error message.
-	 * 
-	 * @return The textual error message.
-	 */
 	public String getMessage()
 	{
 		return message;
 	}
 
-	/**
-	 * Returns the ID that correlates the server log messages to this error.
-	 * 
-	 * @return The ID that correlates the server log messages to this error.
-	 */
 	public String getCorrelationId()
 	{
 		return correlationId;

--- a/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
+++ b/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
@@ -64,7 +64,7 @@ public class GlobalExceptionMapping
 	{
 		logUnhandledException("completed with Yona exception", buildRequestInfo(request), exception);
 
-		ErrorResponseDto responseMessage = new ErrorResponseDto(exception.getMessageId(), exception.getMessage());
+		ErrorResponseDto responseMessage = ErrorResponseDto.createInstance(exception.getMessageId(), exception.getMessage());
 
 		return new ResponseEntity<>(responseMessage, exception.getStatusCode());
 	}
@@ -136,7 +136,7 @@ public class GlobalExceptionMapping
 	{
 		logUnhandledException(message, buildRequestInfo(request), exception);
 
-		return new ErrorResponseDto(null, exception.getMessage());
+		return ErrorResponseDto.createInstance(exception.getMessage());
 	}
 
 	private void logUnhandledException(String message, String requestInfo, Exception exception)


### PR DESCRIPTION
This enables the app to include that in error reports that the users send to support, which in turn enables us to find the related log messages.