### PR TITLE
YD-628 Upgraded to Liquibase Hibernate5 3.7

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2015, 2018 Stichting Yona Foundation
+# Copyright (c) 2015, 2019 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,7 +7,7 @@
 ###############################################################################
 
 # Hibernate
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.session.events.log=false
 # logging.level.org.hibernate.SQL=DEBUG

--- a/dbinit/liquibase.gradle
+++ b/dbinit/liquibase.gradle
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-	liquibase "org.liquibase.ext:liquibase-hibernate5:3.6"
+	liquibase "org.liquibase.ext:liquibase-hibernate5:3.7"
 }
 
 //loading properties file.
@@ -28,7 +28,7 @@ task liquibasePathingJar(type: Jar) {
 	appendix = 'pathing'
 	doFirst {
 		manifest {
-			attributes "Class-Path": configurations.runtime.files.collect {
+			attributes "Class-Path": (configurations.runtime.files + configurations.liquibase.files).collect {
 				it.toURL().toString().replaceFirst(/file:\/+/, '/')
 			}.join(' ')
 		}
@@ -68,10 +68,12 @@ task liquibaseDiffChangelog(type: JavaExec) {
 	group = "liquibase"
 	dependsOn liquibasePathingJar
 
+	workingDir = "${changeLogPath}"
+
 	classpath = files(liquibasePathingJar.archivePath)
 	main = "liquibase.integration.commandline.Main"
 
-	args "--changeLogFile=${changeLogPath}/updates/changelog-0000-yd-000.yml"
+	args "--changeLogFile=updates/changelog-0000-yd-000.yml"
 	args "--referenceUrl=${hibernateUrl}"
 	args "--url=${databaseUrl}"
 	args "--driver=${jdbcDriver}"

--- a/dbinit/src/main/liquibase/updates/changelog-0020-yd-628.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0020-yd-628.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+- changeSet:
+    id: 1556985544837-1
+    author: Bert (Manually created)
+    changes:
+    - modifyDataType:
+        tableName: goals
+        columnName: zones
+        newDataType: varchar(1152)
+    - modifyDataType:
+        tableName: message_sources
+        columnName: private_key_bytes
+        newDataType: varchar(1024)

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -59,3 +59,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0019-yd-597.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0020-yd-628.yml


### PR DESCRIPTION
Along with this:
* Switched the Hibernate dialect from MySQL to MariaDB
* Corrected two column types from longtext to the appropriate varchar length
* Corrected an issue in the Gradle task liquibasePathingJar: the dependencies for the liquibase configuration weren't included in the pathing JAR
* For uniformity, changed the working directory for the Gradle task liquibaseDiffChangelog to the same one as used for liquibaseUpdate