### PR TITLE
YD-652 Add app version info to logging context

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -363,6 +363,34 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		"IOS" | null | 5000 | 400
 	}
 
+	def 'Use different app version headers'(appVersionHeader, responseStatus)
+	{
+		given:
+		def ts = timestamp
+		User john = createJohnDoe(ts)
+		john = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, john)
+
+		when:
+		def response = appService.getResourceWithPassword(john.url, john.password, ["Yona-App-Version" : appVersionHeader])
+
+		then:
+		assertResponseStatus(response, responseStatus)
+
+		cleanup:
+		appService.deleteUser(john)
+
+		where:
+		appVersionHeader | responseStatus
+		"ANDROID/123/1.2 build 360" | 200
+		"IOS/123/1.2 build 360" | 200
+		"IOS/123/1.2" | 200
+		"ANDROID/abc/1.2 build 360" | 400
+		"ANDROID/-1/1.2 build 360" | 400
+		"ANDROID/0/1.2 build 360" | 400
+		"ANDROID/123" | 400
+		"ANDROID/123/a/b" | 400
+	}
+
 	private User createJohnDoe(ts, deviceName, deviceOperatingSystem, firebaseInstanceId = null)
 	{
 		appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "John", "Doe", "JD",

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -8,6 +8,8 @@ import java.io.Serializable;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
+import nu.yona.server.rest.Constants;
+
 /**
  * This exception is to be used in case data is wrong in DTOs. So whenever a field has a wrong value you should throw this
  * exception.
@@ -149,5 +151,15 @@ public class InvalidDataException extends YonaException
 	public static InvalidDataException missingRequestParameter(String name, String hint)
 	{
 		return new InvalidDataException("error.request.missing.request.parameter", name, hint);
+	}
+
+	public static InvalidDataException invalidAppVersionHeader(String header)
+	{
+		return new InvalidDataException("error.request.with.invalid.app.version.header", Constants.APP_VERSION_HEADER, header);
+	}
+
+	public static InvalidDataException invalidVersionCode(String versionCodeString)
+	{
+		return new InvalidDataException("error.request.with.invalid.version.code", versionCodeString);
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/Constants.java
+++ b/core/src/main/java/nu/yona/server/rest/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
@@ -8,6 +8,7 @@ public final class Constants
 {
 	public static final String PASSWORD_HEADER = "Yona-Password";
 	public static final String NEW_DEVICE_REQUEST_PASSWORD_HEADER = "Yona-NewDeviceRequestPassword";
+	public static final String APP_VERSION_HEADER = "Yona-App-Version";
 
 	private Constants()
 	{

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -97,18 +97,10 @@ public class ErrorLoggingFilter implements Filter
 			MDC.put(APP_VERSION_NAME_MDC_KEY, versionName);
 		}
 
-		private static Optional<YonaException> validateHeaders(HttpServletRequest request)
+		private static void assertValidHeaders(HttpServletRequest request)
 		{
-			try
-			{
-				Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER))
-						.ifPresent(LoggingContext::validateAppVersionHeader);
-			}
-			catch (YonaException e)
-			{
-				return Optional.of(e);
-			}
-			return Optional.empty();
+			Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER))
+					.ifPresent(LoggingContext::validateAppVersionHeader);
 		}
 
 		private static void validateAppVersionHeader(String header)
@@ -160,10 +152,12 @@ public class ErrorLoggingFilter implements Filter
 	{
 		HttpServletRequest request = (HttpServletRequest) servletRequest;
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
-		Optional<YonaException> exception = LoggingContext.validateHeaders(request);
-		if (exception.isPresent())
+		try
 		{
-			YonaException e = exception.get();
+			LoggingContext.assertValidHeaders(request);
+		}
+		catch (YonaException e)
+		{
 			response.sendError(e.getStatusCode().value(), e.getMessage());
 			logResponseStatus(request, response, e.getStatusCode().series());
 			return;

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -163,7 +163,9 @@ public class ErrorLoggingFilter implements Filter
 		Optional<YonaException> exception = LoggingContext.validateHeaders(request);
 		if (exception.isPresent())
 		{
-			response.sendError(exception.get().getStatusCode().value(), exception.get().getMessage());
+			YonaException e = exception.get();
+			response.sendError(e.getStatusCode().value(), e.getMessage());
+			logResponseStatus(request, response, e.getStatusCode().series());
 			return;
 		}
 

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -1,13 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.servlet.Filter;
@@ -26,6 +29,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.stereotype.Component;
 
+import nu.yona.server.exceptions.InvalidDataException;
+import nu.yona.server.exceptions.YonaException;
+import nu.yona.server.util.Require;
+
 @Component
 public class ErrorLoggingFilter implements Filter
 {
@@ -37,8 +44,13 @@ public class ErrorLoggingFilter implements Filter
 
 	public static class LoggingContext implements AutoCloseable
 	{
-		private static final String CORRELATION_ID = "yona.correlation.id";
 		private static final String TRACE_ID_HEADER = "x-b3-traceid";
+		private static final String CORRELATION_ID_MDC_KEY = "yona.correlation.id";
+		private static final String APP_OS_MDC_KEY = "yona.app.os";
+		private static final String APP_VERSION_CODE_MDC_KEY = "yona.app.versionCode";
+		private static final String APP_VERSION_NAME_MDC_KEY = "yona.app.versionName";
+		private static final List<String> MDC_KEYS = Arrays.asList(CORRELATION_ID_MDC_KEY, APP_OS_MDC_KEY,
+				APP_VERSION_CODE_MDC_KEY, APP_VERSION_NAME_MDC_KEY);
 
 		private LoggingContext()
 		{
@@ -48,18 +60,20 @@ public class ErrorLoggingFilter implements Filter
 		@Override
 		public void close()
 		{
-			MDC.remove(CORRELATION_ID);
+			MDC_KEYS.forEach(MDC::remove);
 		}
 
 		public static LoggingContext createInstance(HttpServletRequest request)
 		{
-			MDC.put(CORRELATION_ID, getCorrelationId(request));
+			MDC.put(CORRELATION_ID_MDC_KEY, getCorrelationId(request));
+			Optional<String> yonaAppVersionHeader = Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER));
+			yonaAppVersionHeader.ifPresent(LoggingContext::putAppVersionContext);
 			return new LoggingContext();
 		}
 
 		public static String getCorrelationId()
 		{
-			return (String) MDC.get(CORRELATION_ID);
+			return (String) MDC.get(CORRELATION_ID_MDC_KEY);
 		}
 
 		private static String getCorrelationId(HttpServletRequest request)
@@ -72,6 +86,60 @@ public class ErrorLoggingFilter implements Filter
 			return traceIdHeader;
 		}
 
+		private static void putAppVersionContext(String header)
+		{
+			String[] parts = header.split("/");
+			String operatingSystem = parts[0];
+			int versionCode = Integer.parseInt(parts[1]);
+			String versionName = parts[2];
+			MDC.put(APP_OS_MDC_KEY, operatingSystem);
+			MDC.put(APP_VERSION_CODE_MDC_KEY, versionCode);
+			MDC.put(APP_VERSION_NAME_MDC_KEY, versionName);
+		}
+
+		private static Optional<YonaException> validateHeaders(HttpServletRequest request)
+		{
+			try
+			{
+				Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER))
+						.ifPresent(LoggingContext::validateAppVersionHeader);
+			}
+			catch (YonaException e)
+			{
+				return Optional.of(e);
+			}
+			return Optional.empty();
+		}
+
+		private static void validateAppVersionHeader(String header)
+		{
+			String[] parts = header.split("/");
+			Require.that(parts.length == 3, () -> InvalidDataException.invalidAppVersionHeader(header));
+			assertValidOperatingSystem(parts[0]);
+			assertValidVersionCode(parts[1]);
+		}
+
+		private static void assertValidOperatingSystem(String osString)
+		{
+			Require.that(osString.equals("ANDROID") || osString.equals("IOS"),
+					() -> InvalidDataException.invalidOperatingSystem(osString));
+		}
+
+		private static void assertValidVersionCode(String versionCodeString)
+		{
+			try
+			{
+				if (Integer.parseInt(versionCodeString) > 0)
+				{
+					return;
+				}
+			}
+			catch (NumberFormatException e)
+			{
+				// Handled below
+			}
+			throw InvalidDataException.invalidVersionCode(versionCodeString);
+		}
 	}
 
 	private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingFilter.class);
@@ -92,7 +160,19 @@ public class ErrorLoggingFilter implements Filter
 	{
 		HttpServletRequest request = (HttpServletRequest) servletRequest;
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
+		Optional<YonaException> exception = LoggingContext.validateHeaders(request);
+		if (exception.isPresent())
+		{
+			response.sendError(exception.get().getStatusCode().value(), exception.get().getMessage());
+			return;
+		}
 
+		handleRequestInContext(chain, request, response);
+	}
+
+	private void handleRequestInContext(FilterChain chain, HttpServletRequest request, HttpServletResponse response)
+			throws IOException, ServletException
+	{
 		try (LoggingContext loggingContext = LoggingContext.createInstance(request))
 		{
 			chain.doFilter(request, response);

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -179,6 +179,8 @@ error.batch.job.not.found=Job ''{1}'' not found in group ''{0}''
 error.request.missing.property=Mandatory property ''{0}'' is missing. Hint: {1}
 error.request.extra.property=Property ''{0}'' is not supported in this context. Hint: {1}
 error.request.missing.request.parameter=Request parameter ''{0}'' is mandatory in this context. Hint: {1}
+error.request.with.invalid.app.version.header=Request header ''{0}'' is invalid: ''{1}''. Should follow the format <OS>/<versionCode>/<versionName>
+error.request.with.invalid.version.code="Request contains an invalid version code: ''{0}''. Must be an integer value > 0
 
 error.missing.entity=Inconsistent data: entity of type ''{0}'' with ID ''{1}'' cannot be found
 

--- a/core/src/main/resources/messages/messages_nl.properties
+++ b/core/src/main/resources/messages/messages_nl.properties
@@ -160,9 +160,9 @@ error.user.overwrite.confirmation.code.mismatch=De bevestigingscode ({1}) voor h
 error.user.overwrite.confirmation.code.not.set=De bevestigingscode voor het overschrijven van het account van nummer ''{0}'' is niet gezet
 error.user.overwrite.confirmation.code.too.many.failed.attempts=Te veel mislukte pogingen bij het invoeren van de bevestigingscode voor het overschrijven van het account met nummer ''{0}''
 
-error.pin.reset.overwrite.confirmation.code.mismatch=De bevestigingscode ({1}) voor het resetten van de pin van het account van nummer ''{0}'' is onjuist
-error.pin.reset.overwrite.confirmation.code.not.set=De bevestigingscode voor het resetten van de pin van het account van nummer ''{0}'' is niet gezet
-error.pin.reset.overwrite.confirmation.code.too.many.failed.attempts=Te veel mislukte pogingen bij het invoeren van de bevestigingscode voor het resetten van de pin van het account met nummer ''{0}''
+error.pin.reset.request.confirmation.code.mismatch=De bevestigingscode ({1}) voor het resetten van de pin van het account van nummer ''{0}'' is onjuist
+error.pin.reset.request.confirmation.code.not.set=De bevestigingscode voor het resetten van de pin van het account van nummer ''{0}'' is niet gezet
+error.pin.reset.request.confirmation.code.too.many.failed.attempts=Te veel mislukte pogingen bij het invoeren van de bevestigingscode voor het resetten van de pin van het account met nummer ''{0}''
 
 error.email.sending.failed=Versturen e-mail mislukt: {0}
 
@@ -179,6 +179,8 @@ error.batch.job.not.found=Job ''{1}'' niet gevonden in groep ''{0}''
 error.request.missing.property=Verplicht property ''{0}'' ontbreekt. Hint: {1}
 error.request.extra.property=Property ''{0}'' wordt niet ondersteund. Hint: {1}
 error.request.missing.request.parameter=Request parameter ''{0}'' is verplicht in deze context. Hint: {1}
+error.request.with.invalid.app.version.header=HTTP header ''{0}'' is fout: ''{1}''. Deze moet aan het patroon <OS>/<versionCode>/<versionName> voldoen. 
+error.request.with.invalid.version.code="Request bevat een foute version code: ''{0}''. Moet een integer zijn > 0
 
 error.missing.entity=Inconsistente data: entity van het type ''{0}'' met ID ''{1}'' kan niet worden gevonden
 


### PR DESCRIPTION
Added the information from the Yona-App-Version header to the MDC.

Along with this corrected the message IDs of the Dutch messages for PIN reset confirmation codes from "error.pin.reset.overwrite.confirmation" into "error.pin.reset.request.confirmation".