### PR TITLE
YD-647 Add user name to email subject

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -606,7 +606,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(response)
 		assert response.responseData.from == "Richard Quinn <noreply@yona.nu>"
 		assert response.responseData.to == "Bobby Dun <bobdunn325@gmail.com>"
-		assert response.responseData.subject == "Become my friend on Yona!"
+		assert response.responseData.subject == "Become friend of Richard Quinn on Yona!"
 		assert response.responseData.body ==~ /(?s).*Return to this mail and click <a href=\"http.*/
 	}
 

--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -1843,11 +1843,11 @@ definitions:
   DeviceAppVersion:
     type: string
     description: The version of the Yona app running on this device. This is the marketing version, a free text string.
-    example: 1.1 build 83
+    example: 1.2 build 83
   DeviceAppVersionCode:
     type: integer
     description: The version code of the Yona app running on this device. This is a positive, monotonic increasing number, across releases
-    example: 31
+    example: 218
   FirebaseInstanceId:
     type: string
     description: The Instance ID provided by Firebase to the app

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -549,12 +549,13 @@ public class BuddyService
 		{
 			String subjectTemplateName = "buddy-invitation-subject";
 			String bodyTemplateName = "buddy-invitation-body";
-			String requestingUserName = getFullName(requestingUser.getPrivateData());
+			String requestingUserFullName = getFullName(requestingUser.getPrivateData());
 			String requestingUserMobileNumber = requestingUser.getMobileNumber();
 			String buddyName = getFullName(buddy.getUser().getPrivateData());
 			String buddyMobileNumber = buddy.getUser().getMobileNumber();
-			Map<String, Object> templateParams = fillTemplateParams(requestingUser, buddy, inviteUrl, requestingUserMobileNumber);
-			emailService.sendEmail(requestingUserName, new InternetAddress(buddy.getUser().getEmailAddress(), buddyName),
+			Map<String, Object> templateParams = fillTemplateParams(requestingUser, buddy, inviteUrl, requestingUserFullName,
+					requestingUserMobileNumber);
+			emailService.sendEmail(requestingUserFullName, new InternetAddress(buddy.getUser().getEmailAddress(), buddyName),
 					subjectTemplateName, bodyTemplateName, templateParams);
 			smsService.send(buddyMobileNumber, SmsTemplate.BUDDY_INVITE, templateParams);
 		}
@@ -570,10 +571,11 @@ public class BuddyService
 	}
 
 	private Map<String, Object> fillTemplateParams(UserDto requestingUser, BuddyDto buddy, String inviteUrl,
-			String requestingUserMobileNumber)
+			String requestingUserFullName, String requestingUserMobileNumber)
 	{
 		Map<String, Object> templateParams = new HashMap<>();
 		templateParams.put("inviteUrl", inviteUrl);
+		templateParams.put("requestingUserFullName", requestingUserFullName);
 		templateParams.put("requestingUserFirstName", requestingUser.getPrivateData().getFirstName());
 		templateParams.put("requestingUserLastName", requestingUser.getPrivateData().getLastName());
 		templateParams.put("requestingUserMobileNumber", requestingUserMobileNumber);

--- a/core/src/main/resources/templates/email/buddy-invitation-subject.txt
+++ b/core/src/main/resources/templates/email/buddy-invitation-subject.txt
@@ -1,1 +1,1 @@
-[[ #{buddy-invitation-subject(${requestingUserName})} ]]
+[[ #{buddy-invitation-subject(${requestingUserFullName})} ]]

--- a/core/src/main/resources/templates/email/messages.properties
+++ b/core/src/main/resources/templates/email/messages.properties
@@ -1,11 +1,11 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Stichting Yona Foundation
+# Copyright (c) 2017, 2019 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ###############################################################################
-buddy-invitation-subject=Become my friend on Yona!
+buddy-invitation-subject=Become friend of {0} on Yona!
 buddy-invitation-body.header=Become friends on Yona!
 buddy-invitation-body.p1={0} has invited you to become friends on Yona. With Yona, you together ensure Internet stays fun. Follow the steps below and see which goals have been set by {0}. After that, set your own goals.
 buddy-invitation-body.step1=Go to the <a href="{0}" style="color: #2678bf; text-decoration: none;">Apple App Store</a> or the <a href="{1}" style="color: #2678bf; text-decoration: none;">Google Play Store</a> and download Yona.

--- a/core/src/main/resources/templates/email/messages_nl.properties
+++ b/core/src/main/resources/templates/email/messages_nl.properties
@@ -1,11 +1,11 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Stichting Yona Foundation
+# Copyright (c) 2017, 2019 Stichting Yona Foundation
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ###############################################################################
-buddy-invitation-subject=Word vriend op Yona!
+buddy-invitation-subject=Word vriend van {0} op Yona!
 buddy-invitation-body.header=Word vrienden op Yona!
 buddy-invitation-body.p1={0} heeft je uitgenodigd om Yona-vrienden te worden bij Yona. Met Yona zorg je er samen voor dat internet leuk blijft. Volg onderstaande stappen en kijk welke doelen {0} heeft ingesteld. Vervolgens stel jij jouw doelen in.
 buddy-invitation-body.step1=Ga naar de <a href="{0}" style="color: #2678bf; text-decoration: none;">Apple App Store</a> of de <a href="{1}" style="color: #2678bf; text-decoration: none;">Google Play Store</a> en download Yona.

--- a/core/src/test/java/nu/yona/server/ThymeleafConfigurationTest.java
+++ b/core/src/test/java/nu/yona/server/ThymeleafConfigurationTest.java
@@ -96,7 +96,7 @@ public class ThymeleafConfigurationTest
 		Context ctx = ThymeleafUtil.createContext();
 		ctx.setVariable("requestingUserFirstName", requestingUserFirstName);
 		ctx.setVariable("emailAddress", emailAddress);
-		locale.ifPresent(l -> ctx.setLocale(l));
+		locale.ifPresent(ctx::setLocale);
 
 		return smsTemplateEngine.process("buddy-invitation.txt", ctx);
 	}
@@ -104,23 +104,24 @@ public class ThymeleafConfigurationTest
 	@Test
 	public void emailTemplateEngine_processBuddyInvitationSubjectDefault_defaultTemplateFoundAndExpanded()
 	{
-		String result = buildEmailSubject(Optional.empty());
+		String result = buildEmailSubject(Optional.empty(), "John Doe");
 
-		assertThat(result, equalTo("Become my friend on Yona!"));
+		assertThat(result, equalTo("Become friend of John Doe on Yona!"));
 	}
 
 	@Test
 	public void emailTemplateEngine_processBuddyInvitationSubjectDutch_dutchTemplateFoundAndExpanded()
 	{
-		String result = buildEmailSubject(Optional.of(Locale.forLanguageTag("nl-NL")));
+		String result = buildEmailSubject(Optional.of(Locale.forLanguageTag("nl-NL")), "John Doe");
 
-		assertThat(result, equalTo("Word vriend op Yona!"));
+		assertThat(result, equalTo("Word vriend van John Doe op Yona!"));
 	}
 
-	private String buildEmailSubject(Optional<Locale> locale)
+	private String buildEmailSubject(Optional<Locale> locale, String requestingUserFullName)
 	{
 		Context ctx = ThymeleafUtil.createContext();
-		locale.ifPresent(l -> ctx.setLocale(l));
+		locale.ifPresent(ctx::setLocale);
+		ctx.setVariable("requestingUserFullName", requestingUserFullName);
 
 		return emailTemplateEngine.process("buddy-invitation-subject.txt", ctx);
 	}


### PR DESCRIPTION
Along with this updated the example version code and version number in swagger-spec.yaml, so the default sample can be used immediately, even after we upped the minimum version from 31 to 218.