### PR TITLE
YD-637 Disconnect activities before delete device

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
@@ -11,6 +11,7 @@ import static nu.yona.server.test.CommonAssertions.*
 
 import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.Device
+import nu.yona.server.test.Goal
 import nu.yona.server.test.User
 
 class DeviceManagementTest extends AbstractAppServiceIntegrationTest
@@ -519,11 +520,23 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		given:
 		def ts = timestamp
 		User richardOnFirstDevice = addRichard()
+		setCreationTimeOfMandatoryGoalsToNow(richardOnFirstDevice)
 		setGoalCreationTime(richardOnFirstDevice, NEWS_ACT_CAT_URL, "W-1 Mon 02:18")
 		Device remainingDevice = richardOnFirstDevice.devices[0]
 		def deletedDeviceName = "Second device"
 		User richardOnSecondDevice = appService.addDevice(richardOnFirstDevice, deletedDeviceName, "ANDROID")
 		reportAppActivity(richardOnSecondDevice, "NU.nl", "W-1 Mon 03:15", "W-1 Mon 03:35")
+		Goal budgetGoalNewsRichard = richardOnFirstDevice.findActiveGoal(NEWS_ACT_CAT_URL)
+		def expectedValuesRichardLastWeek = [
+			"Mon" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: false, minutesBeyondGoal: 20, spread: [13 : 15, 14 : 5]]]],
+			"Tue" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]]],
+			"Wed" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]]],
+			"Thu" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]]],
+			"Fri" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]]],
+			"Sat" : [[goal:budgetGoalNewsRichard, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: []]]]]
+		def currentDayOfWeek = YonaServer.getCurrentDayOfWeek()
+		def expectedTotalDays = 6 + currentDayOfWeek + 1
+		def expectedTotalWeeks = 2
 
 		Device deviceToDelete = richardOnSecondDevice.devices.find{ YonaServer.stripQueryString(it.url) != YonaServer.stripQueryString(remainingDevice.url) }
 
@@ -537,6 +550,19 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		richardAfterReload.devices.size == 1
 		richardAfterReload.devices[0].name == remainingDevice.name
 		richardAfterReload.devices[0].operatingSystem == remainingDevice.operatingSystem
+
+		when:
+		def responseWeekOverviews = appService.getWeekActivityOverviews(richardOnFirstDevice)
+		//get all days at once (max 2 weeks) to make assertion easy
+		def responseDayOverviewsAll = appService.getDayActivityOverviews(richardOnFirstDevice, ["size": 14])
+
+		then:
+		assertWeekOverviewBasics(responseWeekOverviews, [2, 1], expectedTotalWeeks)
+
+		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalNewsRichard, 6)
+		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Mon")
+		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Tue")
 
 		cleanup:
 		appService.deleteUser(richardOnFirstDevice)

--- a/core/src/main/java/nu/yona/server/analysis/entities/Activity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/Activity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
@@ -137,7 +137,7 @@ public class Activity extends EntityWithId
 
 	public Optional<DeviceAnonymized> getDeviceAnonymized()
 	{
-		// Old activities do not have an associated device
+		// Old activities and activities for which the device was deleted do not have an associated device
 		return Optional.ofNullable(deviceAnonymized);
 	}
 

--- a/core/src/main/java/nu/yona/server/analysis/entities/ActivityRepository.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/ActivityRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -29,4 +30,8 @@ public interface ActivityRepository extends CrudRepository<Activity, Long>
 			@Param("app") String app, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
 	Set<Activity> findByDeviceAnonymized(DeviceAnonymized deviceAnonymized);
+
+	@Modifying
+	@Query("update Activity a set a.deviceAnonymized = null where a.deviceAnonymized.id = :deviceAnonymizedId")
+	void disconnectAllActivitiesFromDevice(@Param("deviceAnonymizedId") UUID deviceAnonymizedId);
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
@@ -105,6 +105,7 @@ public class DeviceService
 		UserDevice deviceEntity = userDeviceRepository.save(UserDevice.createInstance(userEntity, deviceDto.getName(),
 				deviceAnonymized.getId(), userService.generatePassword()));
 		userEntity.addDevice(deviceEntity);
+		userAnonymizedService.updateUserAnonymized(userEntity.getAnonymized().getId());
 
 		ldapUserService.createVpnAccount(buildVpnLoginId(userEntity.getAnonymized(), deviceEntity),
 				deviceEntity.getVpnPassword());
@@ -231,6 +232,7 @@ public class DeviceService
 			UUID deviceAnonymizedId = deviceEntity.getDeviceAnonymized().getId();
 
 			deleteDeviceWithoutBuddyNotification(userEntity, deviceEntity);
+			userAnonymizedService.updateUserAnonymized(userEntity.getAnonymized().getId());
 
 			sendDeviceChangeMessageToBuddies(DeviceChange.DELETE, userEntity, Optional.of(oldName), Optional.empty(),
 					deviceAnonymizedId);
@@ -246,6 +248,7 @@ public class DeviceService
 			throw DeviceServiceException.notFoundById(device.getId());
 		}
 		ldapUserService.deleteVpnAccount(buildVpnLoginId(userEntity.getAnonymized(), device));
+		activityRepository.disconnectAllActivitiesFromDevice(device.getDeviceAnonymizedId());
 
 		deviceAnonymizedRepository.delete(device.getDeviceAnonymized());
 		deviceAnonymizedRepository.flush(); // Without this, the delete doesn't always occur

--- a/core/src/test/java/nu/yona/server/entities/ActivityRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/ActivityRepositoryMock.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.entities;
 
@@ -31,8 +31,19 @@ public class ActivityRepositoryMock extends MockCrudRepositoryEntityWithId<Activ
 	@Override
 	public Set<Activity> findByDeviceAnonymized(DeviceAnonymized deviceAnonymized)
 	{
+		return findByDeviceAnonymized(deviceAnonymized.getId());
+	}
+
+	private Set<Activity> findByDeviceAnonymized(UUID deviceAnonymizedId)
+	{
 		return StreamSupport.stream(findAll().spliterator(), false)
-				.filter(a -> a.getDeviceAnonymized().map(DeviceAnonymized::getId).orElse(null) == deviceAnonymized.getId())
+				.filter(a -> a.getDeviceAnonymized().map(DeviceAnonymized::getId).orElse(null) == deviceAnonymizedId)
 				.collect(Collectors.toSet());
+	}
+
+	@Override
+	public void disconnectAllActivitiesFromDevice(UUID deviceAnonymizedId)
+	{
+		deleteAll(findByDeviceAnonymized(deviceAnonymizedId));
 	}
 }

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/AddFirstDeviceTest.java
@@ -64,6 +64,7 @@ import nu.yona.server.subscriptions.entities.User;
 import nu.yona.server.subscriptions.service.LDAPUserService;
 import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
 import nu.yona.server.subscriptions.service.UserAnonymizedDto;
+import nu.yona.server.subscriptions.service.UserAnonymizedService;
 import nu.yona.server.subscriptions.service.UserService;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.InCryptoSession;
@@ -129,6 +130,9 @@ public class AddFirstDeviceTest extends BaseSpringIntegrationTest
 
 	@MockBean
 	private UserService mockUserService;
+
+	@MockBean
+	private UserAnonymizedService mockUserAnonymizedService;
 
 	@MockBean
 	private LDAPUserService mockLdapUserService;


### PR DESCRIPTION
Activities have an optional reference to the device on which they occurred. If the user deletes the device, the device reference on the related activities is cleared, but the activities are retained.

Along with this fixed the issue that the cached user anonymized wasn't updated when a device was added or removed.