### PR TITLE
YD-591 Add Spring Cloud Sleuth

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
 			steps {
 				sh 'helm repo add yona https://jump.ops.yona.nu/helm-charts'
 				sh 'helm upgrade --install -f /config/values.yaml --namespace loadtest --version 1.2.${BUILD_NUMBER_TO_DEPLOY} loadtest yona/yona'
-				sh 'scripts/wait-for-services.sh k8snew'
+				sh 'NAMESPACE=loadtest scripts/wait-for-services.sh k8snew'
 			}
 			post {
 				failure {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compile "org.springframework.boot:spring-boot-starter-data-jpa"
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-actuator"
+	compile "org.springframework.cloud:spring-cloud-starter-sleuth:2.0.1.RELEASE"
 	compile "org.springframework.metrics:spring-metrics:0.5.1.RELEASE"
 	compile "io.micrometer:micrometer-registry-prometheus:1.0.6"
 	compile "org.springframework:spring-context-support"


### PR DESCRIPTION
That takes care of propagating the B3 headers. It might add extra (unnecessary) spans. We'll see that on the beta test server.

Along with this, the Jenkinsfile now sets the proper namespace to wait for the load test services after deploying to that server. Earlier, it was waiting for the beta services (which were already deployed as part of the previous pipeline stage).