### PR TITLE
YD-645 Remove last JUnit 4 dependencies

### DIFF
--- a/adminservice/build.gradle
+++ b/adminservice/build.gradle
@@ -19,6 +19,8 @@ release {
 
 configurations {
 	providedRuntime
+	intTestCompile.extendsFrom testCompile
+	intTestRuntime.extendsFrom testRuntime
 }
 
 dependencies {
@@ -27,6 +29,10 @@ dependencies {
 	providedRuntime "org.springframework.boot:spring-boot-starter-tomcat"
 
 	testCompile project(path: ":core", configuration: "testUtils")
+
+	intTestCompile "org.codehaus.groovy:groovy-all:2.5.5"
+	intTestCompile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
+	intTestCompile "org.spockframework:spock-core:1.2-groovy-2.5"
 }
 
 test {
@@ -82,11 +88,6 @@ sourceSets {
 			runtimeClasspath += main.output
 		}
 	}
-}
-
-configurations {
-	intTestCompile.extendsFrom testCompile
-	intTestRuntime.extendsFrom testRuntime
 }
 
 task intTest(type:Test){

--- a/analysisservice/build.gradle
+++ b/analysisservice/build.gradle
@@ -19,6 +19,8 @@ release {
 
 configurations {
 	providedRuntime
+	intTestCompile.extendsFrom testCompile
+	intTestRuntime.extendsFrom testRuntime
 }
 
 dependencies {
@@ -31,6 +33,10 @@ dependencies {
 	testCompile project(path: ":core", configuration: "testUtils")
 	testCompile project(':core').sourceSets.test.output
 	testCompile "org.mockito:mockito-core:2.21.0"
+
+	intTestCompile "org.codehaus.groovy:groovy-all:2.5.5"
+	intTestCompile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
+	intTestCompile "org.spockframework:spock-core:1.2-groovy-2.5"
 }
 
 test {
@@ -87,11 +93,6 @@ sourceSets {
 			runtimeClasspath += main.output
 		}
 	}
-}
-
-configurations {
-	intTestCompile.extendsFrom testCompile
-	intTestRuntime.extendsFrom testRuntime
 }
 
 task intTest(type:Test){

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/ActivityUpdateServiceTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AnalysisEngineServiceTest.java
@@ -5,8 +5,8 @@
 package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;

--- a/analysisservice/src/test/java/nu/yona/server/analysis/service/AppActivitiesDtoTest.java
+++ b/analysisservice/src/test/java/nu/yona/server/analysis/service/AppActivitiesDtoTest.java
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;

--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -19,6 +19,8 @@ release {
 
 configurations {
 	providedRuntime
+	intTestCompile.extendsFrom testCompile
+	intTestRuntime.extendsFrom testRuntime
 }
 
 dependencies {
@@ -33,6 +35,10 @@ dependencies {
 	testCompile project(path: ":core", configuration: "testUtils")
 	testCompile "org.apache.httpcomponents:httpmime:4.5.3"
 	testCompile "org.mockito:mockito-core:2.21.0"
+
+	intTestCompile "org.codehaus.groovy:groovy-all:2.5.5"
+	intTestCompile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
+	intTestCompile "org.spockframework:spock-core:1.2-groovy-2.5"
 }
 
 test {
@@ -88,11 +94,6 @@ sourceSets {
 			runtimeClasspath += main.output
 		}
 	}
-}
-
-configurations {
-	intTestCompile.extendsFrom testCompile
-	intTestRuntime.extendsFrom testRuntime
 }
 
 task intTest(type:Test){

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,15 +49,13 @@ dependencies {
 	compile "com.googlecode.libphonenumber:libphonenumber:8.9.1"
 	compile "com.google.firebase:firebase-admin:6.4.0"
 
-	compile "org.codehaus.groovy:groovy-all:2.5.5"
-	compile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
-
-	testCompile "org.springframework.boot:spring-boot-starter-test"
+	testCompile ("org.springframework.boot:spring-boot-starter-test") {
+		exclude group: 'junit', module: 'junit' 
+	}
 	testCompile "org.mockito:mockito-junit-jupiter:2.25.0"
 	testCompile "org.junit.jupiter:junit-jupiter:5.4.0"
 	testCompile "com.spencerwi:hamcrest-jdk8-time:0.7.1"
 	testCompile "nl.jqno.equalsverifier:equalsverifier:3.1.4"
-	testCompile "org.spockframework:spock-core:1.2-groovy-2.5"
 	
 	testUtilsCompile "org.codehaus.groovy:groovy-all:2.5.5"
 	testUtilsCompile "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"

--- a/core/src/test/java/nu/yona/server/ThymeleafConfigurationTest.java
+++ b/core/src/test/java/nu/yona/server/ThymeleafConfigurationTest.java
@@ -6,7 +6,7 @@ package nu.yona.server;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.text.MessageFormat;
 import java.util.Locale;

--- a/core/src/test/java/nu/yona/server/analysis/entities/DayActivityTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/DayActivityTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.entities;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;

--- a/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/IntervalActivityTestBase.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.entities;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.text.MessageFormat;
 import java.time.ZoneId;

--- a/core/src/test/java/nu/yona/server/analysis/entities/WeekActivityTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/entities/WeekActivityTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.entities;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.ZonedDateTime;
 

--- a/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/ActivityServiceTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/core/src/test/java/nu/yona/server/analysis/service/DayActivityDtoTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/DayActivityDtoTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;

--- a/core/src/test/java/nu/yona/server/analysis/service/WeekActivityDtoTest.java
+++ b/core/src/test/java/nu/yona/server/analysis/service/WeekActivityDtoTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.analysis.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.DayOfWeek;

--- a/core/src/test/java/nu/yona/server/crypto/pubkey/PublicKeyDecryptorTest.java
+++ b/core/src/test/java/nu/yona/server/crypto/pubkey/PublicKeyDecryptorTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.crypto.pubkey;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;

--- a/core/src/test/java/nu/yona/server/crypto/pubkey/PublicKeyEncryptorTest.java
+++ b/core/src/test/java/nu/yona/server/crypto/pubkey/PublicKeyEncryptorTest.java
@@ -6,7 +6,7 @@ package nu.yona.server.crypto.pubkey;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;

--- a/core/src/test/java/nu/yona/server/crypto/seckey/SecretKeyUtilTest.java
+++ b/core/src/test/java/nu/yona/server/crypto/seckey/SecretKeyUtilTest.java
@@ -6,7 +6,7 @@ package nu.yona.server.crypto.seckey;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
 import java.util.UUID;

--- a/core/src/test/java/nu/yona/server/exceptions/ResourceBasedExceptionTest.java
+++ b/core/src/test/java/nu/yona/server/exceptions/ResourceBasedExceptionTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.exceptions;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
 import java.util.Locale;

--- a/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/entities/UserTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.subscriptions.entities;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegrationTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.subscriptions.service;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegration_stepOrderTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegration_stepOrderTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.subscriptions.service;
 
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.Collections;

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -4,8 +4,7 @@
  *******************************************************************************/
 package nu.yona.server.test.util;
 
-import static com.spencerwi.hamcrestJDK8Time.matchers.IsAfter.after;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -129,6 +128,6 @@ public class JUnitUtil
 
 	public static void skipBefore(String description, ZonedDateTime now, int hour, int minute)
 	{
-		assumeThat(description, now, after(now.withHour(hour).withMinute(minute).withSecond(0)));
+		assumeTrue(now.isAfter(now.withHour(hour).withMinute(minute).withSecond(0)), description);
 	}
 }

--- a/core/src/test/java/nu/yona/server/util/LockPoolTest.java
+++ b/core/src/test/java/nu/yona/server/util/LockPoolTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/core/src/test/java/nu/yona/server/util/TimeUtilTest.java
+++ b/core/src/test/java/nu/yona/server/util/TimeUtilTest.java
@@ -5,7 +5,7 @@
 package nu.yona.server.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.time.LocalDate;
 import java.time.ZoneId;


### PR DESCRIPTION
The class JUnitUtil used org.junit.Assume.assumeThat of JUnit 4. If that assumption failed, JUnit failed the test rather than skipping it. Now the assume is done with org.junit.jupiter.api.Assumptions.assumeTrue.

To prevent such issues, JUnit 4 was removed from the compile-time dependencies of the tests. This required:
* Replacing quite some assertThat calls
* Moving Groovy and Spock from the unit test dependencies and adding them to the integration test dependencies
* Excluding JUnit from the transitive dependencies of the Spring Boot test starter