### PR TITLE
YD-641 Upgrade to Liquibase Hibernate5 3.8

### DIFF
--- a/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/DayActivity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.entities;
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ManyToOne;
@@ -44,6 +45,7 @@ public class DayActivity extends IntervalActivity
 							// so you get 4 goals * 1 day = 4 activity collections to be joined
 	private List<Activity> activities;
 
+	@Column(columnDefinition = "bit default false")
 	private boolean goalAccomplished;
 	private int totalMinutesBeyondGoal;
 

--- a/core/src/main/java/nu/yona/server/analysis/entities/IntervalActivity.java
+++ b/core/src/main/java/nu/yona/server/analysis/entities/IntervalActivity.java
@@ -20,6 +20,7 @@ import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,11 +33,9 @@ import nu.yona.server.goals.entities.Goal;
 import nu.yona.server.subscriptions.entities.UserAnonymized;
 
 @Entity
-@Table(name = "INTERVAL_ACTIVITIES")
+@Table(name = "INTERVAL_ACTIVITIES", uniqueConstraints = @UniqueConstraint(name = "no_duplicate_activities", columnNames = {
+		"dtype", "user_anonymized_id", "startDate", "goal_id" }))
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-// We used to have a unique constraint defined here: @UniqueConstraint(columnNames = { "dtype", "user_anonymized", "startDate",
-// "goal" })
-// Due to an inconsistency between Liquibase and JPA, we have moved this to Liquibase (extra.yml)
 public abstract class IntervalActivity extends EntityWithId
 {
 	private static final Logger logger = LoggerFactory.getLogger(IntervalActivity.class);

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.entities;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 
 import nu.yona.server.device.entities.UserDevice;
@@ -16,7 +17,9 @@ import nu.yona.server.subscriptions.service.BuddyServiceException;
 @Entity
 public class BuddyConnectRequestMessage extends BuddyConnectMessage
 {
+	@Column(columnDefinition = "bit default false")
 	private boolean isRequestingSending;
+	@Column(columnDefinition = "bit default false")
 	private boolean isRequestingReceiving;
 
 	private Status status;

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectResponseMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.entities;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 
 import nu.yona.server.device.entities.UserDevice;
@@ -15,6 +16,7 @@ import nu.yona.server.device.entities.UserDevice;
 public class BuddyConnectResponseMessage extends BuddyConnectMessage
 {
 	private BuddyAnonymized.Status status = BuddyAnonymized.Status.NOT_REQUESTED;
+	@Column(columnDefinition = "bit default false")
 	private boolean isProcessed;
 
 	// Default constructor is required for JPA

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDeviceChangeMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
@@ -33,6 +33,7 @@ public class BuddyDeviceChangeMessage extends BuddyMessage
 	private Optional<String> newName;
 	private byte[] newNameCiphertext;
 
+	@Column(columnDefinition = "bit default false")
 	private boolean isProcessed;
 
 	// Default constructor is required for JPA

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
@@ -1,9 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 
 import nu.yona.server.subscriptions.service.BuddyService.DropBuddyReason;
@@ -11,6 +12,7 @@ import nu.yona.server.subscriptions.service.BuddyService.DropBuddyReason;
 @Entity
 public class BuddyDisconnectMessage extends BuddyConnectionChangeMessage
 {
+	@Column(columnDefinition = "bit default false")
 	private boolean isProcessed;
 	private DropBuddyReason reason;
 

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyInfoChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyInfoChangeMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.entities;
 import java.util.Optional;
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
 
@@ -28,6 +29,7 @@ public class BuddyInfoChangeMessage extends BuddyMessage
 	@Transient
 	private Optional<UUID> newUserPhotoId;
 	private byte[] newUserPhotoIdCiphertext;
+	@Column(columnDefinition = "bit default false")
 	private boolean isProcessed;
 
 	public BuddyInfoChangeMessage(BuddyInfoParameters buddyInfoParameters, String message, String newFirstName,

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyVpnConnectionStatusChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyVpnConnectionStatusChangeMessage.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
 import java.util.UUID;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -17,6 +18,7 @@ import nu.yona.server.messaging.entities.BuddyMessage;
 @DiscriminatorValue("BuddyVpnConnectionStatChngMsg") // Default max length = 31
 public class BuddyVpnConnectionStatusChangeMessage extends BuddyMessage
 {
+	@Column(columnDefinition = "bit default false")
 	private boolean isVpnConnected;
 
 	@Transient

--- a/dbinit/liquibase.gradle
+++ b/dbinit/liquibase.gradle
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-	liquibase "org.liquibase.ext:liquibase-hibernate5:3.7"
+	liquibase "org.liquibase.ext:liquibase-hibernate5:3.8"
 }
 
 //loading properties file.

--- a/dbinit/src/main/liquibase/updates/changelog-0021-yd-641.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0021-yd-641.yml
@@ -1,0 +1,557 @@
+databaseChangeLog:
+- changeSet:
+    id: 1567747746730-1
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: activity_category_id
+        tableName: activities
+- changeSet:
+    id: 1567747746730-2
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: activity_category_id
+        tableName: goals
+- changeSet:
+    id: 1567747746730-4
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: anonymous_destination_id
+        tableName: users_anonymized
+- changeSet:
+    id: 1567747746730-5
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: anonymous_message_source_id
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-6
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: app
+        tableName: activities
+- changeSet:
+    id: 1567747746730-7
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: app_last_opened_date
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-8
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: date
+        columnName: app_last_opened_date
+        tableName: users
+- changeSet:
+    id: 1567747746730-9
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: app_version
+        tableName: devices_anonymized
+- changeSet:
+    id: 1567747746730-10
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: int
+        columnName: app_version_code
+        tableName: devices_anonymized
+- changeSet:
+    id: 1567747746730-11
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: applications
+        tableName: activity_category_applications
+- changeSet:
+    id: 1567747746730-12
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: buddy_anonymized_id
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-13
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: confirmation_code
+        tableName: confirmation_codes
+- changeSet:
+    id: 1567747746730-14
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: decryption_check
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-15
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: decryption_check_cipher_text
+        tableName: new_device_requests
+- changeSet:
+    id: 1567747746730-16
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: device_anonymized_id
+        tableName: activities
+- changeSet:
+    id: 1567747746730-17
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: device_anonymized_id
+        tableName: buddy_devices
+- changeSet:
+    id: 1567747746730-18
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: device_anonymized_id
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-19
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: device_anonymized_id
+        tableName: vpn_status_change_events
+- changeSet:
+    id: 1567747746730-20
+    author: bert (generated)
+    changes:
+    - addNotNullConstraint:
+        columnDataType: int
+        columnName: device_index
+        tableName: devices_anonymized
+- changeSet:
+    id: 1567747746730-21
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: firebase_instance_id
+        tableName: devices_anonymized
+- changeSet:
+    id: 1567747746730-22
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: first_name
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-23
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: first_name
+        tableName: users
+- changeSet:
+    id: 1567747746730-24
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: first_name
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-26
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: goal_id
+        tableName: interval_activities
+- changeSet:
+    id: 1567747746730-28
+    author: bert (generated)
+    changes:
+    - addNotNullConstraint:
+        columnDataType: boolean
+        columnName: is_legacy_vpn_account
+        tableName: user_devices
+    - dropDefaultValue:
+        columnDataType: boolean
+        columnName: is_legacy_vpn_account
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-33
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: last_name
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-34
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: last_name
+        tableName: users
+- changeSet:
+    id: 1567747746730-35
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: last_name
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-36
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: last_status_change_time
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-37
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: localizable_description
+        tableName: activity_category_localizable_description
+- changeSet:
+    id: 1567747746730-38
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: localizable_name
+        tableName: activity_category_localizable_name
+- changeSet:
+    id: 1567747746730-40
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: message_destination_id
+        tableName: message_sources
+- changeSet:
+    id: 1567747746730-41
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: message_destination_id
+        tableName: messages
+- changeSet:
+    id: 1567747746730-42
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: message_destination_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-43
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: mobile_number
+        tableName: users
+- changeSet:
+    id: 1567747746730-44
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: mobile_number
+        tableName: white_listed_number
+- changeSet:
+    id: 1567747746730-45
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: mobile_number_confirmation_code_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-46
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: name
+        tableName: buddy_devices
+- changeSet:
+    id: 1567747746730-47
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: name
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-48
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: named_message_source_id
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-49
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: new_device_request_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-50
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: nickname
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-51
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: nickname
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-52
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: overwrite_user_confirmation_code_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-53
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: owning_buddy_id
+        tableName: buddy_devices
+- changeSet:
+    id: 1567747746730-54
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: owning_user_anonymized_id
+        tableName: buddies_anonymized
+- changeSet:
+    id: 1567747746730-55
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: owning_user_private_id
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-56
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: pin_reset_confirmation_code_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-57
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: previous_instance_of_this_goal_id
+        tableName: goals
+- changeSet:
+    id: 1567747746730-58
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: int
+        columnName: private_data_migration_version
+        tableName: users
+- changeSet:
+    id: 1567747746730-59
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(1024)
+        columnName: private_key_bytes
+        tableName: message_sources
+- changeSet:
+    id: 1567747746730-60
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: registration_time
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-61
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: related_user_anonymized_id
+        tableName: messages
+- changeSet:
+    id: 1567747746730-62
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: smoothwall_categories
+        tableName: activity_category_smoothwall_categories
+- changeSet:
+    id: 1567747746730-63
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: time_zone
+        tableName: activities
+- changeSet:
+    id: 1567747746730-64
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: time_zone
+        tableName: interval_activities
+- changeSet:
+    id: 1567747746730-65
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_anonymized_id
+        tableName: buddies_anonymized
+- changeSet:
+    id: 1567747746730-66
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_anonymized_id
+        tableName: devices_anonymized
+- changeSet:
+    id: 1567747746730-67
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_anonymized_id
+        tableName: goals
+- changeSet:
+    id: 1567747746730-68
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_anonymized_id
+        tableName: interval_activities
+- changeSet:
+    id: 1567747746730-69
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_anonymized_id
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-70
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_id
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-71
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_photo_id
+        tableName: buddies
+- changeSet:
+    id: 1567747746730-72
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_photo_id
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-73
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_private_id
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-74
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: user_private_id
+        tableName: users
+- changeSet:
+    id: 1567747746730-75
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: vpn_password
+        tableName: user_devices
+- changeSet:
+    id: 1567747746730-76
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: vpn_password
+        tableName: users_private
+- changeSet:
+    id: 1567747746730-77
+    author: bert (generated)
+    changes:
+    - dropDefaultValue:
+        columnDataType: varchar(255)
+        columnName: yona_password_cipher_text
+        tableName: new_device_requests

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -62,3 +62,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0020-yd-628.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0021-yd-641.yml


### PR DESCRIPTION
The new version addresses a number of issues (most notably liquibase/liquibase-hibernate#134), resulting in much cleaner output for diffChangeLog.

The new version proposes to basically drop all default values. I've accepted most of them in changelog-0021-yd-641.yml. Some however are unjustified and cause runtime issues if they would be dropped. These will still have to be removed from a future generated change log. I will update the wiki page accordingly.

The new version now properly handles a unique constraint on a type, so I've put that back in IntervalActivity.java