### PR TITLE
Defining variable

### DIFF
--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -235,5 +235,5 @@ certs:
     A+pewjPUaERijjkgaT2qygKCkQQ03iaLEz6jD1DKvY9NipcY2f8WBK+STNz6qAyp
     MCuIv7V26zjwX1P91NOo0s/htoxxxxDiv86nUuYW8A==
 
-nodePorts:
+nodePorts: {}
   # Placeholder. Normally, we use the defaults configured in the services yamls


### PR DESCRIPTION
Defining nodeport with anything fixes the parsing error on subvalues, even if that anything is nothing, as long as it exists. Alternate fix would be to not reference nested variables, e.g. change the structure from .Values.nodePorts.admin to .Values.nodeports-admin, since .Values always exists. 