### PR TITLE
YD-616 Extended test to verify buddy goals loading error

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -240,6 +240,12 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		Buddy[] buddiesBob = appService.getBuddies(bob)
 
 		then:
+		def getBuddyUserGoalsResponse = appService.yonaServer.getResource(richard.buddies[0].user.goalsUrl, ["Yona-Password": richard.password])
+		assertResponseStatusOk(getBuddyUserGoalsResponse)
+		getBuddyUserGoalsResponse.responseData._embedded."yona:goals".size() == 2
+
+		richard.buddies[0].user.goalsUrl == richard.buddies[0].goalsUrl // YD-505
+
 		buddiesRichard[0].goals.size() == 2 // YD-505
 		buddiesRichard[0].user.goals.size() == 2
 		buddiesRichard[0].user.devices.size() == 1

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -989,47 +989,6 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
-  '/users/{userID}/buddies/{buddyID}/goals/':
-    get:
-      summary: Get all goals
-      description: Fetches all goals of the buddy with the given ID
-      parameters:
-        - $ref: "#/parameters/yonaPassword"
-        - $ref: "#/parameters/userID"
-        - $ref: "#/parameters/buddyID"
-      tags:
-        - Buddy
-      responses:
-        '200':
-          description: All goals of this user.
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Goal'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
-  '/users/{userID}/buddies/{buddyID}/goals/{goalID}':
-    get:
-      summary: Get a goal
-      description: Fetches the goal identified by the given ID
-      parameters:
-        - $ref: "#/parameters/yonaPassword"
-        - $ref: "#/parameters/userID"
-        - $ref: "#/parameters/buddyID"
-        - $ref: "#/parameters/goalID"
-      tags:
-        - Buddy
-      responses:
-        '200':
-          description: The requested goal.
-          schema:
-            $ref: '#/definitions/Goal'
-        default:
-          description: Unexpected error
-          schema:
-            $ref: '#/definitions/Error'
   '/users/{userID}/buddies/{buddyID}/activity/days/{date}/details/{goalID}':
     get:
       summary: Get day activity detail

--- a/core/src/testUtils/groovy/nu/yona/server/test/Buddy.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Buddy.groovy
@@ -23,6 +23,7 @@ class Buddy
 	final User user
 	final List<Goal> goals
 	final String url
+	final String goalsUrl
 	final String dailyActivityReportsUrl
 	final String weeklyActivityReportsUrl
 	final String editUrl
@@ -37,6 +38,7 @@ class Buddy
 		{
 			this.user = new User(json._embedded."yona:user")
 		}
+		this.goalsUrl = json._embedded?."yona:goals"?._links?.self?.href
 		this.goals = (json._embedded?."yona:goals"?._embedded?."yona:goals") ? json._embedded."yona:goals"._embedded."yona:goals".collect{Goal.fromJson(it)} : null
 		this.url = YonaServer.stripQueryString(json._links.self.href)
 		this.dailyActivityReportsUrl = json._links?."yona:dailyActivityReports"?.href


### PR DESCRIPTION
* The test now verifies that the goals link is loadable and identical on the user embedded in the buddy and the one in the buddy
* Removed the paths from the swagger-spec.yaml that were already removed from the server code