### PR TITLE
YD-593 Throw specific exception when user anon not found

### DIFF
--- a/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/service/AnalysisEngineService.java
@@ -30,6 +30,7 @@ import nu.yona.server.device.entities.DeviceAnonymized.OperatingSystem;
 import nu.yona.server.device.service.DeviceAnonymizedDto;
 import nu.yona.server.device.service.DeviceService;
 import nu.yona.server.exceptions.AnalysisException;
+import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.goals.service.ActivityCategoryDto;
 import nu.yona.server.goals.service.ActivityCategoryService;
 import nu.yona.server.goals.service.GoalDto;
@@ -440,7 +441,7 @@ public class AnalysisEngineService
 			{
 				entity = userAnonymizedService.getUserAnonymizedEntity(id);
 			}
-			return entity.get();
+			return entity.orElseThrow(() -> InvalidDataException.userAnonymizedIdNotFound(id));
 		}
 
 		boolean isEntityFetched()


### PR DESCRIPTION
Currently, it just performs a get on the Optional, causing an error with no user anonymized ID. The current patch addresses that.

My suspicion of the issue is that a user deleted their account, causing the user anonymized to be deleted from the database but not from the cache. With improved error handling, we should be able to see that.