### PR TITLE
YD-630 Explicitly assert time measurement no-go goals

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1599,9 +1599,9 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		where:
 		operatingSystem | budget | expectedValue
 		"ANDROID" | 0 | [ 13 : 4]
-		"ANDROID" | 60 | [ : ]
+		"ANDROID" | 60 | [ : ] // We only track no-go goals on Android, as app activity monitoring provides much better measurements
 		"IOS" | 0 | [13 : 4]
-		"IOS" | 60 | [13 : 4]
+		"IOS" | 60 | [13 : 4] // App activity monitoring is not possible on iOS, so we also track budget goals
 	}
 
 	private def getRawActivityData(User user, relativeDate, goal) {

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1558,7 +1558,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		reportNetworkActivity(richard, ["social"], "http://www.facebook.com", "W-1 Mon 03:24")
 
 		def expectedGoalAccomplished = budget > 0
-		def expectedMinutesBeyondGoal = expectedGoalAccomplished ? 0 : expectedValue.size() == 0 ? 0 :  expectedValue.entrySet().iterator().next().value
+		def expectedMinutesBeyondGoal = expectedGoalAccomplished || expectedValue.size() == 0 ? 0 :  expectedValue.entrySet().iterator().next().value
 		def expectedValuesRichardLastWeek = [
 			"Mon" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: expectedGoalAccomplished, minutesBeyondGoal: expectedMinutesBeyondGoal, spread: expectedValue]]],
 			"Tue" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -1544,25 +1544,28 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richardDefault)
 	}
 
-	def 'Richard\'s \'non-no-go\' network activity is measured on iOS only'(def operatingSystem, def expectedValue)
+	def 'Richard\'s network activity is measured properly on different OSes and different budget goals'(def operatingSystem, def budget, def expectedValue)
 	{
 		given:
 		User richard = addRichard(false, operatingSystem)
 		setCreationTimeOfMandatoryGoalsToNow(richard)
-		addTimeZoneGoal(richard, SOCIAL_ACT_CAT_URL, ["01:00-12:00"], "W-1 Mon 02:18")
+		addBudgetGoal(richard, SOCIAL_ACT_CAT_URL, budget, "W-1 Mon 02:18")
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsWithPrivateDataIgnoreDefaultDevice)
-		Goal timeZoneGoalSocialRichard = richard.findActiveGoal(SOCIAL_ACT_CAT_URL)
+		BudgetGoal budgetGoalSocialRichard = richard.findActiveGoal(SOCIAL_ACT_CAT_URL)
 
 		// Activities on default device
 		reportNetworkActivity(richard, ["social"], "http://www.facebook.com", "W-1 Mon 03:20")
+		reportNetworkActivity(richard, ["social"], "http://www.facebook.com", "W-1 Mon 03:24")
 
+		def expectedGoalAccomplished = budget > 0
+		def expectedMinutesBeyondGoal = expectedGoalAccomplished ? 0 : expectedValue.size() == 0 ? 0 :  expectedValue.entrySet().iterator().next().value
 		def expectedValuesRichardLastWeek = [
-			"Mon" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: expectedValue]]],
-			"Tue" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
-			"Wed" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
-			"Thu" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
-			"Fri" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
-			"Sat" : [[goal:timeZoneGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]]]
+			"Mon" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: expectedGoalAccomplished, minutesBeyondGoal: expectedMinutesBeyondGoal, spread: expectedValue]]],
+			"Tue" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Wed" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Thu" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Fri" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]],
+			"Sat" : [[goal:budgetGoalSocialRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [ : ]]]]]
 
 		def currentDayOfWeek = YonaServer.getCurrentDayOfWeek()
 		def expectedTotalDays = 6 + currentDayOfWeek + 1
@@ -1579,24 +1582,26 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
 
-		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, timeZoneGoalSocialRichard, 6)
+		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalSocialRichard, 6)
 
-		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, "Mon")
+		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalSocialRichard, expectedValuesRichardLastWeek, "Mon")
 
-		assertWeekDetailForGoal(richard, weekOverviewLastWeek, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek)
+		assertWeekDetailForGoal(richard, weekOverviewLastWeek, budgetGoalSocialRichard, expectedValuesRichardLastWeek)
 
 		assertDayOverviewBasics(responseDayOverviewsAll, expectedTotalDays, expectedTotalDays, 14)
-		assertDayOverviewForTimeZoneGoal(responseDayOverviewsAll, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
+		assertDayOverviewForBudgetGoal(responseDayOverviewsAll, budgetGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
 
-		assertDayDetail(richard, responseDayOverviewsAll, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
+		assertDayDetail(richard, responseDayOverviewsAll, budgetGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
 
 		cleanup:
 		appService.deleteUser(richard)
 
 		where:
-		operatingSystem | expectedValue
-		"ANDROID" | [ : ]
-		"IOS" | [13 : 1]
+		operatingSystem | budget | expectedValue
+		"ANDROID" | 0 | [ 13 : 4]
+		"ANDROID" | 60 | [ : ]
+		"IOS" | 0 | [13 : 4]
+		"IOS" | 60 | [13 : 4]
 	}
 
 	private def getRawActivityData(User user, relativeDate, goal) {


### PR DESCRIPTION
Looking closer into the reported issue, I believe the current behavior is the best we can do. If a user defines a no-go goal, we would like to give an estimated size of the violation. The current time measurement approach is the best we have.

I've extended a test to explicitly assert the behavior for no-go goals too.