### PR TITLE
YD-612 Correct buddy goal LinkProvider

### DIFF
--- a/adminservice/src/main/java/nu/yona/server/admin/DashboardController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/DashboardController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.admin;

--- a/adminservice/src/main/java/nu/yona/server/admin/DashboardController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/DashboardController.java
@@ -16,8 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
@@ -41,7 +41,7 @@ public class DashboardController
 	@Autowired
 	private BuildProperties buildProperties;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@Transactional
 	public String getIndexPage(Model model)
 	{

--- a/adminservice/src/main/java/nu/yona/server/admin/SystemMessageController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/SystemMessageController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.admin;

--- a/adminservice/src/main/java/nu/yona/server/admin/SystemMessageController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/SystemMessageController.java
@@ -6,8 +6,9 @@ package nu.yona.server.admin;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
@@ -20,13 +21,13 @@ public class SystemMessageController
 	@Autowired
 	private BatchProxyService batchProxyService;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	public String getIndexPage()
 	{
 		return "system-messages";
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	public String addSystemMessage(@RequestParam String message, RedirectAttributes redirectAttributes)
 	{
 		batchProxyService.sendSystemMessage(message);

--- a/adminservice/src/main/java/nu/yona/server/admin/WhiteListedNumberController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/WhiteListedNumberController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.admin;

--- a/adminservice/src/main/java/nu/yona/server/admin/WhiteListedNumberController.java
+++ b/adminservice/src/main/java/nu/yona/server/admin/WhiteListedNumberController.java
@@ -7,8 +7,9 @@ package nu.yona.server.admin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import nu.yona.server.subscriptions.service.WhiteListedNumberService;
@@ -20,7 +21,7 @@ public class WhiteListedNumberController
 	@Autowired
 	private WhiteListedNumberService whiteListedNumberService;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	public String getIndexPage(Model model)
 	{
 		model.addAttribute("whiteListedNumbers", whiteListedNumberService.getAllWhiteListedNumbers());
@@ -28,7 +29,7 @@ public class WhiteListedNumberController
 		return "white-listed-numbers";
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	public String addWhiteListedNumber(@RequestParam String mobileNumber)
 	{
 		whiteListedNumberService.addWhiteListedNumber(mobileNumber);

--- a/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;

--- a/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/adminservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -20,10 +20,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -42,7 +45,7 @@ public class ActivityCategoryController extends ControllerBase
 	@Autowired
 	private ActivityCategoryService activityCategoryService;
 
-	@RequestMapping(value = "/{id}", method = RequestMethod.GET)
+	@GetMapping(value = "/{id}")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AdminView.class)
 	public HttpEntity<ActivityCategoryResource> getActivityCategory(@PathVariable UUID id)
@@ -50,7 +53,7 @@ public class ActivityCategoryController extends ControllerBase
 		return createOkResponse(activityCategoryService.getActivityCategory(id), createResourceAssembler());
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AdminView.class)
 	public HttpEntity<Resources<ActivityCategoryResource>> getAllActivityCategories()
@@ -59,7 +62,7 @@ public class ActivityCategoryController extends ControllerBase
 				getAllActivityCategoriesLinkBuilder());
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AdminView.class)
 	public HttpEntity<ActivityCategoryResource> addActivityCategory(@RequestBody ActivityCategoryDto activityCategory)
@@ -68,7 +71,7 @@ public class ActivityCategoryController extends ControllerBase
 		return createOkResponse(activityCategoryService.addActivityCategory(activityCategory), createResourceAssembler());
 	}
 
-	@RequestMapping(value = "/{id}", method = RequestMethod.PUT)
+	@PutMapping(value = "/{id}")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AdminView.class)
 	public HttpEntity<ActivityCategoryResource> updateActivityCategory(@PathVariable UUID id,
@@ -77,7 +80,7 @@ public class ActivityCategoryController extends ControllerBase
 		return createOkResponse(activityCategoryService.updateActivityCategory(id, activityCategory), createResourceAssembler());
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.PUT)
+	@PutMapping(value = "/")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AdminView.class)
 	public HttpEntity<Resources<ActivityCategoryResource>> updateActivityCategorySet(
@@ -88,7 +91,7 @@ public class ActivityCategoryController extends ControllerBase
 				getAllActivityCategoriesLinkBuilder());
 	}
 
-	@RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{id}")
 	@ResponseStatus(HttpStatus.OK)
 	public void deleteActivityCategory(@PathVariable UUID id)
 	{

--- a/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;

--- a/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/rest/AnalysisEngineController.java
@@ -13,10 +13,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -32,7 +33,7 @@ public class AnalysisEngineController
 	@Autowired
 	private AnalysisEngineService analysisEngineService;
 
-	@RequestMapping(value = "/userAnonymized/{userAnonymizedId}/networkActivity/", method = RequestMethod.POST)
+	@PostMapping(value = "/userAnonymized/{userAnonymizedId}/networkActivity/")
 	@ResponseStatus(value = HttpStatus.NO_CONTENT)
 	public void analyzeNetworkActivity(@PathVariable UUID userAnonymizedId,
 			@RequestParam(value = "preventParallelism", required = false, defaultValue = "false") String preventParallelismStr,
@@ -60,7 +61,7 @@ public class AnalysisEngineController
 	 * The app service receives the app activity monitored by the Yona app and sends that to the analysis engine through this
 	 * method.
 	 */
-	@RequestMapping(value = "/userAnonymized/{userAnonymizedId}/{deviceAnonymizedId}/appActivity/", method = RequestMethod.POST)
+	@PostMapping(value = "/userAnonymized/{userAnonymizedId}/{deviceAnonymizedId}/appActivity/")
 	@ResponseStatus(value = HttpStatus.NO_CONTENT)
 	public void analyzeAppActivity(@PathVariable UUID userAnonymizedId, @PathVariable UUID deviceAnonymizedId,
 			@RequestBody AppActivitiesDto appActivities)
@@ -68,7 +69,7 @@ public class AnalysisEngineController
 		analysisEngineService.analyze(userAnonymizedId, deviceAnonymizedId, appActivities);
 	}
 
-	@RequestMapping(value = "/relevantSmoothwallCategories/", method = RequestMethod.GET)
+	@GetMapping(value = "/relevantSmoothwallCategories/")
 	@ResponseBody
 	public HttpEntity<CategoriesResource> getRelevantSmoothwallCategories()
 	{

--- a/analysisservice/src/main/java/nu/yona/server/analysis/rest/InactivityManagementController.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/rest/InactivityManagementController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;

--- a/analysisservice/src/main/java/nu/yona/server/analysis/rest/InactivityManagementController.java
+++ b/analysisservice/src/main/java/nu/yona/server/analysis/rest/InactivityManagementController.java
@@ -12,9 +12,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import nu.yona.server.analysis.service.InactivityManagementService;
@@ -27,7 +27,7 @@ public class InactivityManagementController
 	@Autowired
 	private InactivityManagementService inactivityManagementService;
 
-	@RequestMapping(value = "/{userAnonymizedId}/inactivity/", method = RequestMethod.POST)
+	@PostMapping(value = "/{userAnonymizedId}/inactivity/")
 	@ResponseStatus(value = HttpStatus.NO_CONTENT)
 	public void createInactivityEntities(@PathVariable UUID userAnonymizedId,
 			@RequestBody Set<IntervalInactivityDto> intervalInactivities)

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -236,23 +236,40 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		User bob = richardAndBob.bob
 
 		when:
-		def buddiesRichard = appService.getBuddies(richard)
-		def buddiesBob = appService.getBuddies(bob)
+		Buddy[] buddiesRichard = appService.getBuddies(richard)
+		Buddy[] buddiesBob = appService.getBuddies(bob)
 
 		then:
-		buddiesRichard[0].goals.size() == 2
+		buddiesRichard[0].goals.size() == 2 // YD-505
 		buddiesRichard[0].user.goals.size() == 2
 		buddiesRichard[0].user.devices.size() == 1
-		buddiesBob[0].goals.size() == 2
+		buddiesBob[0].goals.size() == 2 // YD-505
 		buddiesBob[0].user.goals.size() == 2
 		buddiesBob[0].user.devices.size() == 1
 
-		buddiesRichard[0].goals.each
+		def bobGoalUrls = bob.goals.collect { YonaServer.stripQueryString(it.url) }
+		def richardBuddyGoalUrls = buddiesRichard[0].goals.collect { YonaServer.stripQueryString(it.url) } // YD-505
+		def richardBuddyUserGoalUrls = buddiesRichard[0].user.goals.collect { YonaServer.stripQueryString(it.url) }
+
+		assert bobGoalUrls == richardBuddyGoalUrls // YD-505
+		assert bobGoalUrls == richardBuddyUserGoalUrls
+
+		buddiesRichard[0].goals.each // YD-505
 		{
 			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": richard.password]))
 		}
 
-		buddiesBob[0].goals.each
+		buddiesRichard[0].user.goals.each
+		{
+			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": richard.password]))
+		}
+
+		buddiesBob[0].goals.each // YD-505
+		{
+			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": bob.password]))
+		}
+
+		buddiesBob[0].user.goals.each
 		{
 			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": bob.password]))
 		}
@@ -412,7 +429,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		def dayActivityDetailBob = appService.getResourceWithPassword(dayActivityDetailUrlBob, bob.password)
 		assertResponseStatusOk(dayActivityDetailBob)
 		dayActivityDetailBob.responseData.date == YonaServer.toIsoDateString(goalConflictTime)
-		dayActivityDetailBob.responseData._links."yona:goal".href == goalBob.url
+		dayActivityDetailBob.responseData._links."yona:goal".href.startsWith(goalBob.url)
 		dayActivityDetailBob.responseData.totalMinutesBeyondGoal == 1
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -429,7 +429,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		def dayActivityDetailBob = appService.getResourceWithPassword(dayActivityDetailUrlBob, bob.password)
 		assertResponseStatusOk(dayActivityDetailBob)
 		dayActivityDetailBob.responseData.date == YonaServer.toIsoDateString(goalConflictTime)
-		dayActivityDetailBob.responseData._links."yona:goal".href.startsWith(goalBob.url)
+		dayActivityDetailBob.responseData._links."yona:goal".href == goalBob.url
 		dayActivityDetailBob.responseData.totalMinutesBeyondGoal == 1
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
@@ -488,6 +488,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 				.addPart("file", new InputStreamBody(new ByteArrayInputStream(Base64.getDecoder().decode(EXAMPLE_PNG_DATA_BASE64)), "image/png", "MyPhoto.png"))
 				.build()
 		def response = appService.yonaServer.restClient.put(path: user.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": user.password], body: multipartEntity)
+		assertResponseStatusOk(response)
 		response.responseData?._links?."yona:userPhoto"?.href
 	}
 

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -59,7 +59,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		john.postOpenAppEventUrl == baseUserUrl + "/devices/" + john.getRequestingDeviceId() + "/openApp"
 		john.buddiesUrl == baseUserUrl + "/buddies/"
-		john.goalsUrl.startsWith(baseUserUrl + "/goals/")
+		YonaServer.stripQueryString(john.goalsUrl) == baseUserUrl + "/goals/"
 		john.messagesUrl == baseUserUrl + "/messages/"
 		john.newDeviceRequestUrl == appService.url + "/newDeviceRequests/" + john.mobileNumber
 		john.appActivityUrl == baseUserUrl + "/devices/" + john.getRequestingDeviceId() + "/appActivity/"

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -59,7 +59,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		john.postOpenAppEventUrl == baseUserUrl + "/devices/" + john.getRequestingDeviceId() + "/openApp"
 		john.buddiesUrl == baseUserUrl + "/buddies/"
-		john.goalsUrl == baseUserUrl + "/goals/"
+		john.goalsUrl.startsWith(baseUserUrl + "/goals/")
 		john.messagesUrl == baseUserUrl + "/messages/"
 		john.newDeviceRequestUrl == appService.url + "/newDeviceRequests/" + john.mobileNumber
 		john.appActivityUrl == baseUserUrl + "/devices/" + john.getRequestingDeviceId() + "/appActivity/"

--- a/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
+++ b/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.admin.rest;

--- a/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
+++ b/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.admin.rest;
 
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -27,7 +27,7 @@ public class AdminController
 	@Autowired
 	private UserService userService;
 
-	@RequestMapping(value = "/requestUserOverwrite/", method = RequestMethod.POST)
+	@PostMapping(value = "/requestUserOverwrite/")
 	@ResponseStatus(HttpStatus.OK)
 	public void setOverwriteUserConfirmationCode(@RequestParam String mobileNumber)
 	{

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
@@ -20,11 +20,12 @@ import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import nu.yona.server.analysis.entities.IntervalActivity;
@@ -55,7 +56,7 @@ public class BuddyActivityController extends ActivityControllerBase
 	@Autowired
 	private BuddyService buddyService;
 
-	@RequestMapping(value = WEEK_ACTIVITY_OVERVIEWS_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_OVERVIEWS_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<WeekActivityOverviewResource>> getBuddyWeekActivityOverviews(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -72,7 +73,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_OVERVIEW_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_OVERVIEW_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<WeekActivityOverviewResource> getBuddyWeekActivityOverview(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -88,7 +89,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = DAY_OVERVIEWS_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_OVERVIEWS_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<DayActivityOverviewResource>> getBuddyDayActivityOverviews(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -105,7 +106,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = DAY_OVERVIEW_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_OVERVIEW_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<DayActivityOverviewResource> getBuddyDayActivityOverview(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -121,7 +122,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_DETAIL_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_DETAIL_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<WeekActivityResource> getBuddyWeekActivityDetail(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -138,7 +139,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<MessageDto>> getBuddyWeekActivityDetailMessages(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -158,7 +159,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.POST)
+	@PostMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<MessageDto> addBuddyWeekActivityDetailMessage(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -173,7 +174,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<DayActivityResource> getBuddyDayActivityDetail(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -190,7 +191,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<MessageDto>> getBuddyDayActivityDetailMessages(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -210,7 +211,7 @@ public class BuddyActivityController extends ActivityControllerBase
 		}
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.POST)
+	@PostMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<MessageDto> addBuddyDayActivityDetailMessage(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
@@ -30,10 +30,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -65,7 +65,7 @@ import nu.yona.server.subscriptions.service.GoalIdMapping;
 @RequestMapping(value = "/users/{userId}/activity", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class UserActivityController extends ActivityControllerBase
 {
-	@RequestMapping(value = WEEK_ACTIVITY_OVERVIEWS_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_OVERVIEWS_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<WeekActivityOverviewResource>> getUserWeekActivityOverviews(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -76,7 +76,7 @@ public class UserActivityController extends ActivityControllerBase
 				() -> activityService.getUserWeekActivityOverviews(userId, pageable), new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_OVERVIEW_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_OVERVIEW_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<WeekActivityOverviewResource> getUserWeekActivityOverview(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -86,7 +86,7 @@ public class UserActivityController extends ActivityControllerBase
 				date -> activityService.getUserWeekActivityOverview(userId, date), new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = DAY_OVERVIEWS_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_OVERVIEWS_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<DayActivityOverviewResource>> getUserDayActivityOverviews(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -97,7 +97,7 @@ public class UserActivityController extends ActivityControllerBase
 				() -> activityService.getUserDayActivityOverviews(userId, pageable), new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = DAY_OVERVIEW_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_OVERVIEW_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<DayActivityOverviewResource> getUserDayActivityOverview(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -107,7 +107,7 @@ public class UserActivityController extends ActivityControllerBase
 				new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_DETAIL_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_DETAIL_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<WeekActivityResource> getUserWeekActivityDetail(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -117,7 +117,7 @@ public class UserActivityController extends ActivityControllerBase
 				date -> activityService.getUserWeekActivityDetail(userId, date, goalId), new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = WEEK_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<MessageDto>> getUserWeekActivityDetailMessages(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -130,7 +130,7 @@ public class UserActivityController extends ActivityControllerBase
 				new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<DayActivityResource> getUserDayActivityDetail(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -140,7 +140,7 @@ public class UserActivityController extends ActivityControllerBase
 				date -> activityService.getUserDayActivityDetail(userId, date, goalId), new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT, method = RequestMethod.GET)
+	@GetMapping(value = DAY_ACTIVITY_DETAIL_MESSAGES_URI_FRAGMENT)
 	@ResponseBody
 	public HttpEntity<PagedResources<MessageDto>> getUserDayActivityDetailMessages(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -153,7 +153,7 @@ public class UserActivityController extends ActivityControllerBase
 				new UserActivityLinkProvider(userId));
 	}
 
-	@RequestMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT + "/raw/", method = RequestMethod.GET)
+	@GetMapping(value = DAY_ACTIVITY_DETAIL_URI_FRAGMENT + "/raw/")
 	@ResponseBody
 	public HttpEntity<ActivitiesResource> getRawActivities(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable(value = DATE_PATH_VARIABLE) String dateStr,
@@ -180,7 +180,7 @@ public class UserActivityController extends ActivityControllerBase
 	 * suggests that the user activities are supplemented with the buddy activities, while in reality, the buddy activities are
 	 * supplemented with the user activities. The name is retained because it reflects the external API (URL).
 	 */
-	@RequestMapping(value = "/withBuddies/days/", method = RequestMethod.GET)
+	@GetMapping(value = "/withBuddies/days/")
 	@ResponseBody
 	public HttpEntity<PagedResources<DayActivityOverviewWithBuddiesResource>> getDayActivityOverviewsWithBuddies(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -233,7 +233,7 @@ public class UserActivityController extends ActivityControllerBase
 	 * supplemented with the buddy activities, while in reality, the buddy activities are supplemented with the user activities.
 	 * The name is retained because it reflects the external API (URL).
 	 */
-	@RequestMapping(value = "/withBuddies/days/{date}", method = RequestMethod.GET)
+	@GetMapping(value = "/withBuddies/days/{date}")
 	@ResponseBody
 	public HttpEntity<DayActivityOverviewWithBuddiesResource> getDayActivityOverviewWithBuddies(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -550,7 +550,6 @@ public class UserActivityController extends ActivityControllerBase
 			ActivityForOneUserResource dayActivityResource = instantiateResource(dayActivity);
 
 			UUID goalId = dayActivity.getGoalId();
-			UUID requestingUserId = goalIdMapping.getUserId();
 			if (goalIdMapping.isUserGoal(goalId))
 			{
 				addGoalLinkForUser(requestingUserId, goalId, dayActivityResource);

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.rest;

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -39,11 +39,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -129,7 +132,7 @@ public class DeviceController extends ControllerBase
 		ERROR, WARNING
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<Resources<DeviceResource>> getAllDevices(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId,
@@ -144,7 +147,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{deviceId}", method = RequestMethod.GET)
+	@GetMapping(value = "/{deviceId}")
 	@ResponseBody
 	public HttpEntity<DeviceResource> getDevice(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId,
@@ -158,7 +161,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<UserResource> registerDevice(
 			@RequestHeader(value = Constants.NEW_DEVICE_REQUEST_PASSWORD_HEADER) String newDeviceRequestPassword,
@@ -176,7 +179,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{deviceId}/openApp", method = RequestMethod.POST)
+	@PostMapping(value = "/{deviceId}/openApp")
 	@ResponseBody
 	public ResponseEntity<Void> postOpenAppEvent(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId, @RequestBody AppOpenEventDto request)
@@ -209,7 +212,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{deviceId}/apple.mobileconfig", method = RequestMethod.GET)
+	@GetMapping(value = "/{deviceId}/apple.mobileconfig")
 	@ResponseBody
 	public ResponseEntity<byte[]> getAppleMobileConfig(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -243,7 +246,7 @@ public class DeviceController extends ControllerBase
 		return unsignedMobileconfig;
 	}
 
-	@RequestMapping(value = "/{deviceId}", method = RequestMethod.PUT)
+	@PutMapping(value = "/{deviceId}")
 	@ResponseBody
 	public HttpEntity<DeviceResource> updateDevice(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId,
@@ -258,7 +261,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{deviceId}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{deviceId}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deleteDevice(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -278,7 +281,7 @@ public class DeviceController extends ControllerBase
 	 * @param appActivities Because it may be that multiple app activities may have taken place during the time the network is
 	 * down, accept an array of activities.
 	 */
-	@RequestMapping(value = "/{deviceId}/appActivity/", method = RequestMethod.POST)
+	@PostMapping(value = "/{deviceId}/appActivity/")
 	@ResponseBody
 	public ResponseEntity<Void> addAppActivity(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId, @RequestBody AppActivitiesDto appActivities)
@@ -348,7 +351,7 @@ public class DeviceController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{deviceId}/vpnStatus/", method = RequestMethod.POST)
+	@PostMapping(value = "/{deviceId}/vpnStatus/")
 	@ResponseBody
 	public ResponseEntity<Void> postVpnStatusChangeEvent(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId, @RequestBody VpnStatusDto vpnStatus)

--- a/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -18,9 +18,9 @@ import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -38,7 +38,7 @@ public class ActivityCategoryController extends ControllerBase
 	@Autowired
 	private ActivityCategoryService activityCategoryService;
 
-	@RequestMapping(value = "/{id}", method = RequestMethod.GET)
+	@GetMapping(value = "/{id}")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AppView.class)
 	public HttpEntity<ActivityCategoryResource> getActivityCategory(@PathVariable UUID id)
@@ -46,7 +46,7 @@ public class ActivityCategoryController extends ControllerBase
 		return createOkResponse(activityCategoryService.getActivityCategory(id), createResourceAssembler());
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AppView.class)
 	public HttpEntity<Resources<ActivityCategoryResource>> getAllActivityCategories()
@@ -56,7 +56,7 @@ public class ActivityCategoryController extends ControllerBase
 	}
 
 	// Added to analyse randomly failing ActivityCategoriesTest
-	@RequestMapping(value = "/skip-cache/", method = RequestMethod.GET)
+	@GetMapping(value = "/skip-cache/")
 	@ResponseBody
 	@JsonView(ActivityCategoryDto.AppView.class)
 	public HttpEntity<Resources<ActivityCategoryResource>> getAllActivityCategoriesSkipCache()

--- a/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/ActivityCategoryController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -25,11 +25,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -65,7 +68,7 @@ public class GoalController extends ControllerBase
 	@Autowired
 	private CurieProvider curieProvider;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<Resources<GoalDto>> getAllGoals(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = UserController.REQUESTING_USER_ID_PARAM, required = false) String requestingUserIdStr,
@@ -87,7 +90,7 @@ public class GoalController extends ControllerBase
 				.orElseThrow(() -> new IllegalStateException("Goals of user " + userId + " are not available"));
 	}
 
-	@RequestMapping(value = "/{goalId}", method = RequestMethod.GET)
+	@GetMapping(value = "/{goalId}")
 	@ResponseBody
 	public HttpEntity<GoalDto> getGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = UserController.REQUESTING_USER_ID_PARAM, required = false) String requestingUserIdStr,
@@ -114,7 +117,7 @@ public class GoalController extends ControllerBase
 		return (requestingUserIdStr == null) ? userId : UUID.fromString(requestingUserIdStr);
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<GoalDto> addGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @RequestBody GoalDto goal,
@@ -129,7 +132,7 @@ public class GoalController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{goalId}", method = RequestMethod.PUT)
+	@PutMapping(value = "/{goalId}")
 	@ResponseBody
 	public HttpEntity<GoalDto> updateGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID goalId, @RequestBody GoalDto goal,
@@ -144,7 +147,7 @@ public class GoalController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{goalId}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{goalId}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.OK)
 	public void removeGoal(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.rest;

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -32,11 +32,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -93,7 +95,7 @@ public class MessageController extends ControllerBase
 	@Autowired
 	private BuddyActivityController buddyActivityController;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<PagedResources<MessageDto>> getMessages(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = "onlyUnreadMessages", required = false, defaultValue = "false") String onlyUnreadMessagesStr,
@@ -116,7 +118,7 @@ public class MessageController extends ControllerBase
 		return createOkResponse(user, messages, pagedResourcesAssembler);
 	}
 
-	@RequestMapping(value = "/{messageId}", method = RequestMethod.GET)
+	@GetMapping(value = "/{messageId}")
 	@ResponseBody
 	public HttpEntity<MessageDto> getMessage(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable long messageId)
@@ -145,7 +147,7 @@ public class MessageController extends ControllerBase
 		return createOkResponse(messages, pagedResourcesAssembler, createResourceAssembler(createGoalIdMapping(user)));
 	}
 
-	@RequestMapping(value = "/{id}/{action}", method = RequestMethod.POST)
+	@PostMapping(value = "/{id}/{action}")
 	@ResponseBody
 	public HttpEntity<MessageActionResource> handleAnonymousMessageAction(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId, @PathVariable long id,
@@ -161,7 +163,7 @@ public class MessageController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{messageId}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{messageId}")
 	@ResponseBody
 	public HttpEntity<MessageActionResource> deleteAnonymousMessage(
 			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,

--- a/appservice/src/main/java/nu/yona/server/rest/StandardResourcesController.java
+++ b/appservice/src/main/java/nu/yona/server/rest/StandardResourcesController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;

--- a/appservice/src/main/java/nu/yona/server/rest/StandardResourcesController.java
+++ b/appservice/src/main/java/nu/yona/server/rest/StandardResourcesController.java
@@ -13,8 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -33,7 +33,7 @@ public class StandardResourcesController
 	@Qualifier("otherTemplateEngine")
 	private TemplateEngine templateEngine;
 
-	@RequestMapping(value = "/.well-known/apple-app-site-association", method = RequestMethod.GET)
+	@GetMapping(value = "/.well-known/apple-app-site-association")
 	@ResponseBody
 	public ResponseEntity<byte[]> getAppleAppSiteAssociation()
 	{
@@ -44,14 +44,14 @@ public class StandardResourcesController
 				templateEngine.process("apple-app-site-association.json", ctx).getBytes(StandardCharsets.UTF_8), HttpStatus.OK);
 	}
 
-	@RequestMapping(value = "/ssl/rootcert.cer", method = RequestMethod.GET, produces = { "application/pkix-cert" })
+	@GetMapping(value = "/ssl/rootcert.cer", produces = { "application/pkix-cert" })
 	@ResponseBody
 	public FileSystemResource getSslRootCert()
 	{
 		return new FileSystemResource(yonaProperties.getSecurity().getSslRootCertFile());
 	}
 
-	@RequestMapping(value = "/vpn/profile.ovpn", method = RequestMethod.GET, produces = { "application/x-openvpn-profile" })
+	@GetMapping(value = "/vpn/profile.ovpn", produces = { "application/x-openvpn-profile" })
 	@ResponseBody
 	public FileSystemResource getOvpnProfile()
 	{

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/EmailTestController.java
@@ -11,8 +11,8 @@ import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import nu.yona.server.email.EmailService;
@@ -39,7 +39,7 @@ public class EmailTestController extends ControllerBase
 	 * @param userId The ID of the user. This is part of the URL.
 	 * @return the list of buddies for the current user
 	 */
-	@RequestMapping(value = "/last", method = RequestMethod.GET)
+	@GetMapping(value = "/last")
 	@ResponseBody
 	public HttpEntity<EmailResource> getLast()
 	{

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
@@ -21,11 +21,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -57,7 +59,7 @@ public class NewDeviceRequestController extends ControllerBase
 	@Autowired
 	private NewDeviceRequestService newDeviceRequestService;
 
-	@RequestMapping(value = "/{mobileNumber}", method = RequestMethod.PUT)
+	@PutMapping(value = "/{mobileNumber}")
 	@ResponseStatus(HttpStatus.OK)
 	public void setNewDeviceRequestForUser(@RequestHeader(value = Constants.PASSWORD_HEADER) String password,
 			@PathVariable String mobileNumber, @RequestBody NewDeviceRequestCreationDto newDeviceRequestCreation)
@@ -81,7 +83,7 @@ public class NewDeviceRequestController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{mobileNumber}", method = RequestMethod.GET)
+	@GetMapping(value = "/{mobileNumber}")
 	@ResponseBody
 	public HttpEntity<NewDeviceRequestResource> getNewDeviceRequestForUser(
 			@RequestHeader(value = Constants.NEW_DEVICE_REQUEST_PASSWORD_HEADER) Optional<String> newDeviceRequestPassword,
@@ -102,7 +104,7 @@ public class NewDeviceRequestController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{mobileNumber}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{mobileNumber}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.OK)
 	public void clearNewDeviceRequestForUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
@@ -112,7 +114,8 @@ public class NewDeviceRequestController extends ControllerBase
 		{
 			userService.assertValidMobileNumber(mobileNumber);
 			UUID userId = userService.getUserByMobileNumber(mobileNumber).getId();
-			try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+			try (CryptoSession cryptoSession = CryptoSession.start(password,
+					() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 			{
 				newDeviceRequestService.clearNewDeviceRequestForUser(userId);
 			}

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -22,10 +22,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import nu.yona.server.crypto.seckey.CryptoSession;
@@ -58,12 +58,13 @@ public class PinResetRequestController
 	@Autowired
 	private GlobalExceptionMapping globalExceptionMapping;
 
-	@RequestMapping(value = "/request", method = RequestMethod.POST)
+	@PostMapping(value = "/request")
 	@ResponseBody
 	public ResponseEntity<ConfirmationCodeDelayDto> requestPinReset(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			pinResetRequestService.requestPinReset(userId);
 			return new ResponseEntity<>(
@@ -72,13 +73,14 @@ public class PinResetRequestController
 		}
 	}
 
-	@RequestMapping(value = "/verify", method = RequestMethod.POST)
+	@PostMapping(value = "/verify")
 	@ResponseBody
 	public ResponseEntity<Void> verifyPinResetConfirmationCode(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
 			@RequestBody ConfirmationCodeDto confirmationCode)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 
 			pinResetRequestService.verifyPinResetConfirmationCode(userId, confirmationCode.getCode());
@@ -86,24 +88,26 @@ public class PinResetRequestController
 		}
 	}
 
-	@RequestMapping(value = "/resend", method = RequestMethod.POST)
+	@PostMapping(value = "/resend")
 	@ResponseBody
 	public ResponseEntity<Void> resendPinResetConfirmationCode(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			pinResetRequestService.resendPinResetConfirmationCode(userId);
 			return new ResponseEntity<>(HttpStatus.OK);
 		}
 	}
 
-	@RequestMapping(value = "/clear", method = RequestMethod.POST)
+	@PostMapping(value = "/clear")
 	@ResponseBody
 	public ResponseEntity<Void> clearPinResetRequest(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			pinResetRequestService.clearPinResetRequest(userId);
 			return new ResponseEntity<>(HttpStatus.OK);

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -89,7 +89,7 @@ import nu.yona.server.util.Require;
 @RequestMapping(value = "/users", produces = { MediaType.APPLICATION_JSON_VALUE })
 public class UserController extends ControllerBase
 {
-	private static final String REQUESTING_USER_ID_PARAM = "requestingUserId";
+	public static final String REQUESTING_USER_ID_PARAM = "requestingUserId";
 	public static final String REQUESTING_DEVICE_ID_PARAM = "requestingDeviceId";
 	private static final String INCLUDE_PRIVATE_DATA_PARAM = "includePrivateData";
 	private static final String TEMP_PASSWORD_PARAM = "tempPassword";
@@ -548,14 +548,16 @@ public class UserController extends ControllerBase
 		private final CurieProvider curieProvider;
 		private static String sslRootCertificateCn; // YD-544
 		private UserResourceRepresentation representation;
+		private Optional<UUID> requestingUserId;
 		private Optional<UUID> requestingDeviceId;
 
 		public UserResource(CurieProvider curieProvider, UserResourceRepresentation representation, UserDto user,
-				Optional<UUID> requestingDeviceId)
+				Optional<UUID> requestingUserId, Optional<UUID> requestingDeviceId)
 		{
 			super(user);
 			this.curieProvider = curieProvider;
 			this.representation = representation;
+			this.requestingUserId = requestingUserId;
 			this.requestingDeviceId = requestingDeviceId;
 		}
 
@@ -590,7 +592,7 @@ public class UserController extends ControllerBase
 
 				Optional<Set<GoalDto>> goals = getContent().getPrivateData().getGoals();
 				goals.ifPresent(g -> result.put(curieProvider.getNamespacedRelFor(UserDto.GOALS_REL_NAME),
-						GoalController.createAllGoalsCollectionResource(userId, g)));
+						GoalController.createAllGoalsCollectionResource(requestingUserId.orElse(userId), userId, g)));
 			}
 			if (representation.includeOwnUserNumConfirmedContent.apply(getContent()))
 			{
@@ -743,7 +745,7 @@ public class UserController extends ControllerBase
 		@Override
 		protected UserResource instantiateResource(UserDto user)
 		{
-			return new UserResource(curieProvider, representation, user, requestingDeviceId);
+			return new UserResource(curieProvider, representation, user, requestingUserId, requestingDeviceId);
 		}
 
 		private void addSelfLink(Resource<UserDto> userResource)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -37,12 +37,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -132,7 +135,7 @@ public class UserController extends ControllerBase
 	@Qualifier("sslRootCertificate")
 	private X509Certificate sslRootCertificate; // YD-544
 
-	@RequestMapping(value = "/{userId}", method = RequestMethod.GET)
+	@GetMapping(value = "/{userId}")
 	@ResponseBody
 	public HttpEntity<UserResource> getUser(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = TEMP_PASSWORD_PARAM, required = false) String tempPasswordStr,
@@ -211,7 +214,7 @@ public class UserController extends ControllerBase
 		return createOkResponse(userService.getPublicUser(userId), createResourceAssemblerForPublicUser());
 	}
 
-	@RequestMapping(value = "/", method = RequestMethod.POST)
+	@PostMapping(value = "/")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.CREATED)
 	public HttpEntity<UserResource> addUser(
@@ -258,7 +261,7 @@ public class UserController extends ControllerBase
 				deviceRegistration.map(UserDeviceDto::createDeviceRegistrationInstance));
 	}
 
-	@RequestMapping(value = "/{userId}", method = RequestMethod.PUT)
+	@PutMapping(value = "/{userId}")
 	@ResponseBody
 	public HttpEntity<UserResource> updateUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = TEMP_PASSWORD_PARAM, required = false) String tempPasswordStr, @PathVariable UUID userId,
@@ -321,7 +324,7 @@ public class UserController extends ControllerBase
 				createResourceAssemblerForOwnUser(userId, Optional.of(requestingDeviceId)));
 	}
 
-	@RequestMapping(value = "/{userId}", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/{userId}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.OK)
 	public void deleteUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -334,7 +337,7 @@ public class UserController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{userId}/confirmMobileNumber", method = RequestMethod.POST)
+	@PostMapping(value = "/{userId}/confirmMobileNumber")
 	@ResponseBody
 	public HttpEntity<UserResource> confirmMobileNumber(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
@@ -349,7 +352,7 @@ public class UserController extends ControllerBase
 		}
 	}
 
-	@RequestMapping(value = "/{userId}/resendMobileNumberConfirmationCode", method = RequestMethod.POST)
+	@PostMapping(value = "/{userId}/resendMobileNumberConfirmationCode")
 	@ResponseBody
 	public ResponseEntity<Void> resendMobileNumberConfirmationCode(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
@@ -26,11 +26,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -63,20 +65,21 @@ public class UserPhotoController extends ControllerBase
 	@Autowired
 	private GlobalExceptionMapping globalExceptionMapping;
 
-	@RequestMapping(value = "/userPhotos/{userPhotoId}", method = RequestMethod.GET, produces = { MediaType.IMAGE_PNG_VALUE })
+	@GetMapping(value = "/userPhotos/{userPhotoId}", produces = { MediaType.IMAGE_PNG_VALUE })
 	@ResponseBody
 	public ResponseEntity<byte[]> getUserPhoto(@PathVariable UUID userPhotoId)
 	{
 		return new ResponseEntity<>(userPhotoService.getUserPhoto(userPhotoId).getPngBytes(), HttpStatus.OK);
 	}
 
-	@RequestMapping(value = "/users/{userId}/photo", method = RequestMethod.PUT, consumes = "multipart/form-data")
+	@PutMapping(value = "/users/{userId}/photo", consumes = "multipart/form-data")
 	@ResponseBody
 	public ResponseEntity<UserPhotoResource> uploadUserPhoto(
 			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = "file", required = false) MultipartFile userPhoto, @PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			return createOkResponse(userPhotoService.addUserPhoto(userId, UserPhotoDto.createInstance(getPngBytes(userPhoto))),
 					new UserPhotoResourceAssembler());
@@ -91,12 +94,13 @@ public class UserPhotoController extends ControllerBase
 		return globalExceptionMapping.handleOtherException(exception, request);
 	}
 
-	@RequestMapping(value = "/users/{userId}/photo", method = RequestMethod.DELETE)
+	@DeleteMapping(value = "/users/{userId}/photo")
 	@ResponseStatus(HttpStatus.OK)
 	public void removeUserPhoto(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId)
 	{
-		try (CryptoSession cryptoSession = CryptoSession.start(password, () -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
+		try (CryptoSession cryptoSession = CryptoSession.start(password,
+				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
 		{
 			userPhotoService.removeUserPhoto(userId);
 		}

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/JobController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/JobController.java
@@ -19,10 +19,12 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -36,14 +38,14 @@ public class JobController extends ControllerBase
 	@Autowired
 	private JobManagementService jobManagementService;
 
-	@RequestMapping(value = "/", method = RequestMethod.GET)
+	@GetMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<Resources<JobResource>> getAllJobs()
 	{
 		return createOkResponse(jobManagementService.getAllJobs(), createResourceAssembler(), getAllJobsLinkBuilder());
 	}
 
-	@RequestMapping(value = "/{group}/", method = RequestMethod.GET)
+	@GetMapping(value = "/{group}/")
 	@ResponseBody
 	public HttpEntity<Resources<JobResource>> getJobsInGroup(@PathVariable String group)
 	{
@@ -51,7 +53,7 @@ public class JobController extends ControllerBase
 				getJobsInGroupLinkBuilder(group));
 	}
 
-	@RequestMapping(value = "/{group}/", method = RequestMethod.PUT)
+	@PutMapping(value = "/{group}/")
 	@ResponseBody
 	public HttpEntity<Resources<JobResource>> updateJobGroup(@PathVariable String group, @RequestBody Set<JobDto> jobs)
 	{
@@ -59,7 +61,7 @@ public class JobController extends ControllerBase
 				getJobsInGroupLinkBuilder(group));
 	}
 
-	@RequestMapping(value = "/{group}/{name}", method = RequestMethod.GET)
+	@GetMapping(value = "/{group}/{name}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.OK)
 	public JobResource getJob(@PathVariable String group, @PathVariable String name)
@@ -67,7 +69,7 @@ public class JobController extends ControllerBase
 		return new JobResourceAssembler().toResource(jobManagementService.getJob(name, group));
 	}
 
-	@RequestMapping(value = "/{group}/", method = RequestMethod.POST)
+	@PostMapping(value = "/{group}/")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.CREATED)
 	public JobResource addJob(@PathVariable String group, @RequestBody JobDto job)

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/JobController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/JobController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.quartz;

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerController.java
@@ -19,10 +19,12 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
@@ -36,7 +38,7 @@ public class TriggerController extends ControllerBase
 	@Autowired
 	private TriggerManagementService triggerManagementService;
 
-	@RequestMapping(value = "/cron/", method = RequestMethod.GET)
+	@GetMapping(value = "/cron/")
 	@ResponseBody
 	public HttpEntity<Resources<TriggerResource>> getAllTriggers()
 	{
@@ -44,7 +46,7 @@ public class TriggerController extends ControllerBase
 				getAllTriggersLinkBuilder());
 	}
 
-	@RequestMapping(value = "/cron/{group}/", method = RequestMethod.GET)
+	@GetMapping(value = "/cron/{group}/")
 	@ResponseBody
 	public HttpEntity<Resources<TriggerResource>> getTriggersInGroup(@PathVariable String group)
 	{
@@ -52,7 +54,7 @@ public class TriggerController extends ControllerBase
 				getTriggersInGroupLinkBuilder(group));
 	}
 
-	@RequestMapping(value = "/cron/{group}/", method = RequestMethod.PUT)
+	@PutMapping(value = "/cron/{group}/")
 	@ResponseBody
 	public HttpEntity<Resources<TriggerResource>> updateTriggerGroup(@PathVariable String group,
 			@RequestBody Set<CronTriggerDto> triggers)
@@ -61,7 +63,7 @@ public class TriggerController extends ControllerBase
 				getTriggersInGroupLinkBuilder(group));
 	}
 
-	@RequestMapping(value = "/cron/{group}/{name}", method = RequestMethod.GET)
+	@GetMapping(value = "/cron/{group}/{name}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.OK)
 	public TriggerResource getTrigger(@PathVariable String group, @PathVariable String name)
@@ -69,7 +71,7 @@ public class TriggerController extends ControllerBase
 		return new TriggerResourceAssembler().toResource(triggerManagementService.getTrigger(name, group));
 	}
 
-	@RequestMapping(value = "/cron/{group}/", method = RequestMethod.POST)
+	@PostMapping(value = "/cron/{group}/")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.CREATED)
 	public TriggerResource addTrigger(@PathVariable String group, @RequestBody CronTriggerDto trigger)

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.quartz;

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerManagementService.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/TriggerManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.quartz;

--- a/batchservice/src/main/java/nu/yona/server/batch/rest/BatchTaskController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/rest/BatchTaskController.java
@@ -11,9 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import nu.yona.server.batch.client.PinResetConfirmationCodeSendRequestDto;
@@ -28,7 +28,7 @@ public class BatchTaskController
 	@Autowired
 	private BatchTaskService batchTaskService;
 
-	@RequestMapping(value = "/sendPinResetConfirmationCode/", method = RequestMethod.POST)
+	@PostMapping(value = "/sendPinResetConfirmationCode/")
 	@ResponseStatus(HttpStatus.OK)
 	public void requestPinResetConfirmationCode(
 			@RequestBody PinResetConfirmationCodeSendRequestDto pinResetConfirmationCodeSendRequest)
@@ -36,7 +36,7 @@ public class BatchTaskController
 		batchTaskService.requestPinResetConfirmationCode(pinResetConfirmationCodeSendRequest);
 	}
 
-	@RequestMapping(value = "/sendSystemMessage/", method = RequestMethod.POST)
+	@PostMapping(value = "/sendSystemMessage/")
 	@ResponseStatus(HttpStatus.OK)
 	public void sendSystemMessage(@RequestBody SystemMessageSendRequestDto systemMessageSendRequest)
 	{
@@ -44,7 +44,7 @@ public class BatchTaskController
 	}
 
 	// NOTICE: For integration test purposes. It executes the job synchronously.
-	@RequestMapping(value = "/aggregateActivities/", method = RequestMethod.POST)
+	@PostMapping(value = "/aggregateActivities/")
 	public HttpEntity<Resource<BatchJobResultDto>> aggregateActivities()
 	{
 		return new ResponseEntity<>(new Resource<>(batchTaskService.aggregateActivities()), HttpStatus.OK);

--- a/batchservice/src/main/java/nu/yona/server/batch/rest/BatchTaskController.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/rest/BatchTaskController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.rest;

--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;

--- a/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/ActivityService.java
@@ -102,16 +102,15 @@ public class ActivityService
 	}
 
 	@Transactional
-	public Page<WeekActivityOverviewDto> getBuddyWeekActivityOverviews(UUID buddyId, Pageable pageable)
+	public Page<WeekActivityOverviewDto> getBuddyWeekActivityOverviews(BuddyDto buddy, Pageable pageable)
 	{
-		return executeAndCreateInactivityEntries(
-				mia -> getWeekActivityOverviews(getBuddyUserAnonymizedId(buddyId), pageable, mia));
+		return executeAndCreateInactivityEntries(mia -> getWeekActivityOverviews(getBuddyUserAnonymizedId(buddy), pageable, mia));
 	}
 
 	@Transactional
-	public WeekActivityOverviewDto getBuddyWeekActivityOverview(UUID buddyId, LocalDate date)
+	public WeekActivityOverviewDto getBuddyWeekActivityOverview(BuddyDto buddy, LocalDate date)
 	{
-		return executeAndCreateInactivityEntries(mia -> getWeekActivityOverview(getBuddyUserAnonymizedId(buddyId), date, mia));
+		return executeAndCreateInactivityEntries(mia -> getWeekActivityOverview(getBuddyUserAnonymizedId(buddy), date, mia));
 	}
 
 	private <T> T executeAndCreateInactivityEntries(Function<Set<IntervalInactivityDto>, T> executor)
@@ -319,21 +318,15 @@ public class ActivityService
 	}
 
 	@Transactional
-	public Page<DayActivityOverviewDto<DayActivityDto>> getBuddyDayActivityOverviews(UUID buddyId, Pageable pageable)
+	public Page<DayActivityOverviewDto<DayActivityDto>> getBuddyDayActivityOverviews(BuddyDto buddy, Pageable pageable)
 	{
-		return executeAndCreateInactivityEntries(
-				mia -> getDayActivityOverviews(getBuddyUserAnonymizedId(buddyId), pageable, mia));
+		return executeAndCreateInactivityEntries(mia -> getDayActivityOverviews(getBuddyUserAnonymizedId(buddy), pageable, mia));
 	}
 
 	@Transactional
-	public DayActivityOverviewDto<DayActivityDto> getBuddyDayActivityOverview(UUID buddyId, LocalDate date)
+	public DayActivityOverviewDto<DayActivityDto> getBuddyDayActivityOverview(BuddyDto buddy, LocalDate date)
 	{
-		return executeAndCreateInactivityEntries(mia -> getDayActivityOverview(getBuddyUserAnonymizedId(buddyId), date, mia));
-	}
-
-	private UUID getBuddyUserAnonymizedId(UUID buddyId)
-	{
-		return getBuddyUserAnonymizedId(buddyService.getBuddy(buddyId));
+		return executeAndCreateInactivityEntries(mia -> getDayActivityOverview(getBuddyUserAnonymizedId(buddy), date, mia));
 	}
 
 	private UUID getBuddyUserAnonymizedId(BuddyDto buddy)
@@ -538,9 +531,8 @@ public class ActivityService
 	}
 
 	@Transactional
-	public WeekActivityDto getBuddyWeekActivityDetail(UUID buddyId, LocalDate date, UUID goalId)
+	public WeekActivityDto getBuddyWeekActivityDetail(BuddyDto buddy, LocalDate date, UUID goalId)
 	{
-		BuddyDto buddy = buddyService.getBuddy(buddyId);
 		return executeAndCreateInactivityEntries(
 				mia -> getWeekActivityDetail(buddy.getUser().getId(), getBuddyUserAnonymizedId(buddy), date, goalId, mia));
 	}
@@ -572,10 +564,9 @@ public class ActivityService
 	}
 
 	@Transactional
-	public Page<MessageDto> getBuddyWeekActivityDetailMessages(UUID userId, UUID buddyId, LocalDate date, UUID goalId,
+	public Page<MessageDto> getBuddyWeekActivityDetailMessages(UUID userId, BuddyDto buddy, LocalDate date, UUID goalId,
 			Pageable pageable)
 	{
-		BuddyDto buddy = buddyService.getBuddy(buddyId);
 		Supplier<IntervalActivity> activitySupplier = () -> weekActivityRepository.findOne(getBuddyUserAnonymizedId(buddy), date,
 				goalId);
 		return getActivityDetailMessages(userId, activitySupplier, pageable);
@@ -589,9 +580,8 @@ public class ActivityService
 	}
 
 	@Transactional
-	public DayActivityDto getBuddyDayActivityDetail(UUID buddyId, LocalDate date, UUID goalId)
+	public DayActivityDto getBuddyDayActivityDetail(BuddyDto buddy, LocalDate date, UUID goalId)
 	{
-		BuddyDto buddy = buddyService.getBuddy(buddyId);
 		return executeAndCreateInactivityEntries(
 				mia -> getDayActivityDetail(buddy.getUser().getId(), getBuddyUserAnonymizedId(buddy), date, goalId, mia));
 	}
@@ -619,10 +609,9 @@ public class ActivityService
 	}
 
 	@Transactional
-	public Page<MessageDto> getBuddyDayActivityDetailMessages(UUID userId, UUID buddyId, LocalDate date, UUID goalId,
+	public Page<MessageDto> getBuddyDayActivityDetailMessages(UUID userId, BuddyDto buddy, LocalDate date, UUID goalId,
 			Pageable pageable)
 	{
-		BuddyDto buddy = buddyService.getBuddy(buddyId);
 		Supplier<IntervalActivity> activitySupplier = () -> dayActivityRepository.findOne(getBuddyUserAnonymizedId(buddy), date,
 				goalId);
 		return getActivityDetailMessages(userId, activitySupplier, pageable);

--- a/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.entities;

--- a/core/src/main/java/nu/yona/server/rest/HibernateStatisticsController.java
+++ b/core/src/main/java/nu/yona/server/rest/HibernateStatisticsController.java
@@ -11,8 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -29,7 +30,7 @@ public class HibernateStatisticsController extends ControllerBase
 	@Autowired
 	private HibernateStatisticsService hibernateStatisticsService;
 
-	@RequestMapping(value = "/enable/", params = { "enable" }, method = RequestMethod.POST)
+	@PostMapping(value = "/enable/", params = { "enable" })
 	@ResponseBody
 	public ResponseEntity<Void> enable(@RequestParam(value = "enable", defaultValue = "false") String enableStr)
 	{
@@ -43,7 +44,7 @@ public class HibernateStatisticsController extends ControllerBase
 		return createOkResponse();
 	}
 
-	@RequestMapping(value = "/", params = { "reset" }, method = RequestMethod.GET)
+	@GetMapping(value = "/", params = { "reset" })
 	@ResponseBody
 	public ResponseEntity<StatisticsResource> getStatistics(
 			@RequestParam(value = "reset", defaultValue = "false") String resetStr)
@@ -62,7 +63,7 @@ public class HibernateStatisticsController extends ControllerBase
 		return responseEntity;
 	}
 
-	@RequestMapping(value = "/clearCaches/", method = RequestMethod.POST)
+	@PostMapping(value = "/clearCaches/")
 	@ResponseBody
 	public ResponseEntity<Void> clearCaches()
 	{

--- a/core/src/main/java/nu/yona/server/rest/HibernateStatisticsController.java
+++ b/core/src/main/java/nu/yona/server/rest/HibernateStatisticsController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyInfoChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyInfoChangeMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/GoalIdMapping.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/GoalIdMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/GoalIdMapping.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/GoalIdMapping.java
@@ -18,12 +18,15 @@ public class GoalIdMapping
 	private final UserDto user;
 	private final Set<UUID> userGoalIds;
 	private final Map<UUID, UUID> goalIdToBuddyIdmapping;
+	private final Map<UUID, UUID> buddyIdToUserIdmapping;
 
-	private GoalIdMapping(UserDto user, Set<UUID> userGoalIds, Map<UUID, UUID> goalIdToBuddyIdmapping)
+	private GoalIdMapping(UserDto user, Set<UUID> userGoalIds, Map<UUID, UUID> goalIdToBuddyIdmapping,
+			Map<UUID, UUID> buddyIdToUserIdmapping)
 	{
 		this.user = user;
 		this.userGoalIds = userGoalIds;
 		this.goalIdToBuddyIdmapping = goalIdToBuddyIdmapping;
+		this.buddyIdToUserIdmapping = buddyIdToUserIdmapping;
 	}
 
 	public UserDto getUser()
@@ -34,6 +37,16 @@ public class GoalIdMapping
 	public UUID getUserId()
 	{
 		return user.getId();
+	}
+
+	public UUID getBuddyUserId(UUID buddyId)
+	{
+		UUID uuid = buddyIdToUserIdmapping.get(buddyId);
+		if (uuid == null)
+		{
+			throw new IllegalArgumentException("Buddy " + buddyId + " not found");
+		}
+		return uuid;
 	}
 
 	public boolean isUserGoal(UUID goalId)
@@ -58,6 +71,8 @@ public class GoalIdMapping
 		Map<UUID, UUID> goalIdToBuddyIdmapping = new HashMap<>();
 		user.getOwnPrivateData().getBuddies().forEach(b -> b.getGoals().orElse(Collections.emptySet())
 				.forEach(g -> goalIdToBuddyIdmapping.put(g.getGoalId(), b.getId())));
-		return new GoalIdMapping(user, userGoalIds, goalIdToBuddyIdmapping);
+		Map<UUID, UUID> buddyIdToUserIdmapping = new HashMap<>();
+		user.getOwnPrivateData().getBuddies().forEach(b -> buddyIdToUserIdmapping.put(b.getId(), b.getUser().getId()));
+		return new GoalIdMapping(user, userGoalIds, goalIdToBuddyIdmapping, buddyIdToUserIdmapping);
 	}
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/java/nu/yona/server/subscriptions/service/VPNProfileDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/VPNProfileDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;

--- a/core/src/main/java/nu/yona/server/util/HibernateStatisticsService.java
+++ b/core/src/main/java/nu/yona/server/util/HibernateStatisticsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.util;

--- a/core/src/main/java/nu/yona/server/util/TimeUtil.java
+++ b/core/src/main/java/nu/yona/server/util/TimeUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.util;

--- a/core/src/main/resources/templates/email/messages.properties
+++ b/core/src/main/resources/templates/email/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Stichting Yona Foundation
+# Copyright (c) 2017, 2018 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/core/src/main/resources/templates/email/messages_nl.properties
+++ b/core/src/main/resources/templates/email/messages_nl.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Stichting Yona Foundation
+# Copyright (c) 2017, 2018 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -381,7 +381,7 @@ class AppService extends Service
 	}
 
 	def getDayDetails(User user, String activityCategoryUrl, ZonedDateTime date) {
-		def goal = user.findActiveGoal(activityCategoryUrl)
+		Goal goal = user.findActiveGoal(activityCategoryUrl)
 		def url = YonaServer.stripQueryString(user.url) + "/activity/days/" + YonaServer.toIsoDateString(date) + "/details/" + goal.getId()
 		getResourceWithPassword(url, user.password)
 	}

--- a/core/src/testUtils/groovy/nu/yona/server/test/Goal.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Goal.groovy
@@ -22,7 +22,7 @@ abstract class Goal
 	{
 		this.creationTime = (json.creationTime instanceof ZonedDateTime) ? json.creationTime : null // Only set the creation time when explicitly provided
 		this.activityCategoryUrl = (json.activityCategoryUrl) ?: json._links."yona:activityCategory".href
-		this.url = json._links ? YonaServer.stripQueryString(json._links.self.href) : null
+		this.url = json._links ? json._links.self.href : null
 		this.editUrl = json._links?.edit?.href
 		this.historyItem = json.historyItem
 	}
@@ -31,7 +31,7 @@ abstract class Goal
 
 	def getId()
 	{
-		url[-36..-1]
+		YonaServer.stripQueryString(url)[-36..-1]
 	}
 
 	static def fromJson(def json)

--- a/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
@@ -158,7 +158,7 @@ class User
 		return url[queryStringStart-36..queryStringStart-1]
 	}
 
-	def findActiveGoal(def activityCategoryUrl)
+	Goal findActiveGoal(def activityCategoryUrl)
 	{
 		goals.find{ it.activityCategoryUrl == activityCategoryUrl && !it.historyItem }
 	}

--- a/core/src/testUtils/logging.properties
+++ b/core/src/testUtils/logging.properties
@@ -1,3 +1,10 @@
+###############################################################################
+# Copyright (c) 2019 Stichting Yona Foundation
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+###############################################################################
 handlers= java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/dbinit/src/main/docker/update.sh
+++ b/dbinit/src/main/docker/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2017 Stichting Yona Foundation
+# Copyright (c) 2017, 2018 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
The link to a buddy goal now always refers to "/users/\<user ID of buddy>/goals/\<goal ID>?requestingUserId=\<ID of requesting user>"

This is done to correct the issue that the goal URL in an activity didn't match the goal URL in a buddy, and also in preparation to removing the goals from the buddy entity.