### PR TITLE
YD-643 Up min app version

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -277,7 +277,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatus(response, 400)
 		assert response.responseData.code == "error.device.app.version.not.supported"
-		assert response.responseData.message == "Yona app is out of date and must be updated. Actual version is '$appVersion' but oldest supported version for 'IOS' is '1.0.1'"
+		assert response.responseData.message == "Yona app is out of date and must be updated. Actual version is '$appVersion' but oldest supported version for 'IOS' is '1.2'"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -331,14 +331,14 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 		where:
 		operatingSystem | appVersion | appVersionCode | responseStatus
-		"IOS" | "1.1" | 50 | 200
+		"IOS" | "1.1" | 5000 | 200
 		null | null | null | 200
 		"IOS" | null | null | 400
 		null | "1.1" | null | 400
-		null | null | 50 | 400
-		null | "1.1" | 50 | 400
+		null | null | 5000 | 400
+		null | "1.1" | 5000 | 400
 		"IOS" | "1.1" | null | 400
-		"IOS" | null | 50 | 400
+		"IOS" | null | 5000 | 400
 	}
 
 	private User createJohnDoe(ts, deviceName, deviceOperatingSystem, firebaseInstanceId = null)

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -8,7 +8,6 @@ package nu.yona.server
 
 import static nu.yona.server.test.CommonAssertions.*
 
-import groovy.json.*
 import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 
@@ -454,22 +453,22 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		where:
 		deviceName | operatingSystem | appVersion | appVersionCode | responseStatus
-		"some name" | "IOS" | "1.1" | 50 | 201
+		"some name" | "IOS" | "1.1" | 5000 | 201
 		"some name" | null | null | null | 400
 		"some name" | "IOS" | null | null | 400
 		"some name" | null | "1.1" | null | 400
-		"some name" | null | null | 50 | 400
+		"some name" | null | null | 5000 | 400
 		"some name" | null | "1.1" | 50 | 400
 		"some name" | "IOS" | "1.1" | null | 400
-		"some name" | "IOS" | null | 50 | 400
-		null | "IOS" | "1.1" | 50 | 400
+		"some name" | "IOS" | null | 5000 | 400
+		null | "IOS" | "1.1" | 5000 | 400
 		null | null | null | null | 201
 		null | "IOS" | null | null | 400
 		null | null | "1.1" | null | 400
-		null | null | null | 50 | 400
-		null | null | "1.1" | 50 | 400
+		null | null | null | 5000 | 400
+		null | null | "1.1" | 5000 | 400
 		null | "IOS" | "1.1" | null | 400
-		null | "IOS" | null | 50 | 400
+		null | "IOS" | null | 5000 | 400
 	}
 
 	private def confirmMobileNumber(User user, code)

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -45,10 +45,10 @@ public class DeviceService
 {
 	// When updating the minimum version, be sure to update the version code and the version.
 	// Minimal technical version codes, used to verify the minimum
-	private static final int ANDROID_MIN_APP_VERSION_CODE = 5;
-	private static final int IOS_MIN_APP_VERSION_CODE = ANDROID_MIN_APP_VERSION_CODE;
+	private static final int ANDROID_MIN_APP_VERSION_CODE = 218;
+	private static final int IOS_MIN_APP_VERSION_CODE = 166;
 	// User-friendly minimum version, used for error message
-	private static final String ANDROID_MIN_APP_VERSION = "1.0.1";
+	private static final String ANDROID_MIN_APP_VERSION = "1.2";
 	private static final String IOS_MIN_APP_VERSION = ANDROID_MIN_APP_VERSION;
 
 	@Autowired(required = false)


### PR DESCRIPTION
This is in preparation to the new API version that will come with YD-622.

The minimum versions for Android is now:
Code: 218
Version: 1.2

For iOS, it does not matter much, as the iOS app is expired in Test Flight, but to be safe there, we demand the latest version on the iOS master branch:
Code: 166
Version: 1.2