### PR TITLE
YD-586 Enable Micrometer with Prometheus endpoint

### DIFF
--- a/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
+++ b/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
@@ -7,11 +7,13 @@ package nu.yona.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.metrics.export.prometheus.EnablePrometheusMetrics;
 
 import nu.yona.server.properties.PropertyInitializer;
 
 @SpringBootApplication(scanBasePackages = { "nu.yona.server" })
 @EnableCaching
+@EnablePrometheusMetrics
 public class AdminServiceApplication
 {
 	public static void main(String[] args)

--- a/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
+++ b/adminservice/src/main/java/nu/yona/server/AdminServiceApplication.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. 
  *******************************************************************************/
 package nu.yona.server;
 

--- a/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
+++ b/analysisservice/src/main/java/nu/yona/server/AnalysisServiceApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
@@ -10,12 +10,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.metrics.export.prometheus.EnablePrometheusMetrics;
 
 import nu.yona.server.properties.PropertyInitializer;
 import nu.yona.server.util.LockPool;
 
 @SpringBootApplication
 @EnableCaching
+@EnablePrometheusMetrics
 public class AnalysisServiceApplication
 {
 	public static void main(String[] args)

--- a/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
+++ b/appservice/src/main/java/nu/yona/server/AppServiceApplication.java
@@ -30,6 +30,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.metrics.export.prometheus.EnablePrometheusMetrics;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -44,6 +45,7 @@ import nu.yona.server.properties.YonaProperties;
 
 @SpringBootApplication
 @EnableCaching
+@EnablePrometheusMetrics
 public class AppServiceApplication
 {
 	private static final Logger logger = LoggerFactory.getLogger(AppServiceApplication.class);

--- a/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
+++ b/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
@@ -9,6 +9,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.metrics.export.prometheus.EnablePrometheusMetrics;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
@@ -19,6 +20,7 @@ import nu.yona.server.properties.PropertyInitializer;
 @EnableBatchProcessing
 @EnableScheduling
 @SpringBootApplication(scanBasePackages = { "nu.yona.server" })
+@EnablePrometheusMetrics
 public class BatchServiceApplication
 {
 	public static void main(String[] args)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	compile "org.springframework.boot:spring-boot-starter-data-jpa"
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-actuator"
+	compile "org.springframework.metrics:spring-metrics:0.5.1.RELEASE"
+	compile "io.prometheus:simpleclient_common:0.5.0"
 	compile "org.springframework:spring-context-support"
 	compile "org.hibernate:hibernate-java8:5.1.2.Final"
 	compile "org.atteo:evo-inflector:1.2.1"


### PR DESCRIPTION
The cache metrics are not exposed yet. Once we've upgraded to Spring 5 (see YD-589), we can extend the current solution with cache metrics (YD-590).