### PR TITLE
YD-601 Addressed some Cinderella bugs

### DIFF
--- a/adminservice/build.gradle
+++ b/adminservice/build.gradle
@@ -95,6 +95,7 @@ task intTest(type:Test){
 	systemProperties = System.getProperties()
 
 	systemProperties = [
+		"java.util.logging.config.file": "../core/src/testUtils/logging.properties",
 		"yona.adminservice.url": project.ext.yona_adminservice_url,
 		"yona.analysisservice.url": project.ext.yona_analysisservice_url,
 		"yona.appservice.url": project.ext.yona_appservice_url,

--- a/analysisservice/build.gradle
+++ b/analysisservice/build.gradle
@@ -97,6 +97,7 @@ task intTest(type:Test){
 	classpath = project.sourceSets.intTest.runtimeClasspath
 
 	systemProperties = [
+		"java.util.logging.config.file": "../core/src/testUtils/logging.properties",
 		"yona.adminservice.url": project.ext.yona_adminservice_url,
 		"yona.analysisservice.url": project.ext.yona_analysisservice_url,
 		"yona.appservice.url": project.ext.yona_appservice_url,

--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -101,6 +101,7 @@ task intTest(type:Test){
 	systemProperties = System.getProperties()
 
 	systemProperties = [
+		"java.util.logging.config.file": "../core/src/testUtils/logging.properties",
 		"yona.adminservice.url": project.ext.yona_adminservice_url,
 		"yona.analysisservice.url": project.ext.yona_analysisservice_url,
 		"yona.appservice.url": project.ext.yona_appservice_url,

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -460,9 +460,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		def richardAndBob = addRichardAndBobAsBuddies()
 		def richard = richardAndBob.richard
 		def bob = richardAndBob.bob
-		BudgetGoal addedGoal = addBudgetGoal(richard, SOCIAL_ACT_CAT_URL, 60, "W-1 Thu 18:00")
+		BudgetGoal addedGoal = addBudgetGoal(richard, SOCIAL_ACT_CAT_URL, 60, "W-2 Thu 18:00")
 		postFacebookActivityPastHour(richard)
-		BudgetGoal updatedGoal = BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 120)
+		def goalUpdateTime = YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Mon 11:00")
+		BudgetGoal updatedGoal = BudgetGoal.createInstance(goalUpdateTime, SOCIAL_ACT_CAT_URL, 120)
 		bob = appService.reloadUser(bob)
 		def buddyRichardUrl = bob.buddies[0].url
 
@@ -478,7 +479,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseGoalsAfterUpdate)
 		responseGoalsAfterUpdate.responseData._embedded."yona:goals".size() == 4
 		findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 120
-		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, YonaServer.now)
+		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime)
 
 		def allSocialGoals = findGoalsIncludingHistoryItems(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL)
 		allSocialGoals.size() == 2
@@ -508,7 +509,8 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		// Change 2
 		when:
-		BudgetGoal updatedGoal2 = BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 180)
+		def goalUpdateTime2 = goalUpdateTime.plusMinutes(15)
+		BudgetGoal updatedGoal2 = BudgetGoal.createInstance(goalUpdateTime2, SOCIAL_ACT_CAT_URL, 180)
 		def response2 = appService.updateGoal(richard, addedGoal.url, updatedGoal2, "Want to become even more social :)")
 
 		then:
@@ -519,7 +521,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseGoalsAfterUpdate2)
 		responseGoalsAfterUpdate2.responseData._embedded."yona:goals".size() == 5
 		findActiveGoal(responseGoalsAfterUpdate2, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 180
-		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, YonaServer.now)
+		assertEquals(findActiveGoal(responseGoalsAfterUpdate2, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime2)
 
 		def allSocialGoals2 = findGoalsIncludingHistoryItems(responseGoalsAfterUpdate2, SOCIAL_ACT_CAT_URL)
 		allSocialGoals2.size() == 3
@@ -549,7 +551,8 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		// Change 3
 		when:
-		BudgetGoal updatedGoal3 = BudgetGoal.createInstance(SOCIAL_ACT_CAT_URL, 240)
+		def goalUpdateTime3 = goalUpdateTime2.plusMinutes(20)
+		BudgetGoal updatedGoal3 = BudgetGoal.createInstance(goalUpdateTime3, SOCIAL_ACT_CAT_URL, 240)
 		def response3 = appService.updateGoal(richard, addedGoal.url, updatedGoal3, "Want to become extremely social :)")
 
 		then:
@@ -560,7 +563,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseGoalsAfterUpdate3)
 		responseGoalsAfterUpdate3.responseData._embedded."yona:goals".size() == 6
 		findActiveGoal(responseGoalsAfterUpdate3, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 240
-		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, YonaServer.now)
+		assertEquals(findActiveGoal(responseGoalsAfterUpdate3, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime3)
 
 		def allSocialGoals3 = findGoalsIncludingHistoryItems(responseGoalsAfterUpdate3, SOCIAL_ACT_CAT_URL)
 		allSocialGoals3.size() == 4

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.gradle.internal.util.PropertiesUtils
+import java.nio.charset.StandardCharsets 
+
 buildscript {
 	repositories {
 		jcenter()
@@ -71,9 +74,18 @@ subprojects {
 	springBoot {
 		buildInfo {
 			properties {
+				time = null
 				additional = [
 					buildNumber : project.ext.build_number
 				]
+			}
+			doLast {
+				File propertiesFile = new File(destinationDir, 'build-info.properties')
+				Properties props = new Properties()
+				propertiesFile.withInputStream { props.load(it)}
+				OutputStream out = new BufferedOutputStream(new FileOutputStream(propertiesFile))
+				PropertiesUtils.store(props, out, "Custom generated to ensure repeatability", StandardCharsets.UTF_8, "\n");
+				out.close()
 			}
 		}
 	}

--- a/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
+++ b/core/src/main/java/nu/yona/server/device/entities/UserDevice.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.Type;
 import nu.yona.server.crypto.seckey.DateFieldEncryptor;
 import nu.yona.server.crypto.seckey.DateTimeFieldEncryptor;
 import nu.yona.server.crypto.seckey.StringFieldEncryptor;
+import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.util.TimeUtil;
 
 @Entity
@@ -45,17 +46,21 @@ public class UserDevice extends DeviceBase
 	{
 	}
 
-	private UserDevice(UUID id, String name, UUID deviceAnonymizedId, String vpnPassword)
+	private UserDevice(UUID id, String name, UUID deviceAnonymizedId, String vpnPassword, LocalDateTime registrationTime,
+			LocalDate appLastOpenedDate)
 	{
 		super(id, name, deviceAnonymizedId);
+		this.registrationTime = registrationTime;
+		this.appLastOpenedDate = appLastOpenedDate;
 		this.vpnPassword = Objects.requireNonNull(vpnPassword);
-		this.registrationTime = TimeUtil.utcNow();
-		this.appLastOpenedDate = TimeUtil.utcNow().toLocalDate(); // The user registers this device, so the app is open now
 	}
 
-	public static UserDevice createInstance(String name, UUID deviceAnonymizedId, String vpnPassword)
+	public static UserDevice createInstance(User userEntity, String name, UUID deviceAnonymizedId, String vpnPassword)
 	{
-		return new UserDevice(UUID.randomUUID(), name, deviceAnonymizedId, vpnPassword);
+		LocalDateTime registrationTime = TimeUtil.utcNow();
+		// The user registers this device, so the app is open now
+		LocalDate appLastOpenedDate = registrationTime.atZone(userEntity.getAnonymized().getTimeZone()).toLocalDate();
+		return new UserDevice(UUID.randomUUID(), name, deviceAnonymizedId, vpnPassword, registrationTime, appLastOpenedDate);
 	}
 
 	public UUID getUserPrivateId()

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -103,8 +103,8 @@ public class DeviceService
 				deviceDto.getOperatingSystem(), deviceDto.getAppVersion(), deviceDto.getAppVersionCode(),
 				deviceDto.getFirebaseInstanceId());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		UserDevice deviceEntity = userDeviceRepository
-				.save(UserDevice.createInstance(deviceDto.getName(), deviceAnonymized.getId(), userService.generatePassword()));
+		UserDevice deviceEntity = userDeviceRepository.save(UserDevice.createInstance(userEntity, deviceDto.getName(),
+				deviceAnonymized.getId(), userService.generatePassword()));
 		userEntity.addDevice(deviceEntity);
 
 		ldapUserService.createVpnAccount(buildVpnLoginId(userEntity.getAnonymized(), deviceEntity),

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserAnonymized.java
@@ -5,6 +5,7 @@
 package nu.yona.server.subscriptions.entities;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -33,6 +34,7 @@ import nu.yona.server.messaging.entities.MessageDestination;
 @Table(name = "USERS_ANONYMIZED")
 public class UserAnonymized extends EntityWithUuid
 {
+	private static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("Europe/Amsterdam");
 	private LocalDate lastMonitoredActivityDate;
 
 	@OneToOne(fetch = FetchType.LAZY)
@@ -154,6 +156,11 @@ public class UserAnonymized extends EntityWithUuid
 	public Set<DeviceAnonymized> getDevicesAnonymized()
 	{
 		return devicesAnonymized;
+	}
+
+	public ZoneId getTimeZone()
+	{
+		return DEFAULT_TIME_ZONE;
 	}
 
 	public void preloadGoals()

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDto.java
@@ -25,22 +25,23 @@ import nu.yona.server.subscriptions.entities.UserAnonymized;
 public class UserAnonymizedDto implements Serializable
 {
 	private static final long serialVersionUID = 5569303515806259326L;
-	private static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("Europe/Amsterdam");
 
 	private final UUID id;
 
 	private final LocalDate lastMonitoredActivityDate;
+	private ZoneId timeZone;
 	private final Set<GoalDto> goals;
 	private final MessageDestinationDto anonymousMessageDestination;
 	private final Set<BuddyAnonymizedDto> buddiesAnonymized;
 	private final Set<DeviceAnonymizedDto> devicesAnonymized;
 
-	public UserAnonymizedDto(UUID id, Optional<LocalDate> lastMonitoredActivityDate, Set<GoalDto> goals,
+	public UserAnonymizedDto(UUID id, Optional<LocalDate> lastMonitoredActivityDate, ZoneId timeZone, Set<GoalDto> goals,
 			MessageDestinationDto anonymousMessageDestination, Set<BuddyAnonymizedDto> buddiesAnonymized,
 			Set<DeviceAnonymizedDto> devicesAnonymized)
 	{
 		this.id = id;
 		this.lastMonitoredActivityDate = lastMonitoredActivityDate.orElse(null);
+		this.timeZone = timeZone;
 		this.goals = new HashSet<>(goals);
 		this.anonymousMessageDestination = anonymousMessageDestination;
 		this.buddiesAnonymized = buddiesAnonymized;
@@ -49,7 +50,8 @@ public class UserAnonymizedDto implements Serializable
 
 	public static UserAnonymizedDto createInstance(UserAnonymized entity)
 	{
-		return new UserAnonymizedDto(entity.getId(), entity.getLastMonitoredActivityDate(), getGoalsIncludingHistoryItems(entity),
+		return new UserAnonymizedDto(entity.getId(), entity.getLastMonitoredActivityDate(), entity.getTimeZone(),
+				getGoalsIncludingHistoryItems(entity),
 				(entity.getAnonymousDestination() == null) ? null
 						: MessageDestinationDto.createInstance(entity.getAnonymousDestination()),
 				entity.getBuddiesAnonymized().stream().map(BuddyAnonymizedDto::createInstance).collect(Collectors.toSet()),
@@ -79,7 +81,7 @@ public class UserAnonymizedDto implements Serializable
 
 	public ZoneId getTimeZone()
 	{
-		return DEFAULT_TIME_ZONE;
+		return timeZone;
 	}
 
 	public MessageDestinationDto getAnonymousDestination()

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -906,7 +906,7 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	{
 		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(deviceIndex, operatingSystem, appVersion,
 				appVersionCode, Optional.empty());
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		UserDevice device = UserDevice.createInstance(richard, deviceName, deviceAnonymized.getId(), "topSecret");
 		deviceAnonymizedRepository.save(deviceAnonymized);
 		userDeviceRepository.save(device);
 		return device;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/BuddyDeviceChangeMessageDtoTest.java
@@ -305,7 +305,7 @@ public class BuddyDeviceChangeMessageDtoTest extends BaseSpringIntegrationTest
 	{
 		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, "Unknown", 0, Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		UserDevice device = UserDevice.createInstance(user, deviceName, deviceAnonymized.getId(), "topSecret");
 		user.addDevice(device);
 
 		return device;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -171,7 +171,7 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, operatingSystem, SOME_APP_VERSION,
 				SUPPORTED_APP_VERSION_CODE, Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		UserDevice device = UserDevice.createInstance(deviceName, deviceAnonymized.getId(), "topSecret");
+		UserDevice device = UserDevice.createInstance(richard, deviceName, deviceAnonymized.getId(), "topSecret");
 		richard.addDevice(device);
 
 		// Verify device is present

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/MoveVpnPasswordToDeviceTest.java
@@ -148,6 +148,6 @@ public class MoveVpnPasswordToDeviceTest extends BaseSpringIntegrationTest
 		DeviceAnonymized deviceAnonymized = DeviceAnonymized.createInstance(0, OperatingSystem.ANDROID, "1.0.0", 2,
 				Optional.empty());
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		return UserDevice.createInstance("Testing", deviceAnonymized.getId(), "toBeOverwritten");
+		return UserDevice.createInstance(richard, "Testing", deviceAnonymized.getId(), "toBeOverwritten");
 	}
 }

--- a/core/src/testUtils/logging.properties
+++ b/core/src/testUtils/logging.properties
@@ -1,0 +1,6 @@
+handlers= java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = %1$tH:%1$tM:%1$tS.%1$tL %4$-6s %2$s - %5$s%n
+
+.level=FINEST


### PR DESCRIPTION
* We used to determine the "app last opened date" based on the UTC time. That's now corrected to be the user's timezone. Till now we don't store the user's timezone, but use a constant. This constant moved from UserAnonymizedDto to UserAnonymized.
* Corrected one test case in EditGoalsTest. More tests are to be corrected.

Along with this:
* Made the build repeatable by preventing a timestamp in the build-info.properties
* Made the integration tests log to stdout again