### PR TITLE
YD-617 Warn when less than 100 users can still join

### DIFF
--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserService.java
@@ -402,7 +402,7 @@ public class UserService
 		int maxUsers = yonaProperties.getMaxUsers();
 		long currentNumberOfUsers = userRepository.count();
 		Require.that(currentNumberOfUsers < maxUsers, UserServiceException::maximumNumberOfUsersReached);
-		if (currentNumberOfUsers >= maxUsers - maxUsers / 10)
+		if (currentNumberOfUsers >= maxUsers - 100)
 		{
 			logger.warn("Nearing the maximum number of users. Current number: {}, maximum: {}", currentNumberOfUsers, maxUsers);
 		}


### PR DESCRIPTION
Instead of "less than 10% of the current maximum number of users"