### PR TITLE
YD-600 Spread index calculation considers DST change

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
@@ -193,6 +193,11 @@ public class DayActivity extends IntervalActivity
 	private static int determineDstCorrectionMinutes(ZonedDateTime time)
 	{
 		ZoneOffsetTransition previousTransition = time.getZone().getRules().previousTransition(time.toInstant());
+		if (previousTransition == null)
+		{
+			// Never did a transition in this zone.
+			return 0;
+		}
 		ZonedDateTime transitionDateTime = previousTransition.getInstant().atZone(time.getZone());
 		if (transitionDateTime.toLocalDate().equals(time.toLocalDate()) && transitionDateTime.isBefore(time))
 		{

--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
@@ -186,18 +186,20 @@ public class DayActivity extends IntervalActivity
 
 	private int getSpreadIndex(ZonedDateTime atTime)
 	{
-		int dstCorrection = determineDstCorrection(atTime);
+		int dstCorrection = determineDstCorrectionMinutes(atTime);
 		return (int) ((Duration.between(getStartTime(), atTime).toMinutes() - dstCorrection) / 15);
 	}
 
-	private static int determineDstCorrection(ZonedDateTime time)
+	private static int determineDstCorrectionMinutes(ZonedDateTime time)
 	{
 		ZoneOffsetTransition previousTransition = time.getZone().getRules().previousTransition(time.toInstant());
 		ZonedDateTime transitionDateTime = previousTransition.getInstant().atZone(time.getZone());
 		if (transitionDateTime.toLocalDate().equals(time.toLocalDate()) && transitionDateTime.isBefore(time))
 		{
 			// Transition happened earlier today
-			return previousTransition.isOverlap() ? 60 : -60;
+			ZoneOffset offsetBefore = previousTransition.getOffsetBefore();
+			ZoneOffset offsetAfter = previousTransition.getOffsetAfter();
+			return (offsetBefore.getTotalSeconds() - offsetAfter.getTotalSeconds()) / 60;
 		}
 		return 0;
 	}


### PR DESCRIPTION
On the date a zone enters or leaves daylight saving time, the day has 23 or 25 hours. This can give issues in the spread calculation. When leaving DST (i.e. on a 25-hour day), the calculated number of minutes for a time stamp after the transition needs to be corrected by subtracting 60 minutes. Right after transitioning into DST, we subtract -60 minutes.