### PR TITLE
YD-603 Upgrade to Spring Boot 2.1.2

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -114,7 +114,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def response = appService.yonaServer.restClient.put(path: richard.editUserPhotoUrl, requestContentType :"multipart/form-data", headers: ["Yona-Password": richard.password], body: multipartEntity)
 
 		then:
-		assertResponseStatus(response, 400)
+		assertResponseStatus(response, 413)
 		response.responseData.code == null // As the app should take care for uploading a resized photo, this is not a user error, so it does not need to have a code
 
 		cleanup:

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 	id "eclipse"
 	id "groovy"
 	id "io.spring.dependency-management" version "1.0.6.RELEASE"
-	id "org.springframework.boot" version "2.0.4.RELEASE" apply false
+	id "org.springframework.boot" version "2.1.2.RELEASE" apply false
 	id "net.researchgate.release" version "2.6.0"
 	id "com.bmuschko.docker-remote-api" version "3.6.1" apply false
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compile "org.springframework.boot:spring-boot-starter-data-jpa"
 	compile "org.springframework.boot:spring-boot-starter-web"
 	compile "org.springframework.boot:spring-boot-starter-actuator"
-	compile "org.springframework.cloud:spring-cloud-starter-sleuth:2.0.1.RELEASE"
+	compile "org.springframework.cloud:spring-cloud-starter-sleuth:2.1.0.RELEASE"
 	compile "org.springframework.metrics:spring-metrics:0.5.1.RELEASE"
 	compile "io.micrometer:micrometer-registry-prometheus:1.0.6"
 	compile "org.springframework:spring-context-support"

--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
@@ -7,7 +7,9 @@ package nu.yona.server;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
@@ -34,6 +36,7 @@ import nu.yona.server.rest.RestClientErrorHandler;
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 @EnableSpringDataWebSupport
 @Configuration
+@EnableAutoConfiguration(exclude = { LdapAutoConfiguration.class })
 public class CoreConfiguration
 {
 	@Autowired

--- a/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
+++ b/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import nu.yona.server.Translator;
 import nu.yona.server.exceptions.YonaException;
@@ -129,6 +130,21 @@ public class GlobalExceptionMapping
 			HttpServletRequest request)
 	{
 		return logUnhandledExceptionAndCreateErrorDto("does not accept our supported media types", exception, request);
+	}
+
+	/**
+	 * Maximum upload size exceeded. Such requests result in a 413 (Payload Too Large).
+	 * 
+	 * @param exception The exception.
+	 * @return The response object to return.
+	 */
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	@ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+	@ResponseBody
+	public ErrorResponseDto handleMaxUploadSizeExceededException(MaxUploadSizeExceededException exception,
+			HttpServletRequest request)
+	{
+		return logUnhandledExceptionAndCreateErrorDto("exceeds the maximum request size", exception, request);
 	}
 
 	private ErrorResponseDto logUnhandledExceptionAndCreateErrorDto(String message, Exception exception,


### PR DESCRIPTION
This includes an upgrade to Spring Cloud 2.1.0

Two changes were needed to make everything work again:
* Add an exception mapping for "Payload Too Large" (we now return the appropriate HTTP status: 413)
* Spring Boot autoconfigured an in-memory LDAP when LDAP is disabled through the Yona settings. This autoconfiguration is disabled.