### PR TITLE
YD-662 Move creation time from User to UserPrivate

### DIFF
--- a/appservice/src/main/resources/static/swagger/swagger-spec.yaml
+++ b/appservice/src/main/resources/static/swagger/swagger-spec.yaml
@@ -2156,11 +2156,6 @@ definitions:
       - $ref: '#/definitions/BaseUser'
       - type: object
         properties:
-          creationTime:
-            type: string
-            format: dateTime
-            description: The creation time of this user
-            example: 2016-04-26T20:08:55.365+0200
           appLastOpenedDate:
             type: string
             format: date

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -206,8 +206,8 @@ public class DeviceService
 		assertAcceptableDeviceName(userEntity, changeRequest.name);
 		deviceEntity.setName(changeRequest.name);
 		userDeviceRepository.save(deviceEntity);
-		sendDeviceChangeMessageToBuddies(DeviceChange.RENAME, userEntity, Optional.of(oldName),
-				Optional.of(changeRequest.name), deviceEntity.getDeviceAnonymized().getId());
+		sendDeviceChangeMessageToBuddies(DeviceChange.RENAME, userEntity, Optional.of(oldName), Optional.of(changeRequest.name),
+				deviceEntity.getDeviceAnonymized().getId());
 	}
 
 	private void saveFirebaseInstanceIdIfUpdated(DeviceUpdateRequestDto changeRequest, UserDevice deviceEntity)
@@ -373,7 +373,19 @@ public class DeviceService
 		LocalDate appLastOpenedDate = deviceEntity.getAppLastOpenedDate();
 		if (appLastOpenedDate.isBefore(today))
 		{
+			roundUserCreationDateIfLoyalUser(userEntity);
 			deviceEntity.setAppLastOpenedDateToNow(userEntity);
+		}
+	}
+
+	private void roundUserCreationDateIfLoyalUser(User userEntity)
+	{
+		LocalDate roundedCreationDate = userEntity.getRoundedCreationDate();
+		if (roundedCreationDate.getDayOfMonth() != 1
+				&& TimeUtil.utcNow().toLocalDate().minusDays(30).isBefore(roundedCreationDate))
+		{
+			// User is active for more than 30 days. Set the date to the first of the month, to reduce identification risk
+			userEntity.setRoundedCreationDate(roundedCreationDate.withDayOfMonth(1));
 		}
 	}
 

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -382,7 +382,7 @@ public class DeviceService
 	{
 		LocalDate roundedCreationDate = userEntity.getRoundedCreationDate();
 		if (roundedCreationDate.getDayOfMonth() != 1
-				&& TimeUtil.utcNow().toLocalDate().minusDays(30).isBefore(roundedCreationDate))
+				&& TimeUtil.utcNow().toLocalDate().minusDays(30).isAfter(roundedCreationDate))
 		{
 			// User is active for more than 30 days. Set the date to the first of the month, to reduce identification risk
 			userEntity.setRoundedCreationDate(roundedCreationDate.withDayOfMonth(1));

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -40,7 +40,8 @@ public class User extends EntityWithUuid
 	@Column(unique = true)
 	private String mobileNumber;
 
-	private LocalDate roundedCreationDate;
+	// YD-666 Change to LocalDate when all users have migrated their data
+	private LocalDateTime roundedCreationDate;
 
 	private LocalDate appLastOpenedDate;
 
@@ -79,7 +80,7 @@ public class User extends EntityWithUuid
 	{
 		super(id);
 		this.initializationVector = initializationVector;
-		this.roundedCreationDate = TimeUtil.utcNow().toLocalDate();
+		this.roundedCreationDate = TimeUtil.utcNow().toLocalDate().atStartOfDay();
 		this.mobileNumber = mobileNumber;
 		this.setUserPrivate(userPrivate);
 		this.messageDestination = messageDestination;
@@ -111,12 +112,12 @@ public class User extends EntityWithUuid
 
 	public LocalDate getRoundedCreationDate()
 	{
-		return roundedCreationDate;
+		return roundedCreationDate.toLocalDate();
 	}
 
 	public void setRoundedCreationDate(LocalDate roundedCreationDate)
 	{
-		this.roundedCreationDate = roundedCreationDate;
+		this.roundedCreationDate = roundedCreationDate.atStartOfDay();
 	}
 
 	public Optional<LocalDate> getAppLastOpenedDate()
@@ -418,6 +419,19 @@ public class User extends EntityWithUuid
 		userPrivate.setLastName(lastName);
 		firstName = null;
 		lastName = null;
+	}
+
+	public void moveCreationTimeToPrivate()
+	{
+		if (userPrivate.getCreationTime() != null)
+		{
+			// Apparently already moved
+			return;
+		}
+		userPrivate.setCreationTime(roundedCreationDate);
+
+		// Round it to a date. Further rounding might happen as part of the app open event
+		roundedCreationDate = roundedCreationDate.toLocalDate().atStartOfDay();
 	}
 
 	public LocalDate getDateInUserTimezone(LocalDateTime utcDateTime)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -40,7 +40,7 @@ public class User extends EntityWithUuid
 	@Column(unique = true)
 	private String mobileNumber;
 
-	private LocalDateTime creationTime;
+	private LocalDate roundedCreationDate;
 
 	private LocalDate appLastOpenedDate;
 
@@ -79,7 +79,7 @@ public class User extends EntityWithUuid
 	{
 		super(id);
 		this.initializationVector = initializationVector;
-		this.creationTime = TimeUtil.utcNow();
+		this.roundedCreationDate = TimeUtil.utcNow().toLocalDate();
 		this.mobileNumber = mobileNumber;
 		this.setUserPrivate(userPrivate);
 		this.messageDestination = messageDestination;
@@ -106,7 +106,17 @@ public class User extends EntityWithUuid
 
 	public LocalDateTime getCreationTime()
 	{
-		return this.creationTime;
+		return userPrivate.getCreationTime();
+	}
+
+	public LocalDate getRoundedCreationDate()
+	{
+		return roundedCreationDate;
+	}
+
+	public void setRoundedCreationDate(LocalDate roundedCreationDate)
+	{
+		this.roundedCreationDate = roundedCreationDate;
 	}
 
 	public Optional<LocalDate> getAppLastOpenedDate()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -5,6 +5,7 @@
 package nu.yona.server.subscriptions.entities;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
@@ -25,11 +26,13 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import nu.yona.server.crypto.CryptoUtil;
+import nu.yona.server.crypto.seckey.DateTimeFieldEncryptor;
 import nu.yona.server.crypto.seckey.StringFieldEncryptor;
 import nu.yona.server.crypto.seckey.UUIDFieldEncryptor;
 import nu.yona.server.device.entities.UserDevice;
 import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.messaging.entities.MessageSource;
+import nu.yona.server.util.TimeUtil;
 
 @Entity
 @Table(name = "USERS_PRIVATE")
@@ -58,6 +61,9 @@ public class UserPrivate extends PrivateUserProperties
 	@Convert(converter = StringFieldEncryptor.class)
 	private String vpnPassword;
 
+	@Convert(converter = DateTimeFieldEncryptor.class)
+	private LocalDateTime creationTime;
+
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
 	@JoinColumn(name = "user_private_id", referencedColumnName = "id")
 	@Fetch(FetchMode.JOIN)
@@ -78,6 +84,7 @@ public class UserPrivate extends PrivateUserProperties
 		this.buddies = new HashSet<>();
 		this.anonymousMessageSourceId = anonymousMessageSourceId;
 		this.namedMessageSourceId = namedMessageSourceId;
+		this.creationTime = TimeUtil.utcNow();
 		this.devices = new HashSet<>();
 	}
 
@@ -138,6 +145,11 @@ public class UserPrivate extends PrivateUserProperties
 		Optional<String> retVal = Optional.of(vpnPassword);
 		vpnPassword = null;
 		return retVal;
+	}
+
+	public LocalDateTime getCreationTime()
+	{
+		return this.creationTime;
 	}
 
 	private boolean isDecrypted()

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserPrivate.java
@@ -152,6 +152,11 @@ public class UserPrivate extends PrivateUserProperties
 		return this.creationTime;
 	}
 
+	public void setCreationTime(LocalDateTime creationTime)
+	{
+		this.creationTime = creationTime;
+	}
+
 	private boolean isDecrypted()
 	{
 		return decryptionCheck != null;

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/UserRepository.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/UserRepository.java
@@ -37,6 +37,6 @@ public interface UserRepository extends JpaRepository<User, UUID>
 	@Query("select u from User u where u.newDeviceRequest != null and u.newDeviceRequest.creationTime < :cuttOffDate")
 	Set<User> findAllWithExpiredNewDeviceRequests(@Param("cuttOffDate") LocalDateTime cuttOffDate);
 
-	@Query("select count(u) from User u where u.appLastOpenedDate != null and datediff(u.appLastOpenedDate, u.creationTime) >= :minNumberOfDays and datediff(u.appLastOpenedDate, u.creationTime) < :maxNumberOfDays")
+	@Query("select count(u) from User u where u.appLastOpenedDate != null and datediff(u.appLastOpenedDate, u.roundedCreationDate) >= :minNumberOfDays and datediff(u.appLastOpenedDate, u.roundedCreationDate) < :maxNumberOfDays")
 	int countByNumberOfDaysAppOpenedAfterInstallation(int minNumberOfDays, int maxNumberOfDays);
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserDto.java
@@ -59,10 +59,10 @@ public class UserDto
 						namedMessageSourceId, anonymousMessageSourceId, goals, buddies, userAnonymizedId, devices));
 	}
 
-	private UserDto(UUID id, LocalDateTime creationTime, Optional<LocalDate> appLastOpenedDate, String mobileNumber,
-			boolean isConfirmed, boolean isCreatedOnBuddyRequest)
+	private UserDto(UUID id, Optional<LocalDate> appLastOpenedDate, String mobileNumber, boolean isConfirmed,
+			boolean isCreatedOnBuddyRequest)
 	{
-		this(id, Optional.of(creationTime), appLastOpenedDate, null, mobileNumber, isConfirmed, isCreatedOnBuddyRequest, null);
+		this(id, Optional.empty(), appLastOpenedDate, null, mobileNumber, isConfirmed, isCreatedOnBuddyRequest, null);
 	}
 
 	@JsonCreator
@@ -185,8 +185,8 @@ public class UserDto
 	{
 		Objects.requireNonNull(userEntity, "userEntity cannot be null");
 
-		return new UserDto(userEntity.getId(), userEntity.getCreationTime(), userEntity.getAppLastOpenedDate(),
-				userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(), userEntity.isCreatedOnBuddyRequest());
+		return new UserDto(userEntity.getId(), userEntity.getAppLastOpenedDate(), userEntity.getMobileNumber(),
+				userEntity.isMobileNumberConfirmed(), userEntity.isCreatedOnBuddyRequest());
 	}
 
 	public static UserDto createInstance(User userEntity, Set<BuddyDto> buddies)
@@ -203,7 +203,7 @@ public class UserDto
 
 	public static UserDto createInstance(User userEntity, BuddyUserPrivateDataDto buddyData)
 	{
-		return new UserDto(userEntity.getId(), Optional.of(userEntity.getCreationTime()), userEntity.getAppLastOpenedDate(), null,
+		return new UserDto(userEntity.getId(), Optional.empty(), userEntity.getAppLastOpenedDate(), null,
 				userEntity.getMobileNumber(), userEntity.isMobileNumberConfirmed(), userEntity.isCreatedOnBuddyRequest(),
 				buddyData);
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/migration/EncryptUserCreationTime.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/migration/EncryptUserCreationTime.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.subscriptions.service.migration;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
+
+@Component
+@Order(4) // Never change the order or remove a migration step. If the step is obsolete, make it empty
+public class EncryptUserCreationTime implements MigrationStep
+{
+	@Override
+	public void upgrade(User user)
+	{
+		user.moveCreationTimeToPrivate();
+	}
+}

--- a/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
+++ b/core/src/test/java/nu/yona/server/device/service/DeviceServiceTest.java
@@ -810,6 +810,38 @@ public class DeviceServiceTest extends BaseSpringIntegrationTest
 	}
 
 	@Test
+	public void postOpenAppEvent_loyalUser_roundedCreationDateUpdated()
+	{
+		UserDevice device = addDeviceToRichard(0, "First", OperatingSystem.ANDROID);
+		LocalDate creationDate = TimeUtil.utcNow().toLocalDate().minusDays(31);
+		LocalDate originalDate = TimeUtil.utcNow().toLocalDate().minusDays(1);
+		richard.setAppLastOpenedDate(originalDate);
+		setAppLastOpenedDateField(device, originalDate);
+		richard.setRoundedCreationDate(creationDate);
+
+		service.postOpenAppEvent(richard.getId(), device.getId(), Optional.empty(), Optional.of(SOME_APP_VERSION),
+				SUPPORTED_APP_VERSION_CODE);
+
+		assertEquals(creationDate.withDayOfMonth(1), richard.getRoundedCreationDate());
+	}
+
+	@Test
+	public void postOpenAppEvent_newUser_roundedCreationDateNotUpdated()
+	{
+		UserDevice device = addDeviceToRichard(0, "First", OperatingSystem.ANDROID);
+		LocalDate creationDate = TimeUtil.utcNow().toLocalDate().minusDays(30);
+		LocalDate originalDate = TimeUtil.utcNow().toLocalDate().minusDays(1);
+		richard.setAppLastOpenedDate(originalDate);
+		setAppLastOpenedDateField(device, originalDate);
+		richard.setRoundedCreationDate(creationDate);
+
+		service.postOpenAppEvent(richard.getId(), device.getId(), Optional.empty(), Optional.of(SOME_APP_VERSION),
+				SUPPORTED_APP_VERSION_CODE);
+
+		assertEquals(creationDate, richard.getRoundedCreationDate());
+	}
+
+	@Test
 	public void removeDuplicateDefaultDevices_singleDevice_noChange()
 	{
 		// Add devices

--- a/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegration_stepOrderTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/PrivateUserDataMigrationServiceIntegration_stepOrderTest.java
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
@@ -29,6 +29,7 @@ import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.Migr
 import nu.yona.server.subscriptions.service.migration.AddFirstDevice;
 import nu.yona.server.subscriptions.service.migration.EncryptBuddyLastStatusChangeTime;
 import nu.yona.server.subscriptions.service.migration.EncryptFirstAndLastName;
+import nu.yona.server.subscriptions.service.migration.EncryptUserCreationTime;
 import nu.yona.server.subscriptions.service.migration.MoveVpnPasswordToDevice;
 import nu.yona.server.test.util.BaseSpringIntegrationTest;
 import nu.yona.server.test.util.JUnitUtil;
@@ -74,6 +75,9 @@ public class PrivateUserDataMigrationServiceIntegration_stepOrderTest extends Ba
 	@Autowired
 	private EncryptFirstAndLastName step4;
 
+	@Autowired
+	private EncryptUserCreationTime step5;
+
 	@Override
 	protected Map<Class<?>, Repository<?, ?>> getRepositories()
 	{
@@ -85,6 +89,6 @@ public class PrivateUserDataMigrationServiceIntegration_stepOrderTest extends Ba
 	{
 		@SuppressWarnings("unchecked")
 		List<MigrationStep> migrationSteps = (List<MigrationStep>) migrationStepsField.get(service);
-		assertThat(migrationSteps, contains(step1, step2, step3, step4));
+		assertThat(migrationSteps, contains(step1, step2, step3, step4, step5));
 	}
 }

--- a/core/src/test/java/nu/yona/server/subscriptions/service/migration/EncryptUserCreationTimeTest.java
+++ b/core/src/test/java/nu/yona/server/subscriptions/service/migration/EncryptUserCreationTimeTest.java
@@ -1,0 +1,105 @@
+package nu.yona.server.subscriptions.service.migration;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.repository.Repository;
+
+import nu.yona.server.crypto.seckey.CryptoSession;
+import nu.yona.server.entities.MessageSourceRepositoryMock;
+import nu.yona.server.entities.UserAnonymizedRepositoryMock;
+import nu.yona.server.entities.UserRepositoryMock;
+import nu.yona.server.messaging.entities.MessageSource;
+import nu.yona.server.subscriptions.entities.User;
+import nu.yona.server.subscriptions.entities.UserAnonymized;
+import nu.yona.server.subscriptions.entities.UserAnonymizedRepository;
+import nu.yona.server.subscriptions.entities.UserPrivate;
+import nu.yona.server.subscriptions.entities.UserRepository;
+import nu.yona.server.subscriptions.service.PrivateUserDataMigrationService.MigrationStep;
+import nu.yona.server.test.util.JUnitUtil;
+
+class EncryptUserCreationTimeTest
+{
+	private static final String PASSWORD = "password";
+	private static final LocalDateTime TEST_CREATION_TIME = LocalDateTime.parse("2019-11-26T21:15:31.043");
+
+	private final MigrationStep migrationStep = new EncryptUserCreationTime();
+
+	protected UserRepository userRepository;
+
+	protected UserAnonymizedRepository userAnonymizedRepository;
+
+	private User user;
+	private UserPrivate userPrivate;
+
+	private ZoneId userAnonZoneId;
+
+	@BeforeEach
+	public void setUpPerTest() throws Exception
+	{
+		setUpRepositoryMocks();
+
+		try (CryptoSession cryptoSession = CryptoSession.start(PASSWORD))
+		{
+			user = JUnitUtil.createRichard();
+			userPrivate = JUnitUtil.getUserPrivate(user);
+			userAnonZoneId = userAnonymizedRepository.getOne(user.getUserAnonymizedId()).getTimeZone();
+		}
+
+		userPrivate = Mockito.spy(userPrivate);
+		JUnitUtil.setUserPrivate(user, userPrivate);
+
+	}
+
+	private void setUpRepositoryMocks()
+	{
+		userRepository = new UserRepositoryMock();
+		userAnonymizedRepository = new UserAnonymizedRepositoryMock();
+
+		Map<Class<?>, Repository<?, ?>> repositoriesMap = new HashMap<>();
+		repositoriesMap.put(User.class, userRepository);
+		repositoriesMap.put(UserAnonymized.class, userAnonymizedRepository);
+		repositoriesMap.put(MessageSource.class, new MessageSourceRepositoryMock());
+		JUnitUtil.setUpRepositoryProviderMock(repositoriesMap);
+	}
+
+	@Test
+	void upgrade_moveCreationTime_creationTimeMoved()
+	{
+		JUnitUtil.skipAfter("Skip shortly before midnight", now(), 23, 55);
+
+		JUnitUtil.setRoundedCreationDate(user, TEST_CREATION_TIME);
+		JUnitUtil.setCreationTime(userPrivate, null);
+		migrationStep.upgrade(user);
+
+		assertThat(userPrivate.getCreationTime(), equalTo(TEST_CREATION_TIME));
+		assertThat(user.getRoundedCreationDate(), equalTo(TEST_CREATION_TIME.toLocalDate()));
+		assertThat(JUnitUtil.getRoundedCreationDate(user), equalTo(TEST_CREATION_TIME.toLocalDate().atStartOfDay()));
+	}
+
+	@Test
+	void upgrade_againMoveCreationTime_noChange()
+	{
+		JUnitUtil.skipAfter("Skip shortly before midnight", now(), 23, 55);
+
+		// Creation time is already set, so upgrade should not call setCreationTime
+		migrationStep.upgrade(user);
+		verify(userPrivate, never()).setCreationTime(Mockito.any());
+	}
+
+	private ZonedDateTime now()
+	{
+		return ZonedDateTime.now().withZoneSameInstant(userAnonZoneId);
+	}
+}

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import org.springframework.data.repository.support.Repositories;
 
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.entities.RepositoryProvider;
+import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.messaging.entities.MessageSource;
 import nu.yona.server.subscriptions.entities.Buddy;
 import nu.yona.server.subscriptions.entities.BuddyAnonymized.Status;
@@ -36,6 +38,9 @@ import nu.yona.server.subscriptions.entities.UserPrivate;
 
 public class JUnitUtil
 {
+	private static final Field userPrivateField = JUnitUtil.getAccessibleField(User.class, "userPrivate");
+	private static final Field creationTimeField = JUnitUtil.getAccessibleField(UserPrivate.class, "creationTime");
+	private static final Field roundedCreationDateField = JUnitUtil.getAccessibleField(User.class, "roundedCreationDate");
 
 	private JUnitUtil()
 	{
@@ -126,8 +131,85 @@ public class JUnitUtil
 		return field;
 	}
 
+	public static LocalDateTime getRoundedCreationDate(User user)
+	{
+		try
+		{
+			return (LocalDateTime) roundedCreationDateField.get(user);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	public static void setRoundedCreationDate(User user, LocalDateTime time)
+	{
+		try
+		{
+			roundedCreationDateField.set(user, time);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	public static LocalDateTime getCreationTime(UserPrivate userPrivate)
+	{
+		try
+		{
+			return (LocalDateTime) creationTimeField.get(userPrivate);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	public static void setCreationTime(UserPrivate userPrivate, LocalDateTime time)
+	{
+		try
+		{
+			creationTimeField.set(userPrivate, time);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	public static UserPrivate getUserPrivate(User user)
+	{
+		try
+		{
+			return (UserPrivate) userPrivateField.get(user);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	public static void setUserPrivate(User user, UserPrivate userPrivate)
+	{
+		try
+		{
+			userPrivateField.set(user, userPrivate);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
 	public static void skipBefore(String description, ZonedDateTime now, int hour, int minute)
 	{
 		assumeTrue(now.isAfter(now.withHour(hour).withMinute(minute).withSecond(0)), description);
+	}
+
+	public static void skipAfter(String description, ZonedDateTime now, int hour, int minute)
+	{
+		assumeTrue(now.isBefore(now.withHour(hour).withMinute(minute).withSecond(0)), description);
 	}
 }

--- a/dbinit/src/main/liquibase/updates/changelog-0023-yd-662.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0023-yd-662.yml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+- changeSet:
+    id: 1574507329427-6
+    author: bert (manually created)
+    changes:
+    - renameColumn:
+        oldColumnName: creation_time
+        newColumnName: rounded_creation_date
+        columnDataType: datetime(6) 
+        tableName: users
+    - modifyDataType:
+        columnName: rounded_creation_date
+        newDataType: date
+        tableName: users
+- changeSet:
+    id: 1574507329427-7
+    author: bert (generated)
+    changes:
+    - addColumn:
+        columns:
+        - column:
+            name: creation_time
+            type: varchar(255)
+        tableName: users_private

--- a/dbinit/src/main/liquibase/updates/changelog-0023-yd-662.yml
+++ b/dbinit/src/main/liquibase/updates/changelog-0023-yd-662.yml
@@ -8,10 +8,6 @@ databaseChangeLog:
         newColumnName: rounded_creation_date
         columnDataType: datetime(6) 
         tableName: users
-    - modifyDataType:
-        columnName: rounded_creation_date
-        newDataType: date
-        tableName: users
 - changeSet:
     id: 1574507329427-7
     author: bert (generated)

--- a/dbinit/src/main/liquibase/updates/updates.yml
+++ b/dbinit/src/main/liquibase/updates/updates.yml
@@ -68,3 +68,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: changelog-0022-yd-642.yml
+  - include:
+      relativeToChangelogFile: true
+      file: changelog-0023-yd-662.yml


### PR DESCRIPTION
This field is an identification risk. We only use it for management tasks, but for that we don't need the precise date, so we could as well round all creation dates to the first of the month and keep the real creation date encrypted inside UserPrivate.

By keeping it there, we can still see when the user was created and use that for decisions like determining the "earliest possible date" for activities.

The rounding only happens for users that use the app for more than 30 days. This way, we can still get insight in the usage statistics and see early leavers. The risk for these short-term users is lot smaller as they gather little data.