### PR TITLE
YD-673 Mark fatal issues with ALERT

### DIFF
--- a/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/BuddyActivityController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 

--- a/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
+++ b/appservice/src/main/java/nu/yona/server/analysis/rest/UserActivityController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.analysis.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 

--- a/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
+++ b/appservice/src/main/java/nu/yona/server/device/rest/DeviceController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -75,7 +75,7 @@ import nu.yona.server.device.service.UserDeviceDto;
 import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.properties.YonaProperties;
-import nu.yona.server.rest.Constants;
+import nu.yona.server.rest.RestConstants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.JsonRootRelProvider;
 import nu.yona.server.rest.RestUtil;
@@ -167,7 +167,7 @@ public class DeviceController extends ControllerBase
 	@PostMapping(value = "/")
 	@ResponseBody
 	public HttpEntity<UserResource> registerDevice(
-			@RequestHeader(value = Constants.NEW_DEVICE_REQUEST_PASSWORD_HEADER) String newDeviceRequestPassword,
+			@RequestHeader(value = RestConstants.NEW_DEVICE_REQUEST_PASSWORD_HEADER) String newDeviceRequestPassword,
 			@PathVariable UUID userId, @RequestBody DeviceRegistrationRequestDto request)
 	{
 		assertValidDeviceDataForRegister(request);
@@ -194,7 +194,7 @@ public class DeviceController extends ControllerBase
 
 	@PostMapping(value = "/{deviceId}/openApp")
 	@ResponseBody
-	public ResponseEntity<Void> postOpenAppEvent(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
+	public ResponseEntity<Void> postOpenAppEvent(@RequestHeader(value = RestConstants.PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId, @PathVariable UUID deviceId, @RequestBody AppOpenEventDto request)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
@@ -228,7 +228,7 @@ public class DeviceController extends ControllerBase
 	@GetMapping(value = "/{deviceId}/apple.mobileconfig")
 	@ResponseBody
 	public ResponseEntity<byte[]> getAppleMobileConfig(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
+			@RequestHeader(value = RestConstants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
 			@PathVariable UUID deviceId)
 	{
 		HttpHeaders headers = new HttpHeaders();

--- a/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
+++ b/appservice/src/main/java/nu/yona/server/goals/rest/GoalController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.goals.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 

--- a/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
+++ b/appservice/src/main/java/nu/yona/server/messaging/rest/MessageController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/BuddyController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/NewDeviceRequestController.java
@@ -1,9 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
 
+import static nu.yona.server.rest.RestConstants.NEW_DEVICE_REQUEST_PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -34,7 +36,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import nu.yona.server.crypto.CryptoException;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.device.rest.DeviceController;
-import nu.yona.server.rest.Constants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.JsonRootRelProvider;
 import nu.yona.server.subscriptions.rest.NewDeviceRequestController.NewDeviceRequestResource;
@@ -61,7 +62,7 @@ public class NewDeviceRequestController extends ControllerBase
 
 	@PutMapping(value = "/{mobileNumber}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void setNewDeviceRequestForUser(@RequestHeader(value = Constants.PASSWORD_HEADER) String password,
+	public void setNewDeviceRequestForUser(@RequestHeader(value = PASSWORD_HEADER) String password,
 			@PathVariable String mobileNumber, @RequestBody NewDeviceRequestCreationDto newDeviceRequestCreation)
 	{
 		try
@@ -86,7 +87,7 @@ public class NewDeviceRequestController extends ControllerBase
 	@GetMapping(value = "/{mobileNumber}")
 	@ResponseBody
 	public HttpEntity<NewDeviceRequestResource> getNewDeviceRequestForUser(
-			@RequestHeader(value = Constants.NEW_DEVICE_REQUEST_PASSWORD_HEADER) Optional<String> newDeviceRequestPassword,
+			@RequestHeader(value = NEW_DEVICE_REQUEST_PASSWORD_HEADER) Optional<String> newDeviceRequestPassword,
 			@PathVariable String mobileNumber)
 	{
 		try
@@ -107,7 +108,7 @@ public class NewDeviceRequestController extends ControllerBase
 	@DeleteMapping(value = "/{mobileNumber}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void clearNewDeviceRequestForUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
+	public void clearNewDeviceRequestForUser(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable String mobileNumber)
 	{
 		try
@@ -189,8 +190,7 @@ public class NewDeviceRequestController extends ControllerBase
 
 		private void addUserLink(Resource<NewDeviceRequestDto> newDeviceRequestResource)
 		{
-			newDeviceRequestResource
-					.add(UserController.getUserLink(BuddyDto.USER_REL_NAME, user.getId(), Optional.empty()));
+			newDeviceRequestResource.add(UserController.getUserLink(BuddyDto.USER_REL_NAME, user.getId(), Optional.empty()));
 		}
 
 		private void addRegisterDeviceLink(Resource<NewDeviceRequestDto> newDeviceRequestResource)

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/PinResetRequestController.java
@@ -1,9 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
 
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -31,7 +32,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.exceptions.ConfirmationException;
 import nu.yona.server.properties.YonaProperties;
-import nu.yona.server.rest.Constants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.ErrorResponseDto;
 import nu.yona.server.rest.GlobalExceptionMapping;
@@ -62,7 +62,7 @@ public class PinResetRequestController extends ControllerBase
 	@PostMapping(value = "/request")
 	@ResponseBody
 	public ResponseEntity<ConfirmationCodeDelayDto> requestPinReset(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
+			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
 				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
@@ -76,9 +76,8 @@ public class PinResetRequestController extends ControllerBase
 
 	@PostMapping(value = "/verify")
 	@ResponseBody
-	public ResponseEntity<Void> verifyPinResetConfirmationCode(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
-			@RequestBody ConfirmationCodeDto confirmationCode)
+	public ResponseEntity<Void> verifyPinResetConfirmationCode(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
+			@PathVariable UUID userId, @RequestBody ConfirmationCodeDto confirmationCode)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
 				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
@@ -91,8 +90,8 @@ public class PinResetRequestController extends ControllerBase
 
 	@PostMapping(value = "/resend")
 	@ResponseBody
-	public ResponseEntity<Void> resendPinResetConfirmationCode(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
+	public ResponseEntity<Void> resendPinResetConfirmationCode(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
+			@PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
 				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))
@@ -104,7 +103,7 @@ public class PinResetRequestController extends ControllerBase
 
 	@PostMapping(value = "/clear")
 	@ResponseBody
-	public ResponseEntity<Void> clearPinResetRequest(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
+	public ResponseEntity<Void> clearPinResetRequest(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserController.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
 
-import static nu.yona.server.rest.Constants.PASSWORD_HEADER;
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -68,7 +68,6 @@ import nu.yona.server.goals.rest.GoalController;
 import nu.yona.server.goals.service.GoalDto;
 import nu.yona.server.messaging.rest.MessageController;
 import nu.yona.server.properties.YonaProperties;
-import nu.yona.server.rest.Constants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.ErrorResponseDto;
 import nu.yona.server.rest.GlobalExceptionMapping;
@@ -253,7 +252,7 @@ public class UserController extends ControllerBase
 
 	@PutMapping(value = "/{userId}")
 	@ResponseBody
-	public HttpEntity<UserResource> updateUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
+	public HttpEntity<UserResource> updateUser(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = TEMP_PASSWORD_PARAM, required = false) String tempPasswordStr, @PathVariable UUID userId,
 			@RequestParam(value = REQUESTING_DEVICE_ID_PARAM, required = false) String requestingDeviceIdStr,
 			@RequestBody PostPutUserDto postPutUser, HttpServletRequest request)
@@ -320,7 +319,7 @@ public class UserController extends ControllerBase
 	@DeleteMapping(value = "/{userId}")
 	@ResponseBody
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void deleteUser(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
+	public void deleteUser(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
 			@RequestParam(value = "message", required = false) String messageStr)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
@@ -332,8 +331,8 @@ public class UserController extends ControllerBase
 
 	@PostMapping(value = "/{userId}/confirmMobileNumber")
 	@ResponseBody
-	public HttpEntity<UserResource> confirmMobileNumber(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId,
+	public HttpEntity<UserResource> confirmMobileNumber(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
+			@PathVariable UUID userId,
 			@RequestParam(value = REQUESTING_DEVICE_ID_PARAM, required = false) UUID requestingDeviceId,
 			@RequestBody ConfirmationCodeDto mobileNumberConfirmation)
 	{
@@ -348,7 +347,7 @@ public class UserController extends ControllerBase
 	@PostMapping(value = "/{userId}/resendMobileNumberConfirmationCode")
 	@ResponseBody
 	public ResponseEntity<Void> resendMobileNumberConfirmationCode(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
+			@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
 				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))

--- a/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
+++ b/appservice/src/main/java/nu/yona/server/subscriptions/rest/UserPhotoController.java
@@ -1,9 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.rest;
 
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
@@ -42,7 +43,6 @@ import org.springframework.web.multipart.MultipartFile;
 import nu.yona.server.crypto.seckey.CryptoSession;
 import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.exceptions.YonaException;
-import nu.yona.server.rest.Constants;
 import nu.yona.server.rest.ControllerBase;
 import nu.yona.server.rest.ErrorResponseDto;
 import nu.yona.server.rest.GlobalExceptionMapping;
@@ -74,8 +74,7 @@ public class UserPhotoController extends ControllerBase
 
 	@PutMapping(value = "/users/{userId}/photo", consumes = "multipart/form-data")
 	@ResponseBody
-	public ResponseEntity<UserPhotoResource> uploadUserPhoto(
-			@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
+	public ResponseEntity<UserPhotoResource> uploadUserPhoto(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password,
 			@RequestParam(value = "file", required = false) MultipartFile userPhoto, @PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
@@ -96,8 +95,7 @@ public class UserPhotoController extends ControllerBase
 
 	@DeleteMapping(value = "/users/{userId}/photo")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void removeUserPhoto(@RequestHeader(value = Constants.PASSWORD_HEADER) Optional<String> password,
-			@PathVariable UUID userId)
+	public void removeUserPhoto(@RequestHeader(value = PASSWORD_HEADER) Optional<String> password, @PathVariable UUID userId)
 	{
 		try (CryptoSession cryptoSession = CryptoSession.start(password,
 				() -> userService.doPreparationsAndCheckCanAccessPrivateData(userId)))

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/ActivityAggregationBatchJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/ActivityAggregationBatchJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
  * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.jobs;
@@ -79,8 +79,8 @@ public class ActivityAggregationBatchJob
 	@Bean("activityAggregationJob")
 	public Job activityAggregationBatchJob()
 	{
-		return jobBuilderFactory.get("activityAggregationBatchJob").incrementer(new RunIdIncrementer())
-				.flow(aggregateDayActivities()).next(aggregateWeekActivities()).end().build();
+		return jobBuilderFactory.get("activityAggregationBatchJob").listener(new ErrorLoggingListener())
+				.incrementer(new RunIdIncrementer()).flow(aggregateDayActivities()).next(aggregateWeekActivities()).end().build();
 	}
 
 	private Step aggregateDayActivities()

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/ErrorLoggingListener.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/ErrorLoggingListener.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.batch.jobs;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+
+import nu.yona.server.Constants;
+
+class ErrorLoggingListener implements JobExecutionListener
+{
+	private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingListener.class);
+
+	@Override
+	public void beforeJob(JobExecution jobExecution)
+	{
+		// Nothing to do here
+	}
+
+	@Override
+	public void afterJob(JobExecution jobExecution)
+	{
+		if (jobExecution.getStatus() == BatchStatus.FAILED)
+		{
+			List<Throwable> failureExceptions = jobExecution.getAllFailureExceptions();
+			String jobName = jobExecution.getJobInstance().getJobName();
+			logger.error(Constants.ALERT_MARKER,
+					"Fatal error: Batch job '" + jobName + "' failed with " + failureExceptions.size() + " failure exceptions");
+			failureExceptions.forEach(e -> logger.error("Batch job '" + jobName + "' failed with exception", e));
+		}
+	}
+}

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.batch.jobs;
@@ -74,8 +74,8 @@ public class SendSystemMessageBatchJob
 	@Bean("sendSystemMessageJob")
 	public Job sendSystemMessagesBatchJob()
 	{
-		return jobBuilderFactory.get("sendSystemMessagesBatchJob").incrementer(new RunIdIncrementer()).flow(sendSystemMessages())
-				.end().build();
+		return jobBuilderFactory.get("sendSystemMessagesBatchJob").listener(new ErrorLoggingListener())
+				.incrementer(new RunIdIncrementer()).flow(sendSystemMessages()).end().build();
 	}
 
 	private Step sendSystemMessages()

--- a/core/src/main/java/nu/yona/server/Constants.java
+++ b/core/src/main/java/nu/yona/server/Constants.java
@@ -1,14 +1,19 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 public final class Constants
 {
 	public static final String ISO_DATE_PATTERN = "yyyy-MM-dd";
 
 	public static final String ISO_DATE_TIME_PATTERN = ISO_DATE_PATTERN + "'T'HH:mm:ss.SSSZ";
+
+	public static final Marker ALERT_MARKER = MarkerFactory.getMarker("ALERT");
 
 	private Constants()
 	{

--- a/core/src/main/java/nu/yona/server/crypto/seckey/WrongPasswordException.java
+++ b/core/src/main/java/nu/yona/server/crypto/seckey/WrongPasswordException.java
@@ -1,13 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.crypto.seckey;
 
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
+
 import java.io.Serializable;
 
 import nu.yona.server.exceptions.YonaException;
-import nu.yona.server.rest.Constants;
 
 public class WrongPasswordException extends YonaException
 {
@@ -20,12 +21,11 @@ public class WrongPasswordException extends YonaException
 
 	public static WrongPasswordException passwordHeaderNotProvided()
 	{
-		return new WrongPasswordException("error.missing.password.header", Constants.PASSWORD_HEADER);
+		return new WrongPasswordException("error.missing.password.header", PASSWORD_HEADER);
 	}
 
 	public static WrongPasswordException wrongPasswordHeaderProvided(String marker, int expectedBytes, int actualBytes)
 	{
-		return new WrongPasswordException("error.wrong.password.header", Constants.PASSWORD_HEADER, marker, expectedBytes,
-				actualBytes);
+		return new WrongPasswordException("error.wrong.password.header", PASSWORD_HEADER, marker, expectedBytes, actualBytes);
 	}
 }

--- a/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/InvalidDataException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.exceptions;
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
-import nu.yona.server.rest.Constants;
+import nu.yona.server.rest.RestConstants;
 
 /**
  * This exception is to be used in case data is wrong in DTOs. So whenever a field has a wrong value you should throw this
@@ -177,7 +177,8 @@ public class InvalidDataException extends YonaException
 
 	public static InvalidDataException invalidAppVersionHeader(String header)
 	{
-		return new InvalidDataException("error.request.with.invalid.app.version.header", Constants.APP_VERSION_HEADER, header);
+		return new InvalidDataException("error.request.with.invalid.app.version.header", RestConstants.APP_VERSION_HEADER,
+				header);
 	}
 
 	public static InvalidDataException invalidVersionCode(String versionCodeString)

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2018, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
@@ -27,6 +27,7 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
+import nu.yona.server.Constants;
 import nu.yona.server.Translator;
 import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.properties.YonaProperties;
@@ -129,7 +130,7 @@ public class FirebaseService
 		}
 		else
 		{
-			logger.error("Fatal error: Exception while sending Firebase message", throwable);
+			logger.error(Constants.ALERT_MARKER, "Fatal error: Exception while sending Firebase message", throwable);
 		}
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
+++ b/core/src/main/java/nu/yona/server/rest/ErrorLoggingFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2016, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
@@ -25,10 +25,12 @@ import javax.servlet.http.HttpServletResponse;
 import org.jboss.logging.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.stereotype.Component;
 
+import nu.yona.server.Constants;
 import nu.yona.server.exceptions.InvalidDataException;
 import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.util.Require;
@@ -39,7 +41,7 @@ public class ErrorLoggingFilter implements Filter
 	@FunctionalInterface
 	public interface LogMethod
 	{
-		void log(String format, Object... insertions);
+		void log(Marker marker, String format, Object... insertions);
 	}
 
 	public static class LoggingContext implements AutoCloseable
@@ -66,7 +68,7 @@ public class ErrorLoggingFilter implements Filter
 		public static LoggingContext createInstance(HttpServletRequest request)
 		{
 			MDC.put(CORRELATION_ID_MDC_KEY, getCorrelationId(request));
-			Optional<String> yonaAppVersionHeader = Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER));
+			Optional<String> yonaAppVersionHeader = Optional.ofNullable(request.getHeader(RestConstants.APP_VERSION_HEADER));
 			yonaAppVersionHeader.ifPresent(LoggingContext::putAppVersionContext);
 			return new LoggingContext();
 		}
@@ -99,7 +101,7 @@ public class ErrorLoggingFilter implements Filter
 
 		private static void assertValidHeaders(HttpServletRequest request)
 		{
-			Optional.ofNullable(request.getHeader(Constants.APP_VERSION_HEADER))
+			Optional.ofNullable(request.getHeader(RestConstants.APP_VERSION_HEADER))
 					.ifPresent(LoggingContext::validateAppVersionHeader);
 		}
 
@@ -145,6 +147,13 @@ public class ErrorLoggingFilter implements Filter
 		map.put(Series.SERVER_ERROR, logger::error);
 		seriesToLoggerMap = Collections.unmodifiableMap(map);
 	}
+	private static final Map<Series, Marker> seriesToMarkerMap;
+	static
+	{
+		Map<Series, Marker> map = new EnumMap<>(Series.class);
+		map.put(Series.SERVER_ERROR, Constants.ALERT_MARKER);
+		seriesToMarkerMap = Collections.unmodifiableMap(map);
+	}
 
 	@Override
 	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
@@ -189,7 +198,8 @@ public class ErrorLoggingFilter implements Filter
 		{
 			throw new IllegalStateException("Status " + responseStatus + " is not supported");
 		}
-		logMethod.log("Status {} returned from {} (request content length: {})", response.getStatus(),
+		Marker marker = seriesToMarkerMap.get(responseStatus);
+		logMethod.log(marker, "Status {} returned from {} (request content length: {})", response.getStatus(),
 				GlobalExceptionMapping.buildRequestInfo(request), request.getContentLength());
 	}
 

--- a/core/src/main/java/nu/yona/server/rest/RestConstants.java
+++ b/core/src/main/java/nu/yona/server/rest/RestConstants.java
@@ -1,16 +1,16 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.rest;
 
-public final class Constants
+public final class RestConstants
 {
 	public static final String PASSWORD_HEADER = "Yona-Password";
 	public static final String NEW_DEVICE_REQUEST_PASSWORD_HEADER = "Yona-NewDeviceRequestPassword";
 	public static final String APP_VERSION_HEADER = "Yona-App-Version";
 
-	private Constants()
+	private RestConstants()
 	{
 		// No instances
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserServiceException.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserServiceException.java
@@ -1,14 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.service;
+
+import static nu.yona.server.rest.RestConstants.PASSWORD_HEADER;
 
 import java.io.Serializable;
 import java.util.UUID;
 
 import nu.yona.server.exceptions.YonaException;
-import nu.yona.server.rest.Constants;
 
 public class UserServiceException extends YonaException
 {
@@ -31,7 +32,7 @@ public class UserServiceException extends YonaException
 
 	public static UserServiceException missingPasswordHeader()
 	{
-		return new UserServiceException("error.missing.password.header", Constants.PASSWORD_HEADER);
+		return new UserServiceException("error.missing.password.header", PASSWORD_HEADER);
 	}
 
 	public static UserServiceException userExistsCreatedOnBuddyRequest(String mobileNumber)

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -198,7 +198,7 @@ mariadb:
 
 spring:
   loglevel: info
-  logpattern: "correlation.id=%X{yona.correlation.id} app.os=%X{yona.app.os} app.versionCode=%X{yona.app.versionCode} app.versionName=\"%X{yona.app.versionName}\" %5p"
+  logpattern: "correlation.id=%X{yona.correlation.id} app.os=%X{yona.app.os} app.versionCode=%X{yona.app.versionCode} app.versionName=\"%X{yona.app.versionName}\" Marker:%marker %5p"
   hazelcast:
     loglevel: info
     config: /opt/app/config/hazelcast-client.xml


### PR DESCRIPTION
This is done for internal server errors occurring in HTTP requests and for asynchronous processes (Quartz jobs, batch jobs and async tasks (CompletableFuture.runAsync).

Along with this:
* Renamed nu.yona.server.rest.Constants into RestConstants, to prevent clashes in places where both are needed
* The PASSWORD_HEADER constant was mostly statically imported. Did this now everywhere.