### PR TITLE
YD-583 Fix Cinderella bug: test failures after midnight

### DIFF
--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
@@ -131,7 +131,7 @@ public class ActivityUpdateServiceTest
 	{
 		setUpRepositoryMocks();
 
-		LocalDateTime yesterday = TimeUtil.utcNow().minusDays(1);
+		LocalDateTime yesterday = TimeUtil.utcNow().minusDays(1).withHour(0).withMinute(1).withSecond(0);
 		gamblingGoal = BudgetGoal.createNoGoInstance(yesterday,
 				ActivityCategory.createInstance(UUID.randomUUID(), usString("gambling"), false,
 						new HashSet<>(Arrays.asList("poker", "lotto")), new HashSet<>(Arrays.asList("Poker App", "Lotto App")),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 	testCompile "com.spencerwi:hamcrest-jdk8-time:0.7.1"
 	testCompile "nl.jqno.equalsverifier:equalsverifier:2.4.3"
 	testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
+	testCompile "org.exparity:hamcrest-date:2.0.4"
 	
 	testUtilsCompile "org.codehaus.groovy:groovy-all:2.4.6"
 	testUtilsCompile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -4,16 +4,19 @@
  *******************************************************************************/
 package nu.yona.server.test.util;
 
+import static org.junit.Assume.assumeThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -120,5 +123,10 @@ public class JUnitUtil
 				.orElseThrow(() -> new IllegalStateException("Cannot find field '" + fieldName + "'"));
 		field.setAccessible(true);
 		return field;
+	}
+
+	public static void skipBefore(String description, ZonedDateTime now, int hour, int minute)
+	{
+		assumeThat(description, now, ZonedDateTimeMatchers.after(now.withHour(hour).withMinute(minute).withSecond(0)));
 	}
 }


### PR DESCRIPTION
Fixed some tests and disabled others in the window just after midnight. The window is specific per test and varies between 5 and 30 minutes.

Along with this removed an unused method from AnalysisEngineServiceTest.