### PR TITLE
Allow not setting max_users

### DIFF
--- a/k8s/helm/yona/templates/01_configmap_properties.yaml
+++ b/k8s/helm/yona/templates/01_configmap_properties.yaml
@@ -21,7 +21,9 @@ data:
     #spring.hazelcast.config={{ .Values.spring.hazelcast.config }}
     #hazelcast.client.config={{ .Values.spring.hazelcast.config }}
     yona.hazelcastConfigFilePath={{ .Values.spring.hazelcast.config }}
-    yona.maxUsers={{ .Values.app.max_users | default "100" }}
+    {{- if .Values.app.max_users }}
+    yona.maxUsers={{ .Values.app.max_users }}
+    {{- end }}
     yona.enableHibernateStatsAllowed={{ .Values.app.enable_hibernate_stats_allowed| default "false" }}
     yona.whiteListActiveFreeSignUp={{ required "True or False required for app.whitelist.active_free_signup" .Values.app.whitelist.active_free_signup }}
     yona.whiteListActiveInvitedUsers={{ required "True or False required for app.whitelist.active_invited_users" .Values.app.whitelist.active_invited_users }}


### PR DESCRIPTION
Helm chart doesn't allow for leaving out max_users, change makes it only set max_users if provided instead of defaulting to 100, makes the app fall back to its default of 1mil. 