### PR TITLE
YD-660 Fixed detached entity error

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/AnalysisEngineHibernateStatsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AnalysisEngineHibernateStatsTest.groovy
@@ -140,7 +140,7 @@ class AnalysisEngineHibernateStatsTest extends AbstractAppServiceIntegrationTest
 		stats.entityDeleteCount == 0
 		stats.entityFetchCount == 1
 		stats.entityInsertCount == 5
-		stats.entityLoadCount == 19
+		stats.entityLoadCount == 16
 		stats.entityUpdateCount == 4
 		stats.transactionCount == 2
 	}

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -204,6 +204,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(response)
 		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll
 		{ it."@type" == "BuddyConnectResponseMessage" }
+		buddyConnectResponseMessages.size() == 1
 		buddyConnectResponseMessages[0]._links."yona:user".href.startsWith(YonaServer.stripQueryString(bob.url))
 		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
 		buddyConnectResponseMessages[0].nickname == bob.nickname

--- a/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDto.java
+++ b/core/src/main/java/nu/yona/server/analysis/service/GoalConflictMessageDto.java
@@ -192,7 +192,7 @@ public class GoalConflictMessageDto extends MessageDto
 			messageEntity = updateMessageStatusAsDisclosureRequested(messageEntity);
 
 			UserAnonymizedDto toUser = userAnonymizedService.getUserAnonymized(messageEntity.getRelatedUserAnonymizedId().get());
-			messageService.sendMessageAndFlushToDatabase(
+			messageService.sendMessage(
 					DisclosureRequestMessage.createInstance(BuddyMessageDto.createBuddyInfoParametersInstance(actingUser),
 							requestPayload.getProperty("message"), messageEntity),
 					toUser);

--- a/core/src/main/java/nu/yona/server/messaging/entities/BuddyMessage.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/BuddyMessage.java
@@ -57,6 +57,20 @@ public abstract class BuddyMessage extends Message
 	}
 
 	/**
+	 * Copy constructor. See {@link nu.yona.server.messaging.entities.Message#duplicate()}
+	 * 
+	 * @param original Message to copy.
+	 */
+	public BuddyMessage(BuddyMessage original)
+	{
+		super(original);
+		this.senderUserId = original.senderUserId;
+		this.message = original.message;
+		this.senderNickname = original.senderNickname;
+		this.senderUserPhotoId = original.senderUserPhotoId;
+	}
+
+	/**
 	 * Returns the user sending this message.
 	 * 
 	 * @return The user sending this message. Might be null if that user is already deleted.

--- a/core/src/main/java/nu/yona/server/messaging/entities/Message.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/Message.java
@@ -88,7 +88,7 @@ public abstract class Message extends EntityWithId
 	 */
 	protected Message(Message original)
 	{
-		this.decryptionInfo = original.decryptionInfo;
+		this.decryptionInfo = null; // Set when encrypting the message
 		this.relatedUserAnonymizedId = original.relatedUserAnonymizedId;
 		this.threadHeadMessage = null;
 		this.messagesInThread = new ArrayList<>();
@@ -228,8 +228,10 @@ public abstract class Message extends EntityWithId
 	 * <li>The ID, which will be 0</li>
 	 * <li>References to other messages (e.g. replies). If this is ever necessary, it needs to be designed and built</li>
 	 * <li>Reference to the message destination. The duplicate is ready to be sent and does not have a destination yet.</li>
+	 * <li>Encrypted fields and decryptionInfo. These are set while encrypting the message when sending it to a destination</li>
 	 * </ul>
-	 * For this to work, the message class needs to have a public copy constructor.
+	 * For this to work, the message class needs to have a public copy constructor. Currently, it is only implemented for message
+	 * sent to the direct message destination of a user.
 	 * 
 	 * @return The duplicate message
 	 */

--- a/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
+++ b/core/src/main/java/nu/yona/server/messaging/entities/MessageDestination.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.Transient;
@@ -41,8 +40,7 @@ public class MessageDestination extends EntityWithUuid
 	@Transient
 	private PublicKey publicKey;
 
-	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JoinColumn(name = "message_destination_id", referencedColumnName = "id")
+	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "messageDestination")
 	private List<Message> messages;
 
 	// Default constructor is required for JPA

--- a/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDto.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/DisclosureRequestMessageDto.java
@@ -181,7 +181,7 @@ public class DisclosureRequestMessageDto extends BuddyMessageLinkedUserDto
 			UserAnonymizedDto toUser = userAnonymizedService.getUserAnonymized(
 					requestMessageEntity.getRelatedUserAnonymizedId().orElseThrow(() -> new IllegalStateException(
 							"Message with ID " + requestMessageEntity.getId() + " does not have a related user anonymized ID")));
-			messageService.sendMessageAndFlushToDatabase(
+			messageService.sendMessage(
 					DisclosureResponseMessage.createInstance(BuddyMessageDto.createBuddyInfoParametersInstance(respondingUser),
 							requestMessageEntity.getTargetGoalConflictMessage(), requestMessageEntity.getStatus(), message),
 					toUser);

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -29,8 +29,8 @@ import com.google.firebase.messaging.Notification;
 
 import nu.yona.server.Translator;
 import nu.yona.server.exceptions.YonaException;
-import nu.yona.server.messaging.entities.MessageRepository;
 import nu.yona.server.properties.YonaProperties;
+import nu.yona.server.util.Require;
 
 @Service
 public class FirebaseService
@@ -44,9 +44,6 @@ public class FirebaseService
 
 	@Autowired
 	private YonaProperties yonaProperties;
-
-	@Autowired(required = false)
-	private MessageRepository messageRepository;
 
 	@PostConstruct
 	private void init()
@@ -96,11 +93,7 @@ public class FirebaseService
 
 	private long getMessageId(nu.yona.server.messaging.entities.Message message)
 	{
-		if (message.getId() == 0)
-		{
-			// Message is not persisted yet, so it didn't yet get an ID. Persist it now.
-			messageRepository.saveAndFlush(message);
-		}
+		Require.that(message.getId() != 0, () -> YonaException.illegalState("Message must be saved before this point"));
 		return message.getId();
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectMessage.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils;
 import nu.yona.server.crypto.seckey.SecretKeyUtil;
 import nu.yona.server.device.entities.DeviceBase;
 import nu.yona.server.device.entities.UserDevice;
+import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.rest.RestUtil;
 
 @Entity
@@ -67,6 +68,20 @@ public abstract class BuddyConnectMessage extends BuddyConnectionChangeMessage
 		this.deviceNames = buildDeviceNamesString(orderedDevices);
 		this.deviceAnonymizedIds = buildDeviceAnonymizedIdsString(orderedDevices);
 		this.deviceVpnConnectionStatuses = buildDeviceVpnConnectionStatusesString(orderedDevices);
+	}
+
+	/**
+	 * Copy constructor. See {@link nu.yona.server.messaging.entities.Message#duplicate()}
+	 * 
+	 * @param original Message to copy.
+	 */
+	public BuddyConnectMessage(BuddyConnectMessage original)
+	{
+		super(original);
+		this.buddyId = original.buddyId;
+		this.deviceNames = original.deviceNames;
+		this.deviceAnonymizedIds = original.deviceAnonymizedIds;
+		this.deviceVpnConnectionStatuses = original.deviceVpnConnectionStatuses;
 	}
 
 	private String buildDeviceNamesString(List<UserDevice> devices)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectRequestMessage.java
@@ -45,6 +45,19 @@ public class BuddyConnectRequestMessage extends BuddyConnectMessage
 		this.isRequestingReceiving = isRequestingReceiving;
 	}
 
+	/**
+	 * Copy constructor. See {@link nu.yona.server.messaging.entities.Message#duplicate()}
+	 * 
+	 * @param original Message to copy.
+	 */
+	public BuddyConnectRequestMessage(BuddyConnectRequestMessage original)
+	{
+		super(original);
+		this.isRequestingSending = original.isRequestingSending;
+		this.isRequestingReceiving = original.isRequestingReceiving;
+		this.status = original.status;
+	}
+
 	public static BuddyConnectRequestMessage createInstance(BuddyInfoParameters buddyInfoParameters, String message, UUID buddyId,
 			Set<UserDevice> devices, boolean isRequestingSending, boolean isRequestingReceiving)
 	{

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyConnectionChangeMessage.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
@@ -13,6 +13,7 @@ import javax.persistence.Transient;
 
 import nu.yona.server.crypto.seckey.SecretKeyUtil;
 import nu.yona.server.messaging.entities.BuddyMessage;
+import nu.yona.server.messaging.entities.Message;
 
 @Entity
 public abstract class BuddyConnectionChangeMessage extends BuddyMessage
@@ -36,6 +37,18 @@ public abstract class BuddyConnectionChangeMessage extends BuddyMessage
 		super(buddyInfoParameters, message);
 		this.firstName = buddyInfoParameters.firstName;
 		this.lastName = buddyInfoParameters.lastName;
+	}
+
+	/**
+	 * Copy constructor. See {@link nu.yona.server.messaging.entities.Message#duplicate()}
+	 * 
+	 * @param original Message to copy.
+	 */
+	public BuddyConnectionChangeMessage(BuddyConnectionChangeMessage original)
+	{
+		super(original);
+		this.firstName = original.firstName;
+		this.lastName = original.lastName;
 	}
 
 	@Override

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyDisconnectMessage.java
@@ -7,6 +7,7 @@ package nu.yona.server.subscriptions.entities;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 
+import nu.yona.server.messaging.entities.Message;
 import nu.yona.server.subscriptions.service.BuddyService.DropBuddyReason;
 
 @Entity
@@ -26,6 +27,18 @@ public class BuddyDisconnectMessage extends BuddyConnectionChangeMessage
 	public BuddyDisconnectMessage()
 	{
 		super();
+	}
+
+	/**
+	 * Copy constructor. See {@link nu.yona.server.messaging.entities.Message#duplicate()}
+	 * 
+	 * @param original Message to copy.
+	 */
+	public BuddyDisconnectMessage(BuddyDisconnectMessage original)
+	{
+		super(original);
+		this.isProcessed = original.isProcessed;
+		this.reason = original.reason;
 	}
 
 	public static BuddyDisconnectMessage createInstance(BuddyInfoParameters buddyInfoParameters, String message,

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -537,7 +537,7 @@ public class BuddyService
 	{
 		UserAnonymizedDto toUser = userAnonymizedService.getUserAnonymized(receiverUserAnonymizedId);
 		assert toUser != null;
-		messageService.sendMessageAndFlushToDatabase(
+		messageService.sendMessage(
 				BuddyConnectResponseMessage.createInstance(buddyInfoParameters, responseMessage, buddyId, devices, status),
 				toUser);
 	}

--- a/core/src/test/java/nu/yona/server/messaging/service/MessageServiceTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/service/MessageServiceTest.java
@@ -207,6 +207,7 @@ public class MessageServiceTest extends BaseSpringIntegrationTest
 	public void prepareMessageCollection_transferringDirectMessagesToAnonymousDestination_sendsFirebaseMessage()
 	{
 		Message message = Mockito.mock(Message.class);
+		when(message.duplicate()).thenReturn(message);
 
 		User user = Mockito.mock(User.class);
 		when(user.getUserAnonymizedId()).thenReturn(userAnonId);


### PR DESCRIPTION
This scenario failed:
* User gets invited as buddy
* Invited user overwrites their account
* From the new account, they request the inviting user to become their buddy
* The inviting buddy now cannot process the messages anymore

This was because the direct messages were removed from the named destination and directly inserted in the anonymous destination.

This is now resolved by duplicating the messages. The original one is deleted from the direct destination and a duplicate of it is attached to the anonymous destination.

Along with this:
* Added extra assert to BasicBuddyTest.'Richard finds Bob\'s buddy connect response', to track down a duplicate message issue.
* Updated AnalysisEngineHibernateStatsTest.groovy to lower the number of entities loaded. That somehow improved.
* Removed MessageService.sendDirectMessageAndFlushToDatabase. THe regular sendDirectMessage now always flushes
* FirebaseService.sendMessage now does not save and flush the message anymore but it demands the message to be saved and flushed by its caller.