### PR TITLE
YD-669 Pass app info all the way

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
 				KUBECONFIG = "/opt/ope-cloudbees/yona/k8s/admin.conf"
 			}
 			steps {
-				getValuesYaml(4, "/helm/values.yaml", valuesYamlOnRegressionTestServer)
+				getValuesYaml(4, "infrastructure/helm/values.yaml", valuesYamlOnRegressionTestServer)
 				sh 'while ! $(curl -s -q -f -o /dev/null https://jump.ops.yona.nu/helm-charts/yona-1.2.$BUILD_NUMBER_TO_DEPLOY.tgz) ;do echo Waiting for Helm chart to become available; sleep 5; done'
 				sh script: 'helm delete --purge yona; kubectl delete -n yona configmaps --all; kubectl delete -n yona job --all; kubectl delete -n yona secrets --all; kubectl delete pvc -n yona --all', returnStatus: true
 				sh script: 'echo Waiting for purge to complete; sleep 30'
@@ -245,6 +245,6 @@ void getValuesYaml(def repoNumber, def srcPath, def targetPath)
 	def encodedPath = java.net.URLEncoder.encode(srcPath, "UTF-8")
 	sh "mkdir --parents `dirname ${targetPath}`"
 	withCredentials([string( credentialsId: 'gitlab-yonabuild', variable: 'token')]) {
-		sh "wget --header='PRIVATE-TOKEN: ${token}' --output-document=${targetPath} https://git.ops.yona.nu/api/v4/projects/${repoNumber}/repository/files/infrastructure${encodedPath}/raw?ref=master"
+		sh "wget --header='PRIVATE-TOKEN: ${token}' --output-document=${targetPath} https://git.ops.yona.nu/api/v4/projects/${repoNumber}/repository/files/${encodedPath}/raw?ref=master"
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -83,7 +83,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	{
 		def deviceName = makeDeviceName("Bob", operatingSystem)
 		User bob = appService.addUser(CommonAssertions.&assertUserCreationResponseDetails, "Bob", "Dunn", "BD",
-				makeMobileNumber(timestamp), deviceName, operatingSystem, Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE, null, ["Accept-Language" : language])
+				makeMobileNumber(timestamp), deviceName, operatingSystem, Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE, null, [:], ["Accept-Language" : language])
 		bob = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, bob)
 		def response = appService.addGoal(bob, BudgetGoal.createNoGoInstance(NEWS_ACT_CAT_URL))
 		assertResponseStatusCreated(response)

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -253,7 +253,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		Buddy[] buddiesBob = appService.getBuddies(bob)
 
 		then:
-		def getBuddyUserGoalsResponse = appService.yonaServer.getResource(richard.buddies[0].user.goalsUrl, ["Yona-Password": richard.password])
+		def getBuddyUserGoalsResponse = appService.yonaServer.getResource(richard.buddies[0].user.goalsUrl, [:], ["Yona-Password": richard.password])
 		assertResponseStatusOk(getBuddyUserGoalsResponse)
 		getBuddyUserGoalsResponse.responseData._embedded."yona:goals".size() == 2
 
@@ -271,12 +271,12 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		buddiesRichard[0].user.goals.each
 		{
-			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": richard.password]))
+			assertResponseStatusOk(appService.yonaServer.getResource(it.url, [:], ["Yona-Password": richard.password]))
 		}
 
 		buddiesBob[0].user.goals.each
 		{
-			assertResponseStatusOk(appService.yonaServer.getResource(it.url, ["Yona-Password": bob.password]))
+			assertResponseStatusOk(appService.yonaServer.getResource(it.url, [:], ["Yona-Password": bob.password]))
 		}
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -381,7 +381,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def inviteUrl = getInviteUrl()
 
 		when:
-		def response = appService.getResource(YonaServer.stripQueryString(inviteUrl), [:], ["tempPassword": "hack", "requestingUserId": richard.getId()])
+		def response = appService.getResource(YonaServer.stripQueryString(inviteUrl), ["tempPassword": "hack", "requestingUserId": richard.getId()])
 
 		then:
 		assertResponseStatus(response, 400)
@@ -405,7 +405,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 				"lastName":"Quin",
 				"nickname":"RQ",
 				"mobileNumber":"${makeMobileNumber(timestamp)}"
-			}""", [:], ["tempPassword": "hack"])
+			}""", ["tempPassword": "hack"])
 
 		then:
 		assertResponseStatus(response, 400)
@@ -422,7 +422,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 
 		when:
-		def response = appService.getResource(richard.url, [:], ["tempPassword": richard.password, "requestingUserId": richard.getId()])
+		def response = appService.getResource(richard.url, ["tempPassword": richard.password, "requestingUserId": richard.getId()])
 
 		then:
 		assertResponseStatus(response, 400)
@@ -464,7 +464,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 				"lastName":"Quin",
 				"nickname":"RQ",
 				"mobileNumber":"${makeMobileNumber(timestamp)}"
-			}""", [:], ["tempPassword": "hack"])
+			}""", ["tempPassword": "hack"])
 
 		then:
 		assertResponseStatus(response, 400)
@@ -489,7 +489,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 
 		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "Bob Changed",
-				"Dunn Changed", "BD Changed", mobileNumberBob, [:], ["overwriteUserConfirmationCode": "1234"])
+				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
 		bob
 		bob.firstName == "Bob Changed"
 		bob.lastName == "Dunn Changed"
@@ -533,7 +533,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		def inviteUrl = getInviteUrl()
 		appService.requestOverwriteUser(mobileNumberBob)
 		User bob = appService.addUser(this.&assertUserOverwriteResponseDetails, "Bob Changed",
-				"Dunn Changed", "BD Changed", mobileNumberBob, [:], ["overwriteUserConfirmationCode": "1234"])
+				"Dunn Changed", "BD Changed", mobileNumberBob, ["overwriteUserConfirmationCode": "1234"])
 		bob.emailAddress = "bob@dunn.net"
 
 		when:
@@ -588,7 +588,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		updatedBobJson.deviceAppVersionCode = 10000
 		updatedBobJson.deviceFirebaseInstanceId = "SomeLongString"
 		updatedBobJson.remove(propertyToRemove)
-		def response = appService.updateResource(inviteUrl, updatedBobJson, [:], [:])
+		def response = appService.updateResource(inviteUrl, updatedBobJson)
 
 		then:
 		assertResponseStatus(response, expectedStatus)
@@ -623,7 +623,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		when:
 		def updatedBobJson = bob.convertToJson()
 		updatedBobJson.mobileNumber = richard.mobileNumber
-		def response = appService.updateResource(inviteUrl, updatedBobJson, [:], [:])
+		def response = appService.updateResource(inviteUrl, updatedBobJson)
 
 		then:
 		assertResponseStatus(response, 400)

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -363,7 +363,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		"IOS" | null | 5000 | 400
 	}
 
-	def 'Use different app version headers'(appVersionHeader, responseStatus)
+	def 'Use different app version headers'(appVersionHeader, expectedStatus, expectedMessagePattern)
 	{
 		given:
 		def ts = timestamp
@@ -374,21 +374,24 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		def response = appService.getResourceWithPassword(john.url, john.password, ["Yona-App-Version" : appVersionHeader])
 
 		then:
-		assertResponseStatus(response, responseStatus)
+		assertResponseStatus(response, expectedStatus)
+		expectedStatus == 200 || response.responseData.message ==~/$expectedMessagePattern/
+
 
 		cleanup:
 		appService.deleteUser(john)
 
 		where:
-		appVersionHeader | responseStatus
-		"ANDROID/123/1.2 build 360" | 200
-		"IOS/123/1.2 build 360" | 200
-		"IOS/123/1.2" | 200
-		"ANDROID/abc/1.2 build 360" | 400
-		"ANDROID/-1/1.2 build 360" | 400
-		"ANDROID/0/1.2 build 360" | 400
-		"ANDROID/123" | 400
-		"ANDROID/123/a/b" | 400
+		appVersionHeader | expectedStatus | expectedMessagePattern
+		"ANDROID/123/1.2 build 360" | 200 | "n/a"
+		"IOS/123/1.2 build 360" | 200 | "n/a"
+		"IOS/123/1.2" | 200 | "n/a"
+		"ANDROID/abc/1.2 build 360" | 400 | ".*contains an invalid version code: 'abc'.*. Must be an integer value > 0"
+		"ANDROID/-1/1.2 build 360" | 400 | ".*contains an invalid version code: '-1'.*. Must be an integer value > 0"
+		"ANDROID/0/1.2 build 360" | 400 | ".*contains an invalid version code: '0'.*. Must be an integer value > 0"
+		"ANDROID/123" | 400 | ".*is invalid: 'ANDROID/123'. Should follow the format.*"
+		"ANDROID/123/a/b" | 400 | ".*is invalid: 'ANDROID/123/a/b'. Should follow the format.*"
+		"" | 400 | ".*is invalid: ''. Should follow the format.*"
 	}
 
 	private User createJohnDoe(ts, deviceName, deviceOperatingSystem, firebaseInstanceId = null)

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -371,7 +371,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		john = appService.confirmMobileNumber(CommonAssertions.&assertResponseStatusSuccess, john)
 
 		when:
-		def response = appService.getResourceWithPassword(john.url, john.password, ["Yona-App-Version" : appVersionHeader])
+		def response = appService.getResourceWithPassword(john.url, john.password, [:], ["Yona-App-Version" : appVersionHeader])
 
 		then:
 		assertResponseStatus(response, expectedStatus)

--- a/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
@@ -59,10 +59,10 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		def appVersionCode = 123
 		def appVersionName = "1.2 (I'm Rich)"
 		def headers = ["Yona-App-Version" : "$appOs/$appVersionCode/$appVersionName"]
-		appService.sendBuddyConnectRequest(richard, bobAndroid, true, headers)
+		appService.sendBuddyConnectRequest(richard, bobAndroid, true, [:], headers)
 
 		when:
-		def messageUrlBobAndroid = appService.getMessages(bobAndroid, headers, [:]).responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}[0]._links.self.href
+		def messageUrlBobAndroid = appService.getMessages(bobAndroid, [:], headers).responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}[0]._links.self.href
 		def responseBobAndroid = appService.getLastFirebaseMessage(bobAndroid.requestingDevice.firebaseInstanceId)
 
 		then:
@@ -184,7 +184,7 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		def headers = ["Yona-App-Version" : "$appOs/$appVersionCode/$appVersionName"]
 
 		when:
-		assertResponseStatusNoContent(appService.postAppActivityToAnalysisEngine(richard, richard.requestingDevice, AppActivity.singleActivity("Poker App", startTime, endTime), headers, [:]))
+		assertResponseStatusNoContent(appService.postAppActivityToAnalysisEngine(richard, richard.requestingDevice, AppActivity.singleActivity("Poker App", startTime, endTime), [:], headers))
 
 		then:
 		def responseRichard = analysisService.getLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)

--- a/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -55,10 +55,10 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		User bobAndroid = addBob(true, "ANDROID", "nl-NL")
 		bobAndroid.emailAddress = "bob@dunn.com"
 		User bobIos = appService.addDevice(bobAndroid, "Bob's iPhone", "IOS", Device.SOME_APP_VERSION)
-		def appOs = "ANDROID"
-		def appVersionCode = 123
-		def appVersionName = "1.2 (I'm Rich)"
-		def headers = ["Yona-App-Version" : "$appOs/$appVersionCode/$appVersionName"]
+		def richardAppOs = "ANDROID"
+		def richardAppVersionCode = 123
+		def richardAppVersionName = "1.2 (I'm Rich)"
+		def headers = ["Yona-App-Version" : "$richardAppOs/$richardAppVersionCode/$richardAppVersionName"]
 		appService.sendBuddyConnectRequest(richard, bobAndroid, true, [:], headers)
 
 		when:
@@ -70,9 +70,9 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		responseBobAndroid.responseData.title == "Bericht ontvangen"
 		responseBobAndroid.responseData.body == "Tik om het bericht te openen"
 		messageUrlBobAndroid.endsWith(responseBobAndroid.responseData.data.messageId.toString())
-		responseBobAndroid.responseData.appOs == appOs
-		responseBobAndroid.responseData.appVersionCode == appVersionCode
-		responseBobAndroid.responseData.appVersionName == appVersionName
+		responseBobAndroid.responseData.appOs == richardAppOs
+		responseBobAndroid.responseData.appVersionCode == richardAppVersionCode
+		responseBobAndroid.responseData.appVersionName == richardAppVersionName
 
 		when:
 		def messageUrlBobIos = appService.getMessages(bobIos).responseData._embedded."yona:messages".findAll{ it."@type" == "BuddyConnectRequestMessage"}[0]._links.self.href
@@ -83,9 +83,9 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		responseBobIos.responseData.title == "Message received"
 		responseBobIos.responseData.body == "Tap to open message"
 		messageUrlBobIos.endsWith(responseBobIos.responseData.data.messageId.toString())
-		responseBobIos.responseData.appOs == appOs
-		responseBobIos.responseData.appVersionCode == appVersionCode
-		responseBobIos.responseData.appVersionName == appVersionName
+		responseBobIos.responseData.appOs == richardAppOs
+		responseBobIos.responseData.appVersionCode == richardAppVersionCode
+		responseBobIos.responseData.appVersionName == richardAppVersionName
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -178,10 +178,10 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		setGoalCreationTime(richard, GAMBLING_ACT_CAT_URL, "W-1 Mon 02:18")
 		ZonedDateTime startTime = YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Mon 11:00")
 		ZonedDateTime endTime = startTime.plusHours(1)
-		def appOs = "ANDROID"
-		def appVersionCode = 123
-		def appVersionName = "1.2 (I'm Rich)"
-		def headers = ["Yona-App-Version" : "$appOs/$appVersionCode/$appVersionName"]
+		def richardAppOs = "ANDROID"
+		def richardAppVersionCode = 123
+		def richardAppVersionName = "1.2 (I'm Rich)"
+		def headers = ["Yona-App-Version" : "$richardAppOs/$richardAppVersionCode/$richardAppVersionName"]
 
 		when:
 		assertResponseStatusNoContent(appService.postAppActivityToAnalysisEngine(richard, richard.requestingDevice, AppActivity.singleActivity("Poker App", startTime, endTime), [:], headers))
@@ -193,9 +193,9 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		responseRichard.responseData.title == "Message received"
 		responseRichard.responseData.body == "Tap to open message"
 		messageUrlRichard.endsWith(responseRichard.responseData.data.messageId.toString())
-		responseRichard.responseData.appOs == appOs
-		responseRichard.responseData.appVersionCode == appVersionCode
-		responseRichard.responseData.appVersionName == appVersionName
+		responseRichard.responseData.appOs == richardAppOs
+		responseRichard.responseData.appVersionCode == richardAppVersionCode
+		responseRichard.responseData.appVersionName == richardAppVersionName
 
 
 		def responseBob = analysisService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
@@ -204,9 +204,9 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		responseBob.responseData.title == "Message received"
 		responseBob.responseData.body == "Tap to open message"
 		messageUrlBob.endsWith(responseBob.responseData.data.messageId.toString())
-		responseBob.responseData.appOs == appOs
-		responseBob.responseData.appVersionCode == appVersionCode
-		responseBob.responseData.appVersionName == appVersionName
+		responseBob.responseData.appOs == richardAppOs
+		responseBob.responseData.appVersionCode == richardAppVersionCode
+		responseBob.responseData.appVersionName == richardAppVersionName
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2018 Stichting Yona Foundation
+ * Copyright (c) 2015, 2019 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -7,8 +7,6 @@
 package nu.yona.server
 
 import static nu.yona.server.test.CommonAssertions.*
-
-import groovy.json.*
 
 class LocalizationTest extends AbstractAppServiceIntegrationTest
 {
@@ -18,7 +16,7 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		def wrongNumber = "NotANumber"
 		when:
 		def successResponse = appService.yonaServer.getResource(GAMBLING_ACT_CAT_URL)
-		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Yona-NewDeviceRequestPassword" : ""])
+		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", [:], ["Yona-NewDeviceRequestPassword" : ""])
 
 		then:
 		assertResponseStatusOk(successResponse)
@@ -37,8 +35,8 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		given:
 		def wrongNumber = "NotANumber"
 		when:
-		def successResponse = appService.yonaServer.getResource(GAMBLING_ACT_CAT_URL, ["Accept-Language" : "nl-NL"])
-		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Accept-Language" : "nl-NL", "Yona-NewDeviceRequestPassword" : ""])
+		def successResponse = appService.yonaServer.getResource(GAMBLING_ACT_CAT_URL, [:], ["Accept-Language" : "nl-NL"])
+		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", [:], ["Accept-Language" : "nl-NL", "Yona-NewDeviceRequestPassword" : ""])
 
 		then:
 		assertResponseStatusOk(successResponse)
@@ -57,8 +55,8 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 		given:
 		def wrongNumber = "NotANumber"
 		when:
-		def successResponse = appService.yonaServer.getResource(GAMBLING_ACT_CAT_URL, ["Accept-Language" : "la"])
-		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", ["Accept-Language" : "la", "Yona-NewDeviceRequestPassword" : ""])
+		def successResponse = appService.yonaServer.getResource(GAMBLING_ACT_CAT_URL, [:], ["Accept-Language" : "la"])
+		def errorResponse = appService.yonaServer.getResource("$appService.NEW_DEVICE_REQUESTS_PATH$wrongNumber", [:], ["Accept-Language" : "la", "Yona-NewDeviceRequestPassword" : ""])
 
 		then:
 		assertResponseStatusOk(successResponse)

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -60,7 +60,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -103,7 +103,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -148,7 +148,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -192,7 +192,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -258,7 +258,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -301,7 +301,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -350,7 +350,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		User bob = richardAndBob.bob
 		appService.requestOverwriteUser(richard.mobileNumber)
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		when:
@@ -378,7 +378,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		User richardChanged = appService.addUser(this.&assertUserOverwriteResponseDetails, "${richard.firstName}Changed",
-				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber, [:],
+				"${richard.lastName}Changed", "${richard.nickname}Changed", richard.mobileNumber,
 				["overwriteUserConfirmationCode": "1234"])
 
 		then:
@@ -409,14 +409,14 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		def userUrl = YonaServer.stripQueryString(userAddResponse.responseData._links.self.href)
 
 		when:
-		def response1TimeWrong = appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12341"])
+		def response1TimeWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12341"])
 		response1TimeWrong.responseData.remainingAttempts == 4
-		appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12342"])
-		appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12343"])
-		def response4TimesWrong = appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12344"])
-		def response5TimesWrong = appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12345"])
-		def response6TimesWrong = appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "12346"])
-		def response7thTimeRight = appService.addUser(userCreationJson, [:], ["overwriteUserConfirmationCode": "1234"])
+		appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12342"])
+		appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12343"])
+		def response4TimesWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12344"])
+		def response5TimesWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12345"])
+		def response6TimesWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12346"])
+		def response7thTimeRight = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "1234"])
 
 		then:
 		assertResponseStatus(userAddResponse, 201)

--- a/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
@@ -11,7 +11,6 @@ import static nu.yona.server.test.CommonAssertions.*
 
 import java.time.Duration
 
-import groovy.json.*
 import nu.yona.server.test.CommonAssertions
 import nu.yona.server.test.User
 
@@ -40,7 +39,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 
 		when:
-		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
+		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
 
 		then:
 		assertResponseStatusOk(response)
@@ -65,17 +64,17 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def firstResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
+		def firstResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
 		assertResponseStatusOk(firstResponse)
 		sleepTillPinResetCodeIsGenerated(richard, firstResponse.responseData.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		assert richard.clearPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/clear"
-		assertResponseStatusNoContent(appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password]))
+		assertResponseStatusNoContent(appService.yonaServer.postJson(richard.clearPinResetUrl, [:], [:], ["Yona-Password" : richard.password]))
 		richard = appService.reloadUser(richard)
 		assert richard.pinResetRequestUrl != null
 
 		when:
-		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
+		def response = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password, "Accept-Language" : "nl-NL"])
 
 		then:
 		assertResponseStatusOk(response)
@@ -109,12 +108,12 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
-		def response = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
+		def response = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password" : richard.password])
 
 		then:
 		assertResponseStatusNoContent(response)
@@ -131,11 +130,11 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def responsePost = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def responsePost = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password])
 		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.responseData.delay)
 
 		when:
-		def response = appService.yonaServer.postJson(YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify", """{"code" : "1234"}""", ["Yona-Password" : richard.password])
+		def response = appService.yonaServer.postJson(YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify", """{"code" : "1234"}""", [:], ["Yona-Password" : richard.password])
 
 		then:
 		assertResponseStatus(response, 400)
@@ -157,12 +156,12 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
-		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password])
+		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], [:], ["Yona-Password" : richard.password])
 
 		then:
 		assertResponseStatusNoContent(response)
@@ -170,7 +169,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		richardAfterGet.pinResetRequestUrl
 		!richardAfterGet.verifyPinResetUrl
 		!richardAfterGet.clearPinResetUrl
-		def verifyPinResetAttemptResponse = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
+		def verifyPinResetAttemptResponse = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password" : richard.password])
 		assertResponseStatus(verifyPinResetAttemptResponse, 400)
 		verifyPinResetAttemptResponse.responseData.code == "error.pin.reset.request.confirmation.code.not.set"
 
@@ -182,14 +181,14 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
-		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
+		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password" : richard.password])
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
-		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], ["Yona-Password" : richard.password])
+		def response = appService.yonaServer.postJson(richard.clearPinResetUrl, [:], [:], ["Yona-Password" : richard.password])
 
 		then:
 		assertResponseStatusNoContent(response)
@@ -206,19 +205,19 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		given:
 		User richard = addRichard()
-		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], ["Yona-Password" : richard.password])
+		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password" : richard.password])
 		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
-		def response1TimeWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12341"}""", ["Yona-Password" : richard.password])
+		def response1TimeWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12341"}""", [:], ["Yona-Password" : richard.password])
 		response1TimeWrong.responseData.remainingAttempts == 4
-		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12342"}""", ["Yona-Password" : richard.password])
-		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12343"}""", ["Yona-Password" : richard.password])
-		def response4TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12344"}""", ["Yona-Password" : richard.password])
-		def response5TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12345"}""", ["Yona-Password" : richard.password])
-		def response6TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12346"}""", ["Yona-Password" : richard.password])
-		def response7thTimeRight = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", ["Yona-Password" : richard.password])
+		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12342"}""", [:], ["Yona-Password" : richard.password])
+		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12343"}""", [:], ["Yona-Password" : richard.password])
+		def response4TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12344"}""", [:], ["Yona-Password" : richard.password])
+		def response5TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12345"}""", [:], ["Yona-Password" : richard.password])
+		def response6TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12346"}""", [:], ["Yona-Password" : richard.password])
+		def response7thTimeRight = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password" : richard.password])
 
 		then:
 		assertResponseStatus(response1TimeWrong, 400)

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -131,7 +131,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		def response1TimeWrong = confirmMobileNumber(john, "12341")
 
 		when:
-		def responseRequestResend = appService.yonaServer.postJson(john.resendMobileNumberConfirmationCodeUrl, "{}", ["Yona-Password" : john.password])
+		def responseRequestResend = appService.yonaServer.postJson(john.resendMobileNumberConfirmationCodeUrl, "{}", [:], ["Yona-Password" : john.password])
 
 		then:
 		assertResponseStatus(response1TimeWrong, 400)

--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -7,12 +7,15 @@ package nu.yona.server;
 import java.util.Properties;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.CustomScopeConfigurer;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.context.support.SimpleThreadScope;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.RelProvider;
 import org.springframework.hateoas.UriTemplate;
@@ -24,14 +27,10 @@ import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.springframework.web.client.RestTemplate;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.rest.JsonRootRelProvider;
-import nu.yona.server.rest.RestClientErrorHandler;
 
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 @EnableSpringDataWebSupport
@@ -107,10 +106,10 @@ public class CoreConfiguration
 	}
 
 	@Bean
-	public RestTemplate restTemplate(ObjectMapper objectMapper)
+	public static CustomScopeConfigurer customScopeConfigurer()
 	{
-		RestTemplate restTemplate = new RestTemplate();
-		restTemplate.setErrorHandler(new RestClientErrorHandler(objectMapper));
-		return restTemplate;
+		CustomScopeConfigurer configurer = new CustomScopeConfigurer();
+		configurer.addScope(ThreadScope.class.getAnnotation(Scope.class).value(), new SimpleThreadScope());
+		return configurer;
 	}
 }

--- a/core/src/main/java/nu/yona/server/ThreadScope.java
+++ b/core/src/main/java/nu/yona/server/ThreadScope.java
@@ -1,13 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v.2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
 
 import org.springframework.context.annotation.Scope;
 
+/**
+ * This type defines a Spring bean scope. Some standard bean scopes exist (e.g. singleton, request, session) and it is possible to
+ * create custom ones, which then have to be configured through CustomScopeConfigurer.
+ */
 @Scope("thread")
 public @interface ThreadScope
 {

--- a/core/src/main/java/nu/yona/server/ThreadScope.java
+++ b/core/src/main/java/nu/yona/server/ThreadScope.java
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server;
+
+import org.springframework.context.annotation.Scope;
+
+@Scope("thread")
+public @interface ThreadScope
+{
+
+}

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -88,7 +88,7 @@ public class FirebaseService
 		ThreadData threadData = asyncExecutor.getThreadData();
 		CompletableFuture
 				.runAsync(() -> asyncExecutor.initThreadAndDo(threadData, () -> sendMessage(registrationToken, firebaseMessage)))
-				.whenCompleteAsync((r, t) -> logIfCompletedWithException(t));
+				.whenCompleteAsync((r, t) -> logIfCompletedWithException(t, registrationToken));
 	}
 
 	private long getMessageId(nu.yona.server.messaging.entities.Message message)
@@ -130,11 +130,11 @@ public class FirebaseService
 		}
 	}
 
-	private void logIfCompletedWithException(Throwable throwable)
+	private void logIfCompletedWithException(Throwable throwable, String token)
 	{
 		if (throwable != null)
 		{
-			logger.error("Fatal error: Exception while sending Firebase message", throwable);
+			logger.error("Fatal error: Exception while sending Firebase message to '" + token + "'", throwable);
 			return;
 		}
 		if (yonaProperties.getFirebase().isEnabled())

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -16,6 +16,7 @@ import javax.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +31,8 @@ import com.google.firebase.messaging.Notification;
 import nu.yona.server.Translator;
 import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.properties.YonaProperties;
+import nu.yona.server.util.AsyncExecutor;
+import nu.yona.server.util.AsyncExecutor.ThreadData;
 import nu.yona.server.util.Require;
 
 @Service
@@ -37,13 +40,16 @@ public class FirebaseService
 {
 	private static final Logger logger = LoggerFactory.getLogger(FirebaseService.class);
 
-	private final Map<String, Message> lastMessageByRegistrationToken = new HashMap<>();
+	private final Map<String, MessageData> lastMessageByRegistrationToken = new HashMap<>();
 
 	@Autowired
 	private Translator translator;
 
 	@Autowired
 	private YonaProperties yonaProperties;
+
+	@Autowired
+	private AsyncExecutor asyncExecutor;
 
 	@PostConstruct
 	private void init()
@@ -78,19 +84,11 @@ public class FirebaseService
 		Message firebaseMessage = Message.builder().setNotification(new Notification(title, body))
 				.putData("messageId", Long.toString(getMessageId(message))).setToken(registrationToken).build();
 
-		if (yonaProperties.getFirebase().isEnabled())
-		{
-			logger.info("Sending Firebase message");
-			// Sending takes quite a bit of time, so do it asynchronously
-			CompletableFuture.runAsync(() -> sendMessage(firebaseMessage))
-					.whenCompleteAsync((r, t) -> logIfCompletedWithException(t));
-		}
-		else
-		{
-			logger.info("Firebase message not sent because Firebase is disabled");
-			// Store for testability
-			lastMessageByRegistrationToken.put(registrationToken, firebaseMessage);
-		}
+		// Sending takes quite a bit of time, so do it asynchronously
+		ThreadData threadData = asyncExecutor.getThreadData();
+		CompletableFuture
+				.runAsync(() -> asyncExecutor.initThreadAndDo(threadData, () -> sendMessage(registrationToken, firebaseMessage)))
+				.whenCompleteAsync((r, t) -> logIfCompletedWithException(t));
 	}
 
 	private long getMessageId(nu.yona.server.messaging.entities.Message message)
@@ -99,21 +97,32 @@ public class FirebaseService
 		return message.getId();
 	}
 
-	public Optional<Message> getLastMessage(String registrationToken)
+	public Optional<MessageData> getLastMessage(String registrationToken)
 	{
 		return Optional.ofNullable(lastMessageByRegistrationToken.get(registrationToken));
 	}
 
-	public Optional<Message> clearLastMessage(String registrationToken)
+	public Optional<MessageData> clearLastMessage(String registrationToken)
 	{
 		return Optional.ofNullable(lastMessageByRegistrationToken.remove(registrationToken));
 	}
 
-	private void sendMessage(Message firebaseMessage)
+	private void sendMessage(String registrationToken, Message firebaseMessage)
 	{
 		try
 		{
-			FirebaseMessaging.getInstance().send(firebaseMessage);
+			if (yonaProperties.getFirebase().isEnabled())
+			{
+				logger.info("Sending Firebase message");
+				FirebaseMessaging.getInstance().send(firebaseMessage);
+			}
+			else
+			{
+				logger.info("Firebase message not sent because Firebase is disabled");
+				// Store for testability
+				lastMessageByRegistrationToken.put(registrationToken,
+						MessageData.createInstance(MDC.getCopyOfContextMap(), firebaseMessage));
+			}
 		}
 		catch (FirebaseMessagingException e)
 		{
@@ -123,13 +132,31 @@ public class FirebaseService
 
 	private void logIfCompletedWithException(Throwable throwable)
 	{
-		if (throwable == null)
+		if (throwable != null)
+		{
+			logger.error("Fatal error: Exception while sending Firebase message", throwable);
+			return;
+		}
+		if (yonaProperties.getFirebase().isEnabled())
 		{
 			logger.info("Firebase message sent successfully");
 		}
-		else
+	}
+
+	public static class MessageData
+	{
+		public final Optional<Map<String, String>> mdc;
+		public final Message firebaseMessage;
+
+		public MessageData(Map<String, String> mdc, Message firebaseMessage)
 		{
-			logger.error("Fatal error: Exception while sending Firebase message", throwable);
+			this.mdc = Optional.ofNullable(mdc);
+			this.firebaseMessage = firebaseMessage;
+		}
+
+		public static MessageData createInstance(Map<String, String> mdc, Message firebaseMessage)
+		{
+			return new MessageData(mdc, firebaseMessage);
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/Config.java
+++ b/core/src/main/java/nu/yona/server/rest/Config.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.rest;
+
+import java.util.Collections;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import nu.yona.server.ThreadScope;
+
+@Configuration
+public class Config implements WebMvcConfigurer
+{
+	@ThreadScope
+	@Bean
+	public HeadersHolder getHeadersHolder()
+	{
+		return new HeadersHolder();
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry)
+	{
+		registry.addInterceptor(new HeadersServerInterceptor(getHeadersHolder()));
+	}
+
+	@Bean
+	public HeadersClientInterceptor getHeadersClientInterceptor()
+	{
+		return new HeadersClientInterceptor(getHeadersHolder());
+	}
+
+	@Bean
+	public RestTemplate restTemplate(ObjectMapper objectMapper)
+	{
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setErrorHandler(new RestClientErrorHandler(objectMapper));
+		restTemplate.setInterceptors(Collections.singletonList(getHeadersClientInterceptor()));
+		return restTemplate;
+	}
+}

--- a/core/src/main/java/nu/yona/server/rest/Config.java
+++ b/core/src/main/java/nu/yona/server/rest/Config.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -23,9 +23,9 @@ public class Config implements WebMvcConfigurer
 {
 	@ThreadScope
 	@Bean
-	public HeadersHolder getHeadersHolder()
+	public PassThroughHeadersHolder getHeadersHolder()
 	{
-		return new HeadersHolder();
+		return new PassThroughHeadersHolder();
 	}
 
 	@Override

--- a/core/src/main/java/nu/yona/server/rest/Constants.java
+++ b/core/src/main/java/nu/yona/server/rest/Constants.java
@@ -9,6 +9,9 @@ public final class Constants
 	public static final String PASSWORD_HEADER = "Yona-Password";
 	public static final String NEW_DEVICE_REQUEST_PASSWORD_HEADER = "Yona-NewDeviceRequestPassword";
 	public static final String APP_VERSION_HEADER = "Yona-App-Version";
+	public static final String APP_OS_MDC_KEY = "yona.app.os";
+	public static final String APP_VERSION_CODE_MDC_KEY = "yona.app.versionCode";
+	public static final String APP_VERSION_NAME_MDC_KEY = "yona.app.versionName";
 
 	private Constants()
 	{

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -22,9 +22,9 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.stereotype.Component;
@@ -46,11 +46,8 @@ public class ErrorLoggingFilter implements Filter
 	{
 		private static final String TRACE_ID_HEADER = "x-b3-traceid";
 		private static final String CORRELATION_ID_MDC_KEY = "yona.correlation.id";
-		private static final String APP_OS_MDC_KEY = "yona.app.os";
-		private static final String APP_VERSION_CODE_MDC_KEY = "yona.app.versionCode";
-		private static final String APP_VERSION_NAME_MDC_KEY = "yona.app.versionName";
-		private static final List<String> MDC_KEYS = Arrays.asList(CORRELATION_ID_MDC_KEY, APP_OS_MDC_KEY,
-				APP_VERSION_CODE_MDC_KEY, APP_VERSION_NAME_MDC_KEY);
+		private static final List<String> MDC_KEYS = Arrays.asList(CORRELATION_ID_MDC_KEY, Constants.APP_OS_MDC_KEY,
+				Constants.APP_VERSION_CODE_MDC_KEY, Constants.APP_VERSION_NAME_MDC_KEY);
 
 		private LoggingContext()
 		{
@@ -73,7 +70,7 @@ public class ErrorLoggingFilter implements Filter
 
 		public static String getCorrelationId()
 		{
-			return (String) MDC.get(CORRELATION_ID_MDC_KEY);
+			return MDC.get(CORRELATION_ID_MDC_KEY);
 		}
 
 		private static String getCorrelationId(HttpServletRequest request)
@@ -90,11 +87,11 @@ public class ErrorLoggingFilter implements Filter
 		{
 			String[] parts = header.split("/");
 			String operatingSystem = parts[0];
-			int versionCode = Integer.parseInt(parts[1]);
+			String versionCode = parts[1];
 			String versionName = parts[2];
-			MDC.put(APP_OS_MDC_KEY, operatingSystem);
-			MDC.put(APP_VERSION_CODE_MDC_KEY, versionCode);
-			MDC.put(APP_VERSION_NAME_MDC_KEY, versionName);
+			MDC.put(Constants.APP_OS_MDC_KEY, operatingSystem);
+			MDC.put(Constants.APP_VERSION_CODE_MDC_KEY, versionCode);
+			MDC.put(Constants.APP_VERSION_NAME_MDC_KEY, versionName);
 		}
 
 		private static void assertValidHeaders(HttpServletRequest request)
@@ -159,6 +156,7 @@ public class ErrorLoggingFilter implements Filter
 		catch (YonaException e)
 		{
 			response.sendError(e.getStatusCode().value(), e.getMessage());
+			logger.error("Invalid header", e);
 			logResponseStatus(request, response, e.getStatusCode().series());
 			return;
 		}

--- a/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
@@ -1,8 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v.2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
@@ -13,11 +11,14 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
+/**
+ * Intercepts client-side HTTP requests in order to add headers to the request as available in the headers holder.
+ */
 public class HeadersClientInterceptor implements ClientHttpRequestInterceptor
 {
-	private final HeadersHolder headersHolder;
+	private final PassThroughHeadersHolder headersHolder;
 
-	public HeadersClientInterceptor(HeadersHolder headersHolder)
+	public HeadersClientInterceptor(PassThroughHeadersHolder headersHolder)
 	{
 		this.headersHolder = headersHolder;
 	}

--- a/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
@@ -12,7 +12,10 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
 /**
- * Intercepts client-side HTTP requests in order to add headers to the request as available in the headers holder.
+ * Intercepts client-side HTTP requests in order to add headers to the request as available in the headers holder. This
+ * interceptor is configured as part of the rest template as created in {@link Config}. See {@link PassThroughHeadersHolder} for
+ * the class that stores the headers and {@link HeadersServerInterceptor} for the class that reads the headers into incoming HTTP
+ * requests.
  */
 public class HeadersClientInterceptor implements ClientHttpRequestInterceptor
 {

--- a/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersClientInterceptor.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.rest;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class HeadersClientInterceptor implements ClientHttpRequestInterceptor
+{
+	private final HeadersHolder headersHolder;
+
+	public HeadersClientInterceptor(HeadersHolder headersHolder)
+	{
+		this.headersHolder = headersHolder;
+	}
+
+	@Override
+	public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException
+	{
+		headersHolder.writeTo(request.getHeaders());
+		return execution.execute(request, body);
+	}
+}

--- a/core/src/main/java/nu/yona/server/rest/HeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersHolder.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.rest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+public class HeadersHolder
+{
+	private final Map<String, String> storedHeaders = new HashMap<>();
+
+	public void readFrom(HttpHeaders headers)
+	{
+		storeIfPresent(headers, Constants.APP_VERSION_HEADER);
+	}
+
+	private void storeIfPresent(HttpHeaders headers, String name)
+	{
+		String value = headers.getFirst(Constants.APP_VERSION_HEADER);
+		if (value != null)
+		{
+			storedHeaders.put(name, value);
+		}
+	}
+
+	public void writeTo(HttpHeaders headers)
+	{
+		storedHeaders.forEach((n, v) -> headers.add(n, v));
+	}
+
+	public void importFrom(Map<String, String> headersToImport)
+	{
+		storedHeaders.putAll(headersToImport);
+	}
+
+	public Map<String, String> export()
+	{
+		return new HashMap<>(storedHeaders);
+	}
+
+	public void clear()
+	{
+		storedHeaders.clear();
+	}
+}

--- a/core/src/main/java/nu/yona/server/rest/HeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersHolder.java
@@ -1,8 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v.2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
@@ -31,7 +29,7 @@ public class HeadersHolder
 
 	public void writeTo(HttpHeaders headers)
 	{
-		storedHeaders.forEach((n, v) -> headers.add(n, v));
+		storedHeaders.forEach(headers::add);
 	}
 
 	public void importFrom(Map<String, String> headersToImport)

--- a/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
@@ -1,8 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Stichting Yona Foundation
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v.2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
@@ -13,6 +11,11 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
+/**
+ * Intercept all incoming HTTP requests, with the intend to store headers that are to be passed through in outgoing HTTP requests.
+ * See {@link PassThroughHeadersHolder} for the class that stores the headers and {@link HeadersClientInterceptor} for the class
+ * that writes the headers into outgoing HTTP requests.
+ */
 public class HeadersServerInterceptor extends HandlerInterceptorAdapter
 {
 	private final PassThroughHeadersHolder headersHolder;

--- a/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
@@ -12,7 +12,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 /**
- * Intercept all incoming HTTP requests, with the intend to store headers that are to be passed through in outgoing HTTP requests.
+ * Intercept all incoming HTTP requests, with the intent to store headers that are to be passed through in outgoing HTTP requests.
  * See {@link PassThroughHeadersHolder} for the class that stores the headers and {@link HeadersClientInterceptor} for the class
  * that writes the headers into outgoing HTTP requests.
  */

--- a/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -15,9 +15,9 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 public class HeadersServerInterceptor extends HandlerInterceptorAdapter
 {
-	private final HeadersHolder headersHolder;
+	private final PassThroughHeadersHolder headersHolder;
 
-	public HeadersServerInterceptor(HeadersHolder headersHolder)
+	public HeadersServerInterceptor(PassThroughHeadersHolder headersHolder)
 	{
 		this.headersHolder = headersHolder;
 	}

--- a/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.rest;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+public class HeadersServerInterceptor extends HandlerInterceptorAdapter
+{
+	private final HeadersHolder headersHolder;
+
+	public HeadersServerInterceptor(HeadersHolder headersHolder)
+	{
+		this.headersHolder = headersHolder;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+	{
+		headersHolder.readFrom(new ServletServerHttpRequest(request).getHeaders());
+		return true;
+	}
+
+	@Override
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable Exception ex)
+	{
+		headersHolder.clear();
+	}
+}

--- a/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
@@ -9,7 +9,10 @@ import java.util.Map;
 
 import org.springframework.http.HttpHeaders;
 
-public class HeadersHolder
+/**
+ * Holds the headers that are received in an incoming HTTP request, which needs to be passed-through in outgoing HTTP requests.
+ */
+public class PassThroughHeadersHolder
 {
 	private final Map<String, String> storedHeaders = new HashMap<>();
 

--- a/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
@@ -25,7 +25,7 @@ public class PassThroughHeadersHolder
 
 	private void storeIfPresent(HttpHeaders headers, String name)
 	{
-		String value = headers.getFirst(Constants.APP_VERSION_HEADER);
+		String value = headers.getFirst(name);
 		if (value != null)
 		{
 			storedHeaders.put(name, value);

--- a/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpHeaders;
 
 /**
  * Holds the headers that are received in an incoming HTTP request, which needs to be passed-through in outgoing HTTP requests.
+ * See {@link HeadersServerInterceptor} for the place where the incoming headers are stored in the holder and
+ * {@link HeadersClientInterceptor} for the place where the headers are read.
  */
 public class PassThroughHeadersHolder
 {

--- a/core/src/main/java/nu/yona/server/util/AsyncExecutor.java
+++ b/core/src/main/java/nu/yona/server/util/AsyncExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2019, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.util;
@@ -11,13 +11,13 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import nu.yona.server.rest.HeadersHolder;
+import nu.yona.server.rest.PassThroughHeadersHolder;
 
 @Service
 public class AsyncExecutor
 {
 	@Autowired
-	private HeadersHolder headersHolder;
+	private PassThroughHeadersHolder headersHolder;
 
 	public static class ThreadData
 	{

--- a/core/src/main/java/nu/yona/server/util/AsyncExecutor.java
+++ b/core/src/main/java/nu/yona/server/util/AsyncExecutor.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.util;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import nu.yona.server.rest.HeadersHolder;
+
+@Service
+public class AsyncExecutor
+{
+	@Autowired
+	private HeadersHolder headersHolder;
+
+	public static class ThreadData
+	{
+
+		final Optional<Map<String, String>> contextMap;
+		final Map<String, String> headers;
+
+		public ThreadData(Map<String, String> contextMap, Map<String, String> headers)
+		{
+			this.contextMap = Optional.ofNullable(contextMap);
+			this.headers = headers;
+		}
+
+	}
+
+	public ThreadData getThreadData()
+	{
+		return new ThreadData(MDC.getCopyOfContextMap(), headersHolder.export());
+	}
+
+	public void initThreadAndDo(ThreadData threadData, Runnable action)
+	{
+		threadData.contextMap.ifPresent(MDC::setContextMap);
+		headersHolder.importFrom(threadData.headers);
+		action.run();
+	}
+}

--- a/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
@@ -42,11 +42,19 @@ class YonaServer
 		formatter.format(now)
 	}
 
-	def createResourceWithPassword(path, jsonString, password, headers = [:], parameters = [:])
+	def createResourceWithPassword(path, jsonString, password, parameters = [:], headers = [:])
+	{
+		createResource(path, jsonString, parameters, addPasswordToHeaders(headers, password))
+	}
+
+	public static addPasswordToHeaders(headers, password)
 	{
 		def headersWithPassword = cloneMap(headers)
-		headersWithPassword["Yona-Password"] = password
-		createResource(path, jsonString, headersWithPassword, parameters)
+		if (password)
+		{
+			headersWithPassword["Yona-Password"] = password
+		}
+		return headersWithPassword
 	}
 
 	private static def cloneMap(map)
@@ -54,55 +62,45 @@ class YonaServer
 		map.getClass().newInstance(map)
 	}
 
-	def createResource(path, jsonString, headers = [:], parameters = [:])
+	def createResource(path, jsonString, parameters = [:], headers = [:])
 	{
-		postJson(path, jsonString, headers, parameters)
+		postJson(path, jsonString, parameters, headers)
 	}
 
-	def updateResourceWithPassword(path, jsonString, password, parameters = [:])
+	def updateResourceWithPassword(path, jsonString, password, parameters = [:], headers = [:])
 	{
-		updateResource(path, jsonString, ["Yona-Password": password], parameters)
+		updateResource(path, jsonString, parameters, addPasswordToHeaders(headers, password))
 	}
 
-	def updateResource(path, jsonString, headers = [:], parameters = [:])
+	def updateResource(path, jsonString, parameters = [:], headers = [:])
 	{
-		putJson(path, jsonString, headers, parameters)
+		putJson(path, jsonString, parameters, headers)
 	}
 
-	def deleteResourceWithPassword(path, password, parameters = [:])
+	def deleteResourceWithPassword(path, password, parameters = [:], headers = [:])
 	{
-		deleteResource(path, ["Yona-Password": password], parameters)
+		deleteResource(path, parameters, addPasswordToHeaders(headers, password))
 	}
 
-	def deleteResource(path, headers = [:], parameters = [:])
+	def deleteResource(path, parameters = [:], headers = [:])
 	{
-		restClient.delete(path: stripQueryString(path), headers: headers, query:parameters + getQueryParams(path))
+		restClient.delete(path: stripQueryString(path), query:parameters + getQueryParams(path), headers: headers)
 	}
 
-	def getResourceWithPassword(path, password, parameters = [:])
+	def getResourceWithPassword(path, password, parameters = [:], headers =[:])
 	{
-		getResource(path, password ? ["Yona-Password": password] : [ : ], parameters)
+		getResource(path, parameters, addPasswordToHeaders(headers, password))
 	}
 
-	def getResourceWithPassword(path, password, headers, parameters)
-	{
-		def headersWithPassword = cloneMap(headers)
-		if (password)
-		{
-			headersWithPassword["Yona-Password"] = password
-		}
-		getResource(path, headersWithPassword, parameters)
-	}
-
-	def getResource(path, headers = [:], parameters = [:])
+	def getResource(path, parameters = [:], headers = [:])
 	{
 		restClient.get(path: stripQueryString(path),
 		contentType:'application/json',
-		headers: headers,
-		query: parameters + getQueryParams(path))
+		query: parameters + getQueryParams(path),
+		headers: headers)
 	}
 
-	def postJson(path, jsonString, headers = [:], parameters = [:])
+	def postJson(path, jsonString, parameters = [:], headers = [:])
 	{
 		def object = null
 		if (jsonString instanceof Map)
@@ -117,11 +115,11 @@ class YonaServer
 		restClient.post(path: stripQueryString(path),
 		body: object,
 		contentType:'application/json',
-		headers: headers,
-		query: parameters + getQueryParams(path))
+		query: parameters + getQueryParams(path),
+		headers: headers)
 	}
 
-	def putJson(path, jsonString, headers = [:], parameters = [:])
+	def putJson(path, jsonString, parameters = [:], headers = [:])
 	{
 		def object = null
 		if (jsonString instanceof Map)

--- a/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/YonaServer.groovy
@@ -42,9 +42,16 @@ class YonaServer
 		formatter.format(now)
 	}
 
-	def createResourceWithPassword(path, jsonString, password, parameters = [:])
+	def createResourceWithPassword(path, jsonString, password, headers = [:], parameters = [:])
 	{
-		createResource(path, jsonString, ["Yona-Password": password], parameters)
+		def headersWithPassword = cloneMap(headers)
+		headersWithPassword["Yona-Password"] = password
+		createResource(path, jsonString, headersWithPassword, parameters)
+	}
+
+	private static def cloneMap(map)
+	{
+		map.getClass().newInstance(map)
 	}
 
 	def createResource(path, jsonString, headers = [:], parameters = [:])
@@ -75,6 +82,16 @@ class YonaServer
 	def getResourceWithPassword(path, password, parameters = [:])
 	{
 		getResource(path, password ? ["Yona-Password": password] : [ : ], parameters)
+	}
+
+	def getResourceWithPassword(path, password, headers, parameters)
+	{
+		def headersWithPassword = cloneMap(headers)
+		if (password)
+		{
+			headersWithPassword["Yona-Password"] = password
+		}
+		getResource(path, headersWithPassword, parameters)
 	}
 
 	def getResource(path, headers = [:], parameters = [:])

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -174,7 +174,7 @@ class AppService extends Service
 		assert processUrl == null // Processing happens automatically these days
 	}
 
-	def sendBuddyConnectRequest(sendingUser, receivingUser, assertSuccess = true)
+	def sendBuddyConnectRequest(sendingUser, receivingUser, assertSuccess = true, headers = [:], parameters = [:])
 	{
 		// Send the buddy request
 		def response = requestBuddy(sendingUser, """{
@@ -189,7 +189,7 @@ class AppService extends Service
 			"message":"Would you like to be my buddy?",
 			"sendingStatus":"REQUESTED",
 			"receivingStatus":"REQUESTED"
-		}""", sendingUser.password)
+		}""", sendingUser.password, headers, parameters)
 		if (assertSuccess) {
 			assertResponseStatusCreated(response)
 		}
@@ -280,9 +280,9 @@ class AppService extends Service
 		yonaServer.postJson(OVERWRITE_USER_REQUEST_PATH, """{ }""", [:], ["mobileNumber":mobileNumber])
 	}
 
-	def requestBuddy(User user, jsonString, password)
+	def requestBuddy(User user, jsonString, password, headers = [:], parameters = [:])
 	{
-		yonaServer.createResourceWithPassword(user.buddiesUrl, jsonString, password)
+		yonaServer.createResourceWithPassword(user.buddiesUrl, jsonString, password, headers, parameters)
 	}
 
 	def removeBuddy(User user, Buddy buddy, message)
@@ -316,6 +316,11 @@ class AppService extends Service
 	def getMessages(User user, parameters = [:])
 	{
 		yonaServer.getResourceWithPassword(user.messagesUrl, user.password, parameters)
+	}
+
+	def getMessages(User user, headers, parameters)
+	{
+		yonaServer.getResourceWithPassword(user.messagesUrl, user.password, headers, parameters)
 	}
 
 	def getWeekActivityOverviews(User user, parameters = [:])
@@ -520,9 +525,14 @@ class AppService extends Service
 		yonaServer.postJson(path, jsonString, headers)
 	}
 
-	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity)
+	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity, parameters = [:])
 	{
-		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password)
+		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password, [:], parameters)
+	}
+
+	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity, headers, parameters)
+	{
+		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password, headers, parameters)
 	}
 
 	def composeActivityCategoryUrl(def activityCategoryId) {

--- a/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/AppService.groovy
@@ -34,33 +34,33 @@ class AppService extends Service
 		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, headers = [:], parameters = [:])
+	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, parameters = [:], headers = [:])
 	{
 		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber)
-		def response = addUser(jsonStr, headers, parameters)
+		def response = addUser(jsonStr, parameters, headers)
 		asserter(response)
 		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addLegacyUser(Closure asserter, firstName, lastName, nickname, mobileNumber, headers = [:], parameters = [:]) // YD-623
+	def addLegacyUser(Closure asserter, firstName, lastName, nickname, mobileNumber, parameters = [:], headers = [:]) // YD-623
 	{
 		def jsonStr = User.makeLegacyUserJsonString(firstName, lastName, nickname, mobileNumber)
-		def response = addUser(jsonStr, headers, parameters)
+		def response = addUser(jsonStr, parameters, headers)
 		asserter(response)
 		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId = null, headers = [:], parameters = [:])
+	def addUser(Closure asserter, firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId = null, parameters = [:], headers = [:])
 	{
 		def jsonStr = User.makeUserJsonString(firstName, lastName, nickname, mobileNumber, deviceName, deviceOperatingSystem, deviceAppVersion, deviceAppVersionCode, firebaseInstanceId)
-		def response = addUser(jsonStr, headers, parameters)
+		def response = addUser(jsonStr, parameters, headers)
 		asserter(response)
 		return (isSuccess(response)) ? new User(response.responseData) : null
 	}
 
-	def addUser(jsonString, headers = [:], parameters = [:])
+	def addUser(jsonString, parameters = [:], headers = [:])
 	{
-		yonaServer.createResource(USERS_PATH, jsonString, headers, parameters)
+		yonaServer.createResource(USERS_PATH, jsonString, parameters, headers)
 	}
 
 	def getUser(Closure asserter, userUrl, boolean includePrivateData, password = null)
@@ -144,7 +144,7 @@ class AppService extends Service
 
 	def updateUser(userUrl, jsonString)
 	{
-		yonaServer.updateResource(userUrl, jsonString, [:], [:])
+		yonaServer.updateResource(userUrl, jsonString)
 	}
 
 	def deleteUser(User user, message = "")
@@ -174,7 +174,7 @@ class AppService extends Service
 		assert processUrl == null // Processing happens automatically these days
 	}
 
-	def sendBuddyConnectRequest(sendingUser, receivingUser, assertSuccess = true, headers = [:], parameters = [:])
+	def sendBuddyConnectRequest(sendingUser, receivingUser, assertSuccess = true, parameters = [:], headers = [:])
 	{
 		// Send the buddy request
 		def response = requestBuddy(sendingUser, """{
@@ -189,7 +189,7 @@ class AppService extends Service
 			"message":"Would you like to be my buddy?",
 			"sendingStatus":"REQUESTED",
 			"receivingStatus":"REQUESTED"
-		}""", sendingUser.password, headers, parameters)
+		}""", sendingUser.password, parameters, headers)
 		if (assertSuccess) {
 			assertResponseStatusCreated(response)
 		}
@@ -277,12 +277,12 @@ class AppService extends Service
 
 	def requestOverwriteUser(mobileNumber)
 	{
-		yonaServer.postJson(OVERWRITE_USER_REQUEST_PATH, """{ }""", [:], ["mobileNumber":mobileNumber])
+		yonaServer.postJson(OVERWRITE_USER_REQUEST_PATH, """{ }""", ["mobileNumber":mobileNumber])
 	}
 
-	def requestBuddy(User user, jsonString, password, headers = [:], parameters = [:])
+	def requestBuddy(User user, jsonString, password, parameters = [:], headers = [:])
 	{
-		yonaServer.createResourceWithPassword(user.buddiesUrl, jsonString, password, headers, parameters)
+		yonaServer.createResourceWithPassword(user.buddiesUrl, jsonString, password, parameters, headers)
 	}
 
 	def removeBuddy(User user, Buddy buddy, message)
@@ -297,7 +297,7 @@ class AppService extends Service
 
 	def getAllActivityCategoriesWithLanguage(language)
 	{
-		yonaServer.getResource(ACTIVITY_CATEGORIES_PATH, ["Accept-Language":language])
+		yonaServer.getResource(ACTIVITY_CATEGORIES_PATH, [:], ["Accept-Language":language])
 	}
 
 	List<Buddy> getBuddies(User user)
@@ -313,14 +313,9 @@ class AppService extends Service
 		response.responseData._embedded."yona:buddies".collect{new Buddy(it)}
 	}
 
-	def getMessages(User user, parameters = [:])
+	def getMessages(User user, parameters = [:], headers = [:])
 	{
-		yonaServer.getResourceWithPassword(user.messagesUrl, user.password, parameters)
-	}
-
-	def getMessages(User user, headers, parameters)
-	{
-		yonaServer.getResourceWithPassword(user.messagesUrl, user.password, headers, parameters)
+		yonaServer.getResourceWithPassword(user.messagesUrl, user.password, parameters, headers)
 	}
 
 	def getWeekActivityOverviews(User user, parameters = [:])
@@ -427,7 +422,7 @@ class AppService extends Service
 
 	def getNewDeviceRequest(mobileNumber, newDeviceRequestPassword = null)
 	{
-		yonaServer.getResource("$NEW_DEVICE_REQUESTS_PATH$mobileNumber", ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
+		yonaServer.getResource("$NEW_DEVICE_REQUESTS_PATH$mobileNumber", [:], ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword])
 	}
 
 	def registerNewDevice(url, newDeviceRequestPassword, name, operatingSystem, appVersion = Device.SOME_APP_VERSION, appVersionCode = Device.SUPPORTED_APP_VERSION_CODE, firebaseInstanceId = null)
@@ -441,7 +436,7 @@ class AppService extends Service
 				"appVersionCode": "$appVersionCode",
 				"firebaseInstanceId": $firebaseInstanceIdString
 				}"""
-		yonaServer.postJson(url, json, ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword], [:])
+		yonaServer.postJson(url, json, [:], ["Yona-NewDeviceRequestPassword":newDeviceRequestPassword])
 	}
 
 	def clearNewDeviceRequest(mobileNumber, password)
@@ -472,7 +467,7 @@ class AppService extends Service
 
 	def addGoal(User user, Goal goal, message = "")
 	{
-		yonaServer.postJson(user.goalsUrl, goal.convertToJsonString(), ["Yona-Password": user.password], ["message": message])
+		yonaServer.postJson(user.goalsUrl, goal.convertToJsonString(), ["message": message], ["Yona-Password": user.password])
 	}
 
 	Goal updateGoal(Closure asserter, User user, String url, Goal goal, message = "")
@@ -484,13 +479,13 @@ class AppService extends Service
 
 	def updateGoal(User user, String url, Goal goal, message = "")
 	{
-		yonaServer.putJson(url, goal.convertToJsonString(), ["Yona-Password": user.password], ["message": message])
+		yonaServer.putJson(url, goal.convertToJsonString(), ["message": message], ["Yona-Password": user.password])
 	}
 
 	def updateLastStatusChangeTime(User user, Buddy buddy, ZonedDateTime lastStatusChangeTime)
 	{
 		def lastStatusChangeTimeStr = yonaServer.toIsoDateTimeString(lastStatusChangeTime)
-		def response = yonaServer.putJson(buddy.editUrl, """{"lastStatusChangeTime":"$lastStatusChangeTimeStr"}""", ["Yona-Password": user.password])
+		def response = yonaServer.putJson(buddy.editUrl, """{"lastStatusChangeTime":"$lastStatusChangeTimeStr"}""", [:], ["Yona-Password": user.password])
 		assertResponseStatusOk(response)
 		return new Buddy(response.responseData)
 	}
@@ -502,7 +497,7 @@ class AppService extends Service
 
 	def getGoals(User user)
 	{
-		yonaServer.getResource(user.goalsUrl, ["Yona-Password": user.password])
+		yonaServer.getResource(user.goalsUrl, [:], ["Yona-Password": user.password])
 	}
 
 	def postMessageActionWithPassword(path, properties, password)
@@ -517,22 +512,17 @@ class AppService extends Service
 
 	def postMessageActionWithPassword(path, String jsonString, password)
 	{
-		postMessageAction(path, jsonString, ["Yona-Password": password])
+		postMessageAction(path, jsonString, [:], ["Yona-Password": password])
 	}
 
-	def postMessageAction(path, jsonString, headers = [:])
+	def postMessageAction(path, jsonString, parameters = [:], headers = [:])
 	{
-		yonaServer.postJson(path, jsonString, headers)
+		yonaServer.postJson(path, jsonString, parameters, headers)
 	}
 
-	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity, parameters = [:])
+	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity, parameters = [:], headers = [:])
 	{
-		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password, [:], parameters)
-	}
-
-	def postAppActivityToAnalysisEngine(User user, Device device, AppActivity appActivity, headers, parameters)
-	{
-		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password, headers, parameters)
+		yonaServer.createResourceWithPassword(device.appActivityUrl, appActivity.getJson(), user.password, parameters, headers)
 	}
 
 	def composeActivityCategoryUrl(def activityCategoryId) {

--- a/core/src/testUtils/groovy/nu/yona/server/test/Device.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Device.groovy
@@ -57,7 +57,7 @@ class Device
 
 	def postOpenAppEvent(AppService appService, operatingSystem = this.operatingSystem, appVersion = Device.SOME_APP_VERSION, appVersionCode = Device.SUPPORTED_APP_VERSION_CODE, locale = "en-US")
 	{
-		appService.createResourceWithPassword(postOpenAppEventUrl, """{"operatingSystem":"$operatingSystem", "appVersion":"$appVersion", "appVersionCode":"$appVersionCode"}""", password, ["Accept-Language" : locale])
+		appService.createResourceWithPassword(postOpenAppEventUrl, """{"operatingSystem":"$operatingSystem", "appVersion":"$appVersion", "appVersionCode":"$appVersionCode"}""", password, [:], ["Accept-Language" : locale])
 	}
 
 	def postVpnStatus(AppService appService, boolean vpnConnected)

--- a/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
@@ -45,25 +45,25 @@ abstract class Service
 
 	void setEnableStatistics(def enable)
 	{
-		def response = yonaServer.createResource("/hibernateStatistics/enable/", "{}", [:], ["enable" : enable])
+		def response = yonaServer.createResource("/hibernateStatistics/enable/", "{}", ["enable" : enable])
 		assert response.status == 204 : "Ensure the server stats are enabled (run with -Dyona.enableHibernateStatsAllowed=true)"
 	}
 
 	void resetStatistics()
 	{
-		def response = getResource("/hibernateStatistics/", [:], ["reset" : "true"])
+		def response = getResource("/hibernateStatistics/", ["reset" : "true"])
 		assertResponseStatusOk(response)
 	}
 
 	void clearCaches()
 	{
-		def response = yonaServer.createResource("/hibernateStatistics/clearCaches/", "{}", [:], [:])
+		def response = yonaServer.createResource("/hibernateStatistics/clearCaches/", "{}")
 		assertResponseStatusNoContent(response)
 	}
 
 	def getStatistics()
 	{
-		def response = getResource("/hibernateStatistics/", [:], ["reset" : "false"])
+		def response = getResource("/hibernateStatistics/", ["reset" : "false"])
 		assertResponseStatusOk(response)
 		response.responseData
 	}
@@ -88,44 +88,38 @@ abstract class Service
 		response.status >= 200 && response.status < 300
 	}
 
-	def createResourceWithPassword(path, jsonString, password, headers = [:], parameters = [:])
+	def createResourceWithPassword(path, jsonString, password, parameters = [:], headers = [:])
 	{
-		def headersWithPassword = headers.clone()
-		headersWithPassword["Yona-Password"] = password
-		yonaServer.createResource(path, jsonString, headersWithPassword, parameters)
+		yonaServer.createResource(path, jsonString, parameters, YonaServer.addPasswordToHeaders(headers, password))
 	}
 
-	def updateResourceWithPassword(path, jsonString, password, headers = [:], parameters = [:])
+	def updateResourceWithPassword(path, jsonString, password, parameters = [:], headers = [:])
 	{
-		def headersWithPassword = headers.clone()
-		headersWithPassword["Yona-Password"] = password
-		yonaServer.updateResource(path, jsonString, headersWithPassword, parameters)
+		yonaServer.updateResource(path, jsonString, parameters, YonaServer.addPasswordToHeaders(headers, password))
 	}
 
-	def deleteResourceWithPassword(path, password, headers = [:], parameters = [:])
+	def deleteResourceWithPassword(path, password, parameters = [:], headers = [:])
 	{
-		yonaServer.deleteResourceWithPassword(path, password, parameters)
+		yonaServer.deleteResourceWithPassword(path, password, parameters, headers)
 	}
 
-	def getResourceWithPassword(path, password, headers = [:], parameters = [:])
+	def getResourceWithPassword(path, password, parameters = [:], headers = [:])
 	{
-		def headersWithPassword = headers.clone()
-		headersWithPassword["Yona-Password"] = password
-		yonaServer.getResource(path, headersWithPassword, parameters)
+		yonaServer.getResource(path, parameters, YonaServer.addPasswordToHeaders(headers, password))
 	}
 
-	def getResource(path, headers = [:], parameters = [:])
+	def getResource(path, parameters = [:], headers = [:])
 	{
-		yonaServer.getResource(path, headers, parameters)
+		yonaServer.getResource(path, parameters, headers)
 	}
 
-	def updateResource(path, jsonString, headers = [:], parameters = [:])
+	def updateResource(path, jsonString, parameters = [:], headers = [:])
 	{
-		yonaServer.updateResource(path, jsonString, headers, parameters)
+		yonaServer.updateResource(path, jsonString, parameters, headers)
 	}
 
-	def deleteResource(path, headers = [:], parameters = [:])
+	def deleteResource(path, parameters = [:], headers = [:])
 	{
-		yonaServer.deleteResource(path, headers, parameters)
+		yonaServer.deleteResource(path, parameters, headers)
 	}
 }


### PR DESCRIPTION
It now goes from the app service to invoked services (e.g. the analysis service) and also to the async thread that sends the Firebase message, so it can be included in the error logging there.

Along with this:
* Improved the error logging for errors returned from an invoked service
* Included the token in the exception logging for Firebase issues
* Made the parameter order in tests consistent. Now the parameter order is always "parameters, headers", where "headers" can be omitted.