### PR TITLE
YD-626 Prevent 500 in invalid date in URL

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/service/DayActivityDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/DayActivityDto.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
@@ -7,6 +7,7 @@ package nu.yona.server.analysis.service;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import nu.yona.server.analysis.entities.DayActivity;
 import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.entities.EntityUtil;
+import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.entities.TimeZoneGoal;
 import nu.yona.server.goals.service.GoalDto;
@@ -78,7 +80,14 @@ public class DayActivityDto extends IntervalActivityDto
 
 	public static LocalDate parseDate(String iso8601)
 	{
-		return LocalDate.parse(iso8601, ISO8601_DAY_FORMATTER);
+		try
+		{
+			return LocalDate.parse(iso8601, ISO8601_DAY_FORMATTER);
+		}
+		catch (DateTimeParseException e)
+		{
+			throw InvalidDataException.invalidDate(e, iso8601);
+		}
 	}
 
 	public static String formatDate(LocalDate date)

--- a/core/src/main/java/nu/yona/server/analysis/service/WeekActivityDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/WeekActivityDto.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
 
@@ -10,6 +10,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.IsoFields;
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import nu.yona.server.Translator;
 import nu.yona.server.analysis.entities.IntervalActivity;
 import nu.yona.server.analysis.entities.WeekActivity;
+import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
@@ -72,9 +74,17 @@ public class WeekActivityDto extends IntervalActivityDto
 
 	public static LocalDate parseDate(String iso8601)
 	{
-		// ISO treats Monday as first day of the week, so our formatter defaults the day as Monday and here we subtract one day to
-		// return the preceding Sunday.
-		return LocalDate.parse(iso8601, ISO8601_WEEK_FORMATTER).minusDays(1);
+		try
+		{
+			// ISO treats Monday as first day of the week, so our formatter defaults the day as Monday and here we subtract one
+			// day to
+			// return the preceding Sunday.
+			return LocalDate.parse(iso8601, ISO8601_WEEK_FORMATTER).minusDays(1);
+		}
+		catch (DateTimeParseException e)
+		{
+			throw InvalidDataException.invalidDate(e, iso8601);
+		}
 	}
 
 	public static String formatDate(LocalDate sundayDate)

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -1,10 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.exceptions;
 
 import java.io.Serializable;
+import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
 /**
@@ -18,6 +19,11 @@ public class InvalidDataException extends YonaException
 	private InvalidDataException(String messageId, Serializable... parameters)
 	{
 		super(messageId, parameters);
+	}
+
+	private InvalidDataException(Throwable t, String messageId, Serializable... parameters)
+	{
+		super(t, messageId, parameters);
 	}
 
 	public static InvalidDataException userAnonymizedIdNotFound(UUID id)
@@ -130,8 +136,13 @@ public class InvalidDataException extends YonaException
 		return new InvalidDataException("error.missing.entity", clazz.getName(), id);
 	}
 
-	public static InvalidDataException invalidUuid(String uuid)
+	public static InvalidDataException invalidUuid(IllegalArgumentException exception, String uuid)
 	{
-		return new InvalidDataException("error.invalid.uuid", uuid);
+		return new InvalidDataException(exception, "error.invalid.uuid", uuid);
+	}
+
+	public static InvalidDataException invalidDate(DateTimeParseException exception, String date)
+	{
+		return new InvalidDataException(exception, "error.invalid.date", date);
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/RestUtil.java
+++ b/core/src/main/java/nu/yona/server/rest/RestUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
@@ -29,9 +29,9 @@ public class RestUtil
 		{
 			return UUID.fromString(uuid);
 		}
-		catch (IllegalArgumentException ex)
+		catch (IllegalArgumentException e)
 		{
-			throw InvalidDataException.invalidUuid(uuid);
+			throw InvalidDataException.invalidUuid(e, uuid);
 		}
 	}
 }

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 Stichting Yona Foundation
+# Copyright (c) 2016, 2019 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,6 +24,7 @@ default.device.name=First device
 
 error.invalid.request=Invalid request
 error.invalid.uuid=String ''{0}'' is not a valid UUID
+error.invalid.date=String ''{0}'' is not a valid date
 error.from.remote.service=Error from another service. Status code: {0}, body: {1}
 
 error.user.firstname=The first name of the user must be set

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2018 Stichting Yona Foundation
+# Copyright (c) 2016, 2019 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,6 +24,7 @@ default.device.name=Eerste apparaat
 
 error.invalid.request=Fout request
 error.invalid.uuid=String ''{0}'' is geen geldig UUID
+error.invalid.date=String ''{0}'' is geen geldige datum
 error.from.remote.service=Fout van andere service. Status code: {0}, body: {1}
 
 error.user.firstname=De voornaam van de gebruiker moet worden ingevuld

--- a/core/src/test/java/nu/yona/server/analysis/service/DayActivityDtoTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/DayActivityDtoTest.java
@@ -6,10 +6,13 @@ package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
+
+import nu.yona.server.exceptions.InvalidDataException;
 
 public class DayActivityDtoTest
 {
@@ -19,6 +22,15 @@ public class DayActivityDtoTest
 		LocalDate parsedDate = DayActivityDto.parseDate("2016-01-11");
 
 		assertThat(parsedDate, equalTo(LocalDate.of(2016, 1, 11)));
+	}
+
+	@Test
+	public void parseDate_invalidDateFormat_throwsInvalidDataException()
+	{
+		InvalidDataException ex = assertThrows(InvalidDataException.class, () -> DayActivityDto.parseDate("2016-01-abc"));
+
+		assertThat(ex.getMessageId(), equalTo("error.invalid.date"));
+
 	}
 
 	@Test

--- a/core/src/test/java/nu/yona/server/analysis/service/WeekActivityDtoTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/WeekActivityDtoTest.java
@@ -13,6 +13,8 @@ import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
+import nu.yona.server.exceptions.InvalidDataException;
+
 public class WeekActivityDtoTest
 {
 	@Test
@@ -22,6 +24,15 @@ public class WeekActivityDtoTest
 
 		assertThat(parsedDate.getDayOfWeek(), equalTo(DayOfWeek.SUNDAY));
 		assertThat(parsedDate, equalTo(LocalDate.of(2016, 1, 10)));
+	}
+
+	@Test
+	public void parseDate_invalidDateFormat_throwsInvalidDataException()
+	{
+		InvalidDataException ex = assertThrows(InvalidDataException.class, () -> WeekActivityDto.parseDate("2016-Wabc"));
+
+		assertThat(ex.getMessageId(), equalTo("error.invalid.date"));
+
 	}
 
 	@Test


### PR DESCRIPTION
Added exception handling. Along with this improved the error logging for invalid UUIDs by including the cause exception.