### PR TITLE
YD-639 Allow Firebase ID on user registration

### DIFF
--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -256,7 +256,8 @@ public class UserController extends ControllerBase
 	{
 		Optional<DeviceRegistrationRequestDto> deviceRegistration = postPutUser.deviceName == null ? Optional.empty()
 				: Optional.of(new DeviceRegistrationRequestDto(postPutUser.deviceName, postPutUser.deviceOperatingSystemStr,
-						postPutUser.deviceAppVersion, postPutUser.deviceAppVersionCode, Optional.empty()));
+						postPutUser.deviceAppVersion, postPutUser.deviceAppVersionCode,
+						Optional.ofNullable(postPutUser.deviceFirebaseInstanceId)));
 		return UserDto.createInstance(postPutUser.firstName, postPutUser.lastName, postPutUser.mobileNumber, postPutUser.nickname,
 				deviceRegistration.map(UserDeviceDto::createDeviceRegistrationInstance));
 	}
@@ -502,10 +503,11 @@ public class UserController extends ControllerBase
 		private final String lastName;
 		private final String mobileNumber;
 		private final String nickname;
-		private String deviceName;
-		private String deviceOperatingSystemStr;
-		private String deviceAppVersion;
-		private Integer deviceAppVersionCode;
+		private final String deviceName;
+		private final String deviceOperatingSystemStr;
+		private final String deviceAppVersion;
+		private final Integer deviceAppVersionCode;
+		private final String deviceFirebaseInstanceId;
 
 		@JsonCreator
 		public PostPutUserDto(@JsonProperty("firstName") String firstName, @JsonProperty("lastName") String lastName,
@@ -514,6 +516,7 @@ public class UserController extends ControllerBase
 				@JsonProperty(value = "deviceOperatingSystem", required = false) String deviceOperatingSystem,
 				@JsonProperty(value = "deviceAppVersion", required = false) String deviceAppVersion,
 				@JsonProperty(value = "deviceAppVersionCode", required = false) Integer deviceAppVersionCode,
+				@JsonProperty(value = "deviceFirebaseInstanceId", required = false) String deviceFirebaseInstanceId,
 				@JsonProperty("_links") Object ignored1, @JsonProperty("yonaPassword") Object ignored2)
 		{
 			this.firstName = firstName;
@@ -524,6 +527,7 @@ public class UserController extends ControllerBase
 			this.deviceOperatingSystemStr = deviceOperatingSystem;
 			this.deviceAppVersion = deviceAppVersion;
 			this.deviceAppVersionCode = deviceAppVersionCode;
+			this.deviceFirebaseInstanceId = deviceFirebaseInstanceId;
 		}
 	}
 

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1848,6 +1848,10 @@ definitions:
     type: integer
     description: The version code of the Yona app running on this device. This is a positive, monotonic increasing number, across releases
     example: 31
+  FirebaseInstanceId:
+    type: string
+    description: The Instance ID provided by Firebase to the app
+    example: d3cIznsu5VQ:APA91bGWLq7xBK1RDkpGURdliHb-S_nCBLqYnXhEWfGnItP_qGDZ6f2EF1mB66yHdBiicggV7APIWwkQXTUq_zJgwPkJtvcdqpUphYN7p8E8Sq02_ErljVApX8-n9-nvVxiyqmUg9ALZ
   DeviceRegistrationRequest:
     allOf:
       - $ref: '#/definitions/OpenAppEvent'
@@ -1858,9 +1862,7 @@ definitions:
             description: Name of the device running the Yona app. The name must be at most 20 characters and should not contain a colon
             example: My S8
           firebaseInstanceId:
-            type: string
-            description: The Instance ID provided by Firebase to the app
-            example: d3cIznsu5VQ:APA91bGWLq7xBK1RDkpGURdliHb-S_nCBLqYnXhEWfGnItP_qGDZ6f2EF1mB66yHdBiicggV7APIWwkQXTUq_zJgwPkJtvcdqpUphYN7p8E8Sq02_ErljVApX8-n9-nvVxiyqmUg9ALZ
+            $ref: '#/definitions/FirebaseInstanceId'
     required:
       - name
       - operatingSystem
@@ -1874,9 +1876,7 @@ definitions:
         description: Name of the device running the Yona app. The name must be at most 20 characters and should not contain a colon
         example: My S8
       firebaseInstanceId:
-        type: string
-        description: The Instance ID provided by Firebase to the app
-        example: d3cIznsu5VQ:APA91bGWLq7xBK1RDkpGURdliHb-S_nCBLqYnXhEWfGnItP_qGDZ6f2EF1mB66yHdBiicggV7APIWwkQXTUq_zJgwPkJtvcdqpUphYN7p8E8Sq02_ErljVApX8-n9-nvVxiyqmUg9ALZ
+        $ref: '#/definitions/FirebaseInstanceId'
     required:
       - name
   DeviceBase:
@@ -1917,9 +1917,7 @@ definitions:
           vpnProfile:
             $ref: '#/definitions/VPNProfile'
           firebaseInstanceId:
-            type: string
-            description: The Instance ID provided by Firebase to the app, if known to the server.
-            example: d3cIznsu5VQ:APA91bGWLq7xBK1RDkpGURdliHb-S_nCBLqYnXhEWfGnItP_qGDZ6f2EF1mB66yHdBiicggV7APIWwkQXTUq_zJgwPkJtvcdqpUphYN7p8E8Sq02_ErljVApX8-n9-nvVxiyqmUg9ALZ
+            $ref: '#/definitions/FirebaseInstanceId'
           _links:
             allOf:
               - $ref: '#/definitions/Curies'
@@ -2007,6 +2005,8 @@ definitions:
             $ref: '#/definitions/DeviceAppVersion'
           deviceAppVersionCode:
             $ref: '#/definitions/DeviceAppVersionCode'
+          deviceFirebaseInstanceId:
+            $ref: '#/definitions/FirebaseInstanceId'
   UserWithPrivateData:
     allOf:
       - $ref: '#/definitions/BaseUser'

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -51,9 +51,9 @@ class AppService extends Service
 		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, parameters = [:])
+	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId = null, parameters = [:])
 	{
-		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode)
+		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId)
 		def response = addUser(jsonStr, parameters)
 		asserter(response)
 		return (isSuccess(response)) ? new User(response.responseData) : null

--- a/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/User.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -9,7 +9,6 @@ package nu.yona.server.test
 import java.time.LocalDate
 import java.time.ZonedDateTime
 
-import groovy.json.*
 import groovy.transform.ToString
 import net.sf.json.groovy.JsonSlurper
 import nu.yona.server.YonaServer
@@ -108,9 +107,10 @@ class User
 		return new JsonSlurper().parseText(jsonStr)
 	}
 
-	private static String makeUserJsonStringInternal(url, firstName, lastName, password, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE, boolean forceDeviceInfo = false)
+	private static String makeUserJsonStringInternal(url, firstName, lastName, password, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE, firebaseInstanceId = null, boolean forceDeviceInfo = false)
 	{
-		def devicePropertiesString = (deviceName || forceDeviceInfo) ? """"deviceName":"$deviceName", "deviceOperatingSystem":"$deviceOperatingSystem", "deviceAppVersion":"$deviceAppVersion", "deviceAppVersionCode":"$deviceAppVersionCode",""" : ""
+		def firebaseInstanceIdString = (firebaseInstanceId) ? """"deviceFirebaseInstanceId":"$firebaseInstanceId",""" : ""
+		def devicePropertiesString = (deviceName || forceDeviceInfo) ? """"deviceName":"$deviceName", "deviceOperatingSystem":"$deviceOperatingSystem", "deviceAppVersion":"$deviceAppVersion", "deviceAppVersionCode":"$deviceAppVersionCode",$firebaseInstanceIdString""" : ""
 		def selfLinkString = (url) ? """"self":{"href":"$url"},""" : ""
 		def passwordString = (password) ? """"yonaPassword":"${password}",""" : ""
 		def json = """{
@@ -163,14 +163,14 @@ class User
 		goals.find{ it.activityCategoryUrl == activityCategoryUrl && !it.historyItem }
 	}
 
-	static String makeUserJsonString(firstName, lastName, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE)
+	static String makeUserJsonString(firstName, lastName, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE, firebaseInstanceId = null)
 	{
-		makeUserJsonStringInternal(null, firstName, lastName, null, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode)
+		makeUserJsonStringInternal(null, firstName, lastName, null, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId)
 	}
 
-	static String makeUserJsonStringWithDeviceInfo(firstName, lastName, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE)
+	static String makeUserJsonStringWithDeviceInfo(firstName, lastName, nickname, mobileNumber, deviceName = null, deviceOperatingSystem = "UNKNOWN", deviceAppVersion = Device.SOME_APP_VERSION, deviceAppVersionCode = Device.SUPPORTED_APP_VERSION_CODE, firebaseInstanceId = null)
 	{
-		makeUserJsonStringInternal(null, firstName, lastName, null, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, true)
+		makeUserJsonStringInternal(null, firstName, lastName, null, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId, true)
 	}
 }
 


### PR DESCRIPTION
Along with this, replaced repeated definition of Firebase instance ID in Swagger spec with a centralized definition