### PR TITLE
Quotes to fix helm parsing

### DIFF
--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -199,7 +199,7 @@ analysis:
   update_skip_window: PT1M
 
 app:
-  max_users: 1000000
+  max_users: "1000000"
   enable_hibernate_stats_allowed: false
   whitelist:
     active_free_signup: false


### PR DESCRIPTION
All the other environments have their own max_users defined which is lower than required for helm to start parsing it as scientific notation, quotes makes it take it literally. 