### PR TITLE
YD-656 Fixed buddy not found by ID issue

### DIFF
--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -369,7 +369,7 @@ public class BuddyService
 	{
 		messageService.deleteUnprocessedMessages(user, m -> isBuddyConnectResponseFromBuddy(m, buddy));
 		// Send message to "self", as if the requested user declined the buddy request
-		UUID buddyUserAnonymizedId = buddy.getUserAnonymizedId().orElse(null); //
+		UUID buddyUserAnonymizedId = buddy.getUserAnonymizedId().orElse(null);
 		sendBuddyConnectResponseMessage(BuddyInfoParameters.createInstance(buddy, buddyUserAnonymizedId),
 				user.getUserAnonymizedId(), buddy.getId(), user.getDevices(), Status.REJECTED,
 				getDropBuddyMessage(DropBuddyReason.USER_ACCOUNT_DELETED, Optional.empty()));

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -12,6 +12,7 @@ spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.session.events.log=false
 # logging.level.org.hibernate.SQL=DEBUG
 # logging.level.org.hibernate=DEBUG
+# logging.level.org.hibernate.type.descriptor.sql=TRACE
 # logging.level.org.quartz=DEBUG
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.hibernate.use-new-id-generator-mappings=true


### PR DESCRIPTION
It used to fail in this scenario:
* Richard sends a buddy connect request to Bob
* Bob accepts the request
* Bob overwrites his account before Richard gets the chance to process the buddy connect response message
* Richard now gets a failure on everything because the pending buddy connect response message cannot be processed

The fix is to delete any pending buddy connect response messages of buddies that were deleted while the user was offline.