### PR TITLE
YD-594 Invalid UUID in URL results in 400

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -302,6 +302,22 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(john)
 	}
 
+	def 'Try get user with invalid ID'()
+	{
+		given:
+		User richard = addRichard()
+
+		when:
+		def response = appService.getUser(richard.url.replaceFirst(/requestingUserId=..../, "requestingUserId=QQQQ"), false)
+
+		then:
+		assertResponseStatus(response, 400)
+		assert response.responseData.code == "error.invalid.uuid"
+
+		cleanup:
+		appService.deleteUser(richard)
+	}
+
 	def 'Retrieve OVPN profile and SSL root certificate (YD-541, YD-544)'()
 	{
 		given:

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -75,6 +75,7 @@ import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.rest.Constants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.JsonRootRelProvider;
+import nu.yona.server.rest.RestUtil;
 import nu.yona.server.rest.StandardResourcesController;
 import nu.yona.server.subscriptions.rest.AppleMobileConfigSigner;
 import nu.yona.server.subscriptions.rest.UserController;
@@ -406,7 +407,7 @@ public class DeviceController extends ControllerBase
 
 	private static Optional<UUID> nullableStringToOptionalUuid(String uuidStr)
 	{
-		return Optional.ofNullable(uuidStr).map(UUID::fromString);
+		return Optional.ofNullable(uuidStr).map(RestUtil::parseUuid);
 	}
 
 	public static ControllerLinkBuilder getDeviceLinkBuilder(UUID userId, UUID deviceId, Optional<UUID> requestingDeviceId)

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -40,6 +40,7 @@ import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.goals.service.GoalService;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.JsonRootRelProvider;
+import nu.yona.server.rest.RestUtil;
 import nu.yona.server.subscriptions.service.UserService;
 
 @Controller
@@ -63,7 +64,8 @@ public class GoalController extends ControllerBase
 	public HttpEntity<Resources<GoalDto>> getAllGoals(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			return new ResponseEntity<>(createAllGoalsCollectionResource(userId, goalService.getGoalsOfUser(userId)),
 					HttpStatus.OK);
@@ -75,7 +77,8 @@ public class GoalController extends ControllerBase
 	public HttpEntity<GoalDto> getGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID goalId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			return createOkResponse(goalService.getGoalForUserId(userId, goalId), createResourceAssembler(userId));
 		}
@@ -87,7 +90,8 @@ public class GoalController extends ControllerBase
 			@PathVariable UUID userId, @RequestBody GoalDto goal,
 			@RequestParam(value = "message", required = false) String messageStr)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			setActivityCategoryId(goal);
 			return createResponse(goalService.addGoal(userId, goal, Optional.ofNullable(messageStr)), HttpStatus.CREATED,
@@ -101,7 +105,8 @@ public class GoalController extends ControllerBase
 			@PathVariable UUID userId, @PathVariable UUID goalId, @RequestBody GoalDto goal,
 			@RequestParam(value = "message", required = false) String messageStr)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			setActivityCategoryId(goal);
 			return createOkResponse(goalService.updateGoal(userId, goalId, goal, Optional.ofNullable(messageStr)),
@@ -115,7 +120,8 @@ public class GoalController extends ControllerBase
 	public void removeGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
 			@PathVariable UUID goalId, @RequestParam(value = "message", required = false) String messageStr)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			goalService.deleteGoalAndInformBuddies(userId, goalId, Optional.ofNullable(messageStr));
 		}
@@ -151,7 +157,7 @@ public class GoalController extends ControllerBase
 
 	private static UUID determineActivityCategoryId(String activityCategoryUrl)
 	{
-		return UUID.fromString(activityCategoryUrl.substring(activityCategoryUrl.lastIndexOf('/') + 1));
+		return RestUtil.parseUuid(activityCategoryUrl.substring(activityCategoryUrl.lastIndexOf('/') + 1));
 	}
 
 	public static ControllerLinkBuilder getGoalLinkBuilder(UUID userId, UUID goalId)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -73,6 +73,7 @@ import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.ErrorResponseDto;
 import nu.yona.server.rest.GlobalExceptionMapping;
 import nu.yona.server.rest.JsonRootRelProvider;
+import nu.yona.server.rest.RestUtil;
 import nu.yona.server.rest.StandardResourcesController;
 import nu.yona.server.subscriptions.rest.UserController.UserResource;
 import nu.yona.server.subscriptions.service.BuddyDto;
@@ -143,7 +144,7 @@ public class UserController extends ControllerBase
 		Optional<String> tempPassword = Optional.ofNullable(tempPasswordStr);
 		Optional<String> passwordToUse = getPasswordToUse(password, tempPassword);
 		return Optional.ofNullable(determineRequestingUserId(userId, requestingUserIdStr, includePrivateDataStr))
-				.map(UUID::fromString)
+				.map(RestUtil::parseUuid)
 				.map(ruid -> getUser(ruid, requestingDeviceIdStr, userId, tempPassword.isPresent(), passwordToUse))
 				.orElseGet(() -> getPublicUser(userId));
 	}
@@ -202,7 +203,7 @@ public class UserController extends ControllerBase
 			return Optional.empty();
 		}
 		return requestingDeviceIdStr == null ? Optional.of(deviceService.getDefaultDeviceId(user))
-				: Optional.of(UUID.fromString(requestingDeviceIdStr));
+				: Optional.of(RestUtil.parseUuid(requestingDeviceIdStr));
 	}
 
 	private HttpEntity<UserResource> getPublicUser(UUID userId)
@@ -246,7 +247,7 @@ public class UserController extends ControllerBase
 		}
 		else
 		{
-			return updateUser(password, userId, UUID.fromString(requestingDeviceIdStr), user, request);
+			return updateUser(password, userId, RestUtil.parseUuid(requestingDeviceIdStr), user, request);
 		}
 	}
 

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.jobs;
@@ -36,6 +36,7 @@ import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.messaging.entities.MessageDestination;
 import nu.yona.server.messaging.entities.SystemMessage;
 import nu.yona.server.messaging.service.MessageService;
+import nu.yona.server.rest.RestUtil;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
 import nu.yona.server.subscriptions.service.UserAnonymizedService;
 
@@ -167,7 +168,7 @@ public class SendSystemMessageBatchJob
 			@Override
 			public UUID mapRow(ResultSet rs, int rowNum) throws SQLException
 			{
-				return UUID.fromString(rs.getString(1));
+				return RestUtil.parseUuid(rs.getString(1));
 			}
 
 		};

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/jobs/PinResetConfirmationCodeSenderQuartzJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/jobs/PinResetConfirmationCodeSenderQuartzJob.java
@@ -1,9 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.quartz.jobs;
 
@@ -19,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.collect.ImmutableMap;
 
+import nu.yona.server.rest.RestUtil;
 import nu.yona.server.subscriptions.service.PinResetRequestService;
 
 @Service
@@ -45,7 +43,7 @@ public class PinResetConfirmationCodeSenderQuartzJob implements org.quartz.Job
 
 	private static UUID getUserId(Map<String, Object> parameterMap)
 	{
-		return UUID.fromString((String) parameterMap.get(USER_ID_KEY));
+		return RestUtil.parseUuid((String) parameterMap.get(USER_ID_KEY));
 	}
 
 	private static Locale getLocale(Map<String, Object> parameterMap)

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -129,4 +129,9 @@ public class InvalidDataException extends YonaException
 	{
 		return new InvalidDataException("error.missing.entity", clazz.getName(), id);
 	}
+
+	public static InvalidDataException invalidUuid(String uuid)
+	{
+		return new InvalidDataException("error.invalid.uuid", uuid);
+	}
 }

--- a/core/src/main/java/nu/yona/server/rest/RestUtil.java
+++ b/core/src/main/java/nu/yona/server/rest/RestUtil.java
@@ -1,10 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
+import java.util.UUID;
+
 import org.springframework.http.HttpStatus;
+
+import nu.yona.server.exceptions.InvalidDataException;
 
 public class RestUtil
 {
@@ -17,5 +21,17 @@ public class RestUtil
 	{
 		HttpStatus.Series series = status.series();
 		return (series == HttpStatus.Series.CLIENT_ERROR || series == HttpStatus.Series.SERVER_ERROR);
+	}
+
+	public static UUID parseUuid(String uuid)
+	{
+		try
+		{
+			return UUID.fromString(uuid);
+		}
+		catch (IllegalArgumentException ex)
+		{
+			throw InvalidDataException.invalidUuid(uuid);
+		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import nu.yona.server.crypto.seckey.SecretKeyUtil;
 import nu.yona.server.device.entities.DeviceBase;
 import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.rest.RestUtil;
 
 @Entity
 public abstract class BuddyConnectMessage extends BuddyConnectionChangeMessage
@@ -95,7 +96,7 @@ public abstract class BuddyConnectMessage extends BuddyConnectionChangeMessage
 
 	public List<UUID> getDeviceAnonymizedIds()
 	{
-		return splitString(deviceAnonymizedIds).map(UUID::fromString).collect(Collectors.toList());
+		return splitString(deviceAnonymizedIds).map(RestUtil::parseUuid).collect(Collectors.toList());
 	}
 
 	public List<Boolean> getDeviceVpnConnectionStatuses()

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -23,6 +23,7 @@ message.alternative.last.name=<{0}>
 default.device.name=First device
 
 error.invalid.request=Invalid request
+error.invalid.uuid=String ''{0}'' is not a valid UUID
 error.from.remote.service=Error from another service. Status code: {0}, body: {1}
 
 error.user.firstname=The first name of the user must be set

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -23,6 +23,7 @@ message.alternative.last.name=<{0}>
 default.device.name=Eerste apparaat
 
 error.invalid.request=Fout request
+error.invalid.uuid=String ''{0}'' is geen geldig UUID
 error.from.remote.service=Fout van andere service. Status code: {0}, body: {1}
 
 error.user.firstname=De voornaam van de gebruiker moet worden ingevuld


### PR DESCRIPTION
Introduced RestUtil.parseUuid and used that where we parse UUIDs. That throws an InvalidDataException, resulting in a 400 status code.