### PR TITLE
YD-657 Delete messages from buddy in incomplete state

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -191,6 +191,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(richard).acceptUrl
 		def acceptResponse = appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], richard.password)
 		assertResponseStatusOk(acceptResponse)
+		analysisService.postToAnalysisEngine(richard.requestingDevice, ["Gambling"], "http://www.poker.com")
 		appService.requestOverwriteUser(richard.mobileNumber)
 
 		when:

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
@@ -87,22 +87,22 @@ public class MessageDestination extends EntityWithUuid
 
 	public Page<Message> getMessages(Pageable pageable)
 	{
-		return Message.getRepository().findFromDestination(this.getId(), pageable);
+		return Message.getRepository().findFromDestination(this, pageable);
 	}
 
 	public Page<Message> getReceivedMessages(Pageable pageable, boolean onlyUnreadMessages)
 	{
 		if (onlyUnreadMessages)
 		{
-			return Message.getRepository().findUnreadReceivedMessagesFromDestination(this.getId(), pageable);
+			return Message.getRepository().findUnreadReceivedMessagesFromDestination(this, pageable);
 
 		}
-		return Message.getRepository().findReceivedMessagesFromDestination(this.getId(), pageable);
+		return Message.getRepository().findReceivedMessagesFromDestination(this, pageable);
 	}
 
 	public Page<Message> getReceivedMessages(Pageable pageable, LocalDateTime earliestDateTime)
 	{
-		return Message.getRepository().findReceivedMessagesFromDestinationSinceDate(this.getId(), earliestDateTime, pageable);
+		return Message.getRepository().findReceivedMessagesFromDestinationSinceDate(this, earliestDateTime, pageable);
 	}
 
 	private PublicKey loadPublicKey()
@@ -129,6 +129,6 @@ public class MessageDestination extends EntityWithUuid
 
 	public Page<Message> getActivityRelatedMessages(IntervalActivity intervalActivityEntity, Pageable pageable)
 	{
-		return Message.getRepository().findByIntervalActivity(getId(), intervalActivityEntity, pageable);
+		return Message.getRepository().findByIntervalActivity(this, intervalActivityEntity, pageable);
 	}
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
@@ -46,4 +46,8 @@ public interface MessageRepository extends JpaRepository<Message, Long>
 
 	@Query("select m.id from Message m, MessageDestination d where d.id = :destinationId and m.isProcessed = false and m member of d.messages order by m.id asc")
 	List<Long> findUnprocessedMessagesFromDestination(@Param("destinationId") UUID destinationId);
+
+	@Query("select m from Message m, MessageDestination d where d = :destination and m.relatedUserAnonymizedId = :relatedUserAnonymizedId and m member of d.messages order by m.id asc")
+	List<Message> findByRelatedUserAnonymizedId(@Param("destination") MessageDestination destination,
+			@Param("relatedUserAnonymizedId") UUID relatedUserAnonymizedId);
 }

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageRepository.java
@@ -22,30 +22,31 @@ import nu.yona.server.analysis.entities.IntervalActivity;
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long>
 {
-	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m member of d.messages order by m.creationTime desc")
-	Page<Message> findFromDestination(@Param("destinationId") UUID destinationId, Pageable pageable);
+	@Query("select m from Message m, MessageDestination d where d = :destination and m member of d.messages order by m.creationTime desc")
+	Page<Message> findFromDestination(@Param("destination") MessageDestination destination, Pageable pageable);
 
-	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
-	Page<Message> findReceivedMessagesFromDestination(@Param("destinationId") UUID destinationId, Pageable pageable);
+	@Query("select m from Message m, MessageDestination d where d = :destination and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
+	Page<Message> findReceivedMessagesFromDestination(@Param("destination") MessageDestination destination, Pageable pageable);
 
-	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m.isRead = false and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
-	Page<Message> findUnreadReceivedMessagesFromDestination(@Param("destinationId") UUID destinationId, Pageable pageable);
+	@Query("select m from Message m, MessageDestination d where d = :destination and m.isRead = false and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
+	Page<Message> findUnreadReceivedMessagesFromDestination(@Param("destination") MessageDestination destination,
+			Pageable pageable);
 
 	@Query("select m from Message m, MessageDestination d, Message threadHeadMessage"
-			+ " where d.id = :destinationId and m member of d.messages and m.intervalActivity = :intervalActivity and threadHeadMessage = m.threadHeadMessage"
+			+ " where d = :destination and m member of d.messages and m.intervalActivity = :intervalActivity and threadHeadMessage = m.threadHeadMessage"
 			+ " order by threadHeadMessage.creationTime asc, m.creationTime asc")
-	Page<Message> findByIntervalActivity(@Param("destinationId") UUID destinationId,
+	Page<Message> findByIntervalActivity(@Param("destination") MessageDestination destination,
 			@Param("intervalActivity") IntervalActivity intervalActivityEntity, Pageable pageable);
 
 	@Query("select m from Message m where m.intervalActivity in :intervalActivities")
 	Set<Message> findByIntervalActivity(@Param("intervalActivities") Collection<IntervalActivity> intervalActivities);
 
-	@Query("select m from Message m, MessageDestination d where d.id = :destinationId and m.creationTime >= :earliestDateTime and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
-	Page<Message> findReceivedMessagesFromDestinationSinceDate(@Param("destinationId") UUID destinationId,
+	@Query("select m from Message m, MessageDestination d where d = :destination and m.creationTime >= :earliestDateTime and m.isSentItem = false and m member of d.messages order by m.creationTime desc")
+	Page<Message> findReceivedMessagesFromDestinationSinceDate(@Param("destination") MessageDestination destination,
 			@Param("earliestDateTime") LocalDateTime earliestDateTime, Pageable pageable);
 
-	@Query("select m.id from Message m, MessageDestination d where d.id = :destinationId and m.isProcessed = false and m member of d.messages order by m.id asc")
-	List<Long> findUnprocessedMessagesFromDestination(@Param("destinationId") UUID destinationId);
+	@Query("select m.id from Message m, MessageDestination d where d = :destination and m.isProcessed = false and m member of d.messages order by m.id asc")
+	List<Long> findUnprocessedMessagesFromDestination(@Param("destination") MessageDestination destination);
 
 	@Query("select m from Message m, MessageDestination d where d = :destination and m.relatedUserAnonymizedId = :relatedUserAnonymizedId and m member of d.messages order by m.id asc")
 	List<Message> findByRelatedUserAnonymizedId(@Param("destination") MessageDestination destination,

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
@@ -129,7 +129,7 @@ public class MessageSource extends EntityWithUuid
 		return message;
 	}
 
-	public List<Message> getMessageFromRelatedUserAnonymizedId(UUID relatedUserAnonymizedId)
+	public List<Message> getMessagesFromRelatedUserAnonymizedId(UUID relatedUserAnonymizedId)
 	{
 		List<Message> messages = Message.getRepository().findByRelatedUserAnonymizedId(messageDestination,
 				relatedUserAnonymizedId);

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.entities;
@@ -8,6 +8,7 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 import javax.persistence.CascadeType;
@@ -126,6 +127,15 @@ public class MessageSource extends EntityWithUuid
 
 		message.decryptMessage(PublicKeyDecryptor.createInstance(loadPrivateKey()));
 		return message;
+	}
+
+	public List<Message> getMessageFromRelatedUserAnonymizedId(UUID relatedUserAnonymizedId)
+	{
+		List<Message> messages = Message.getRepository().findByRelatedUserAnonymizedId(messageDestination,
+				relatedUserAnonymizedId);
+		messages.forEach(m -> m.decryptMessage(PublicKeyDecryptor.createInstance(loadPrivateKey())));
+
+		return messages;
 	}
 
 	public MessageSource touch()

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageDto.java
@@ -223,9 +223,9 @@ public abstract class MessageDto extends PolymorphicDto
 
 		protected SenderInfo getSenderInfoExtensionPoint(Message messageEntity)
 		{
-			throw new IllegalStateException(
-					"Cannot find buddy for message of type '" + messageEntity.getClass().getName() + "' with user anonymized ID '"
-							+ messageEntity.getRelatedUserAnonymizedId().map(UUID::toString).orElse("UNKNOWN") + "'");
+			throw new IllegalStateException("Cannot find buddy for message with ID " + messageEntity.getId() + " of type '"
+					+ messageEntity.getClass().getName() + "' with user anonymized ID '"
+					+ messageEntity.getRelatedUserAnonymizedId().map(UUID::toString).orElse("UNKNOWN") + "'");
 		}
 
 		private SenderInfo createSenderInfoForSelf(UserDto actingUser)

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -153,7 +153,7 @@ public class MessageService
 	private List<Long> getUnprocessedMessageIds(User user)
 	{
 		MessageDestination anonymousMessageDestination = getAnonymousMessageSource(user).getDestination();
-		return messageRepository.findUnprocessedMessagesFromDestination(anonymousMessageDestination.getId());
+		return messageRepository.findUnprocessedMessagesFromDestination(anonymousMessageDestination);
 	}
 
 	public List<Message> getUnprocessedMessages(User user, Predicate<Message> predicate)

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -156,12 +156,16 @@ public class MessageService
 		return messageRepository.findUnprocessedMessagesFromDestination(anonymousMessageDestination.getId());
 	}
 
-	public void deleteUnprocessedMessages(User user, Predicate<Message> predicate)
+	public List<Message> getUnprocessedMessages(User user, Predicate<Message> predicate)
 	{
 		MessageSource messageSource = getAnonymousMessageSource(user);
-		List<Message> messagesToDelete = getUnprocessedMessageIds(user).stream().map(messageSource::getMessage).filter(predicate)
+		return getUnprocessedMessageIds(user).stream().map(messageSource::getMessage).filter(predicate)
 				.collect(Collectors.toList());
-		messageRepository.deleteInBatch(messagesToDelete);
+	}
+
+	public List<Message> getMessagesFromRelatedUserAnonymizedId(User user, UUID relatedUserAnonymizedId)
+	{
+		return getAnonymousMessageSource(user).getMessageFromRelatedUserAnonymizedId(relatedUserAnonymizedId);
 	}
 
 	@Transactional
@@ -210,7 +214,7 @@ public class MessageService
 		deleteMessages(Collections.singleton(message));
 	}
 
-	private void deleteMessages(Collection<Message> messages)
+	public void deleteMessages(Collection<Message> messages)
 	{
 		Set<Message> messagesToBeDeleted = messages.stream().flatMap(m -> m.getMessagesToBeCascadinglyDeleted().stream())
 				.collect(Collectors.toSet());

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -165,7 +165,7 @@ public class MessageService
 
 	public List<Message> getMessagesFromRelatedUserAnonymizedId(User user, UUID relatedUserAnonymizedId)
 	{
-		return getAnonymousMessageSource(user).getMessageFromRelatedUserAnonymizedId(relatedUserAnonymizedId);
+		return getAnonymousMessageSource(user).getMessagesFromRelatedUserAnonymizedId(relatedUserAnonymizedId);
 	}
 
 	@Transactional

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -367,12 +367,34 @@ public class BuddyService
 
 	private void prepareCleanupRemovedBuddyInPendingState(User user, Buddy buddy)
 	{
-		messageService.deleteUnprocessedMessages(user, m -> isBuddyConnectResponseFromBuddy(m, buddy));
+		removeUnprocessedBuddyAcceptanceMessages(user, buddy);
 		// Send message to "self", as if the requested user declined the buddy request
 		UUID buddyUserAnonymizedId = buddy.getUserAnonymizedId().orElse(null);
 		sendBuddyConnectResponseMessage(BuddyInfoParameters.createInstance(buddy, buddyUserAnonymizedId),
 				user.getUserAnonymizedId(), buddy.getId(), user.getDevices(), Status.REJECTED,
 				getDropBuddyMessage(DropBuddyReason.USER_ACCOUNT_DELETED, Optional.empty()));
+	}
+
+	private void removeUnprocessedBuddyAcceptanceMessages(User user, Buddy buddy)
+	{
+		List<Message> responseMessages = messageService.getUnprocessedMessages(user,
+				m -> isBuddyConnectResponseFromBuddy(m, buddy));
+		if (responseMessages.isEmpty())
+		{
+			return;
+		}
+		if (responseMessages.size() > 1)
+		{
+			throw new IllegalStateException("Multiple (" + responseMessages.size()
+					+ ") unprocessed buddy connect response messages exist for buddy with ID " + buddy.getId());
+		}
+		Message responseMessage = responseMessages.get(0);
+		UUID buddyUserAnonymizedId = responseMessage.getRelatedUserAnonymizedId()
+				.orElseThrow(() -> new IllegalStateException("No user anonymized ID on buddy connect response with ID "
+						+ responseMessage.getId() + " for buddy with ID " + buddy.getId()));
+		List<Message> messagesToDelete = messageService.getMessagesFromRelatedUserAnonymizedId(user, buddyUserAnonymizedId);
+		messagesToDelete.add(responseMessage);
+		messageService.deleteMessages(messagesToDelete);
 	}
 
 	private void prepareCleanupRemovedBuddyInAcceptedState(User user, Buddy buddy)


### PR DESCRIPTION
The related defect is about deleting the unprocessed buddy connect response (acceptance) of a buddy that overwrote their account. That same buddy might also have sent goal conflict messages already. These also need to be removed explicitly.

Along with this:
* Improved error logging in ``MessageDto``
* The ``MessageRepository`` used destination ID often where it could use destination. Refactored this to make the code type-safe and simpler.