### PR TITLE
YD-649 Fixed NPE when missing device ID param

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -279,7 +279,29 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.user.exists"
+		response.responseData.code == "error.user.exists"
+
+		cleanup:
+		appService.deleteUser(john)
+	}
+
+	def 'Try update John Doe without requesting device ID request parameter'()
+	{
+		given:
+		def ts = timestamp
+		User richard = addRichard()
+		def john = createJohnDoe(ts)
+		appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, john)
+
+		when:
+		def updatedJohn = john.convertToJson()
+		updatedJohn.mobileNumber = richard.mobileNumber
+		def response = appService.updateUser(YonaServer.removeRequestParam(john.url, "requestingDeviceId"), updatedJohn, john.password)
+
+		then:
+		assertResponseStatus(response, 400)
+		response.responseData.code == "error.request.missing.request.parameter"
+		response.data.message ==~ /^Request parameter 'requestingDeviceId' is mandatory in this context.*/
 
 		cleanup:
 		appService.deleteUser(john)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -244,6 +244,9 @@ public class UserController extends ControllerBase
 		}
 		else
 		{
+			Require.isNonNull(requestingDeviceIdStr,
+					() -> InvalidDataException.missingRequestParameter(REQUESTING_DEVICE_ID_PARAM,
+							"This parameter is mandatory when '" + TEMP_PASSWORD_PARAM + "' is not provided"));
 			return updateUser(password, userId, RestUtil.parseUuid(requestingDeviceIdStr), user, request);
 		}
 	}
@@ -496,9 +499,9 @@ public class UserController extends ControllerBase
 	public static class UserResource extends Resource<UserDto>
 	{
 		private final CurieProvider curieProvider;
-		private UserResourceRepresentation representation;
-		private UUID requestingUserId;
-		private Optional<UUID> requestingDeviceId;
+		private final UserResourceRepresentation representation;
+		private final UUID requestingUserId;
+		private final Optional<UUID> requestingDeviceId;
 
 		public UserResource(CurieProvider curieProvider, UserResourceRepresentation representation, UserDto user,
 				UUID requestingUserId, Optional<UUID> requestingDeviceId)

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -145,4 +145,9 @@ public class InvalidDataException extends YonaException
 	{
 		return new InvalidDataException(exception, "error.invalid.date", date);
 	}
+
+	public static InvalidDataException missingRequestParameter(String name, String hint)
+	{
+		return new InvalidDataException("error.request.missing.request.parameter", name, hint);
+	}
 }

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -178,6 +178,7 @@ error.batch.job.not.found=Job ''{1}'' not found in group ''{0}''
 
 error.request.missing.property=Mandatory property ''{0}'' is missing. Hint: {1}
 error.request.extra.property=Property ''{0}'' is not supported in this context. Hint: {1}
+error.request.missing.request.parameter=Request parameter ''{0}'' is mandatory in this context. Hint: {1}
 
 error.missing.entity=Inconsistent data: entity of type ''{0}'' with ID ''{1}'' cannot be found
 

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -178,6 +178,7 @@ error.batch.job.not.found=Job ''{1}'' niet gevonden in groep ''{0}''
 
 error.request.missing.property=Verplicht property ''{0}'' ontbreekt. Hint: {1}
 error.request.extra.property=Property ''{0}'' wordt niet ondersteund. Hint: {1}
+error.request.missing.request.parameter=Request parameter ''{0}'' is verplicht in deze context. Hint: {1}
 
 error.missing.entity=Inconsistente data: entity van het type ''{0}'' met ID ''{1}'' kan niet worden gevonden
 

--- a/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.

--- a/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
@@ -173,6 +173,12 @@ class YonaServer
 		url - ~/\?.*/
 	}
 
+	static def removeRequestParam(url, param)
+	{
+		URIBuilder uriBuilder = new URIBuilder(url)
+		return uriBuilder.removeQueryParam(param).toString()
+	}
+
 	static String makeStringList(def strings)
 	{
 		def stringList = ""
@@ -251,8 +257,8 @@ class YonaServer
 			// Fall through
 			case 2:
 				int weekDay = getDayOfWeek(DateTimeFormatter.ofPattern("eee")
-					.withLocale(Locale.forLanguageTag("en-US"))
-					.parse(fields[parsedFields]).get(ChronoField.DAY_OF_WEEK)
+				.withLocale(Locale.forLanguageTag("en-US"))
+				.parse(fields[parsedFields]).get(ChronoField.DAY_OF_WEEK)
 				)
 				dayOffset = weekDay - getDayOfWeek(now)
 				parsedFields++
@@ -286,9 +292,9 @@ class YonaServer
 	static def relativeDateStringToDaysOffset(int weeksBack, String shortDay)
 	{
 		int targetWeekDay = getDayOfWeek(DateTimeFormatter.ofPattern("eee")
-			.withLocale(Locale.forLanguageTag("en-US"))
-			.parse(shortDay).get(ChronoField.DAY_OF_WEEK)
-		)
+				.withLocale(Locale.forLanguageTag("en-US"))
+				.parse(shortDay).get(ChronoField.DAY_OF_WEEK)
+				)
 		int currentWeekDay = now.dayOfWeek.value
 		int dayOffset = currentWeekDay - targetWeekDay
 		return weeksBack * 7 + dayOffset


### PR DESCRIPTION
If the tempPassword request parameter is not provided, the requestingDeviceId parameter is mandatory. This is now properly checked.