### PR TITLE
YD-676 Clear Firebase ID if not registered anymore

### DIFF
--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server;
@@ -27,6 +27,7 @@ import org.springframework.ldap.core.LdapTemplate;
 import org.springframework.ldap.core.support.LdapContextSource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.properties.YonaProperties;
@@ -34,6 +35,7 @@ import nu.yona.server.rest.JsonRootRelProvider;
 
 @EnableHypermediaSupport(type = HypermediaType.HAL)
 @EnableSpringDataWebSupport
+@EnableAsync
 @Configuration
 @EnableAutoConfiguration(exclude = { LdapAutoConfiguration.class })
 public class CoreConfiguration

--- a/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
+++ b/core/src/main/java/nu/yona/server/device/entities/DeviceAnonymized.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.entities;
@@ -175,7 +175,12 @@ public class DeviceAnonymized extends EntityWithUuid
 
 	public void setFirebaseInstanceId(String firebaseInstanceId)
 	{
-		this.firebaseInstanceId = firebaseInstanceId;
+		this.firebaseInstanceId = Objects.requireNonNull(firebaseInstanceId);
+	}
+
+	public void clearFirebaseInstanceId()
+	{
+		this.firebaseInstanceId = null;
 	}
 
 	public Locale getLocale()

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -105,6 +105,12 @@ public class DeviceService
 				.orElseThrow(() -> DeviceServiceException.notFoundByAnonymizedId(userAnonymizedId, deviceAnonymizedId));
 	}
 
+	private DeviceAnonymized getDeviceAnonymizedEntity(UUID deviceAnonymizedId)
+	{
+		return deviceAnonymizedRepository.findById(deviceAnonymizedId)
+				.orElseThrow(() -> DeviceServiceException.notFoundByAnonymizedId(deviceAnonymizedId));
+	}
+
 	@Transactional
 	public UserDeviceDto addDeviceToUser(User userEntity, UserDeviceDto deviceDto)
 	{
@@ -500,5 +506,13 @@ public class DeviceService
 	{
 		return (isVpnConnected) ? translator.getLocalizedMessage("message.buddy.device.vpn.connect", deviceName)
 				: translator.getLocalizedMessage("message.buddy.device.vpn.disconnect", deviceName);
+	}
+
+	@Transactional
+	public void clearFirebaseInstanceId(UUID deviceAnonymizedId)
+	{
+		DeviceAnonymized deviceAnonymized = getDeviceAnonymizedEntity(deviceAnonymizedId);
+		deviceAnonymized.clearFirebaseInstanceId();
+		deviceAnonymizedRepository.save(deviceAnonymized);
 	}
 }

--- a/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceServiceException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.device.service;
@@ -29,6 +29,12 @@ public class DeviceServiceException extends YonaException
 	public static DeviceServiceException notFoundById(UUID id)
 	{
 		return new DeviceServiceException(HttpStatus.NOT_FOUND, "error.device.not.found.id", id);
+	}
+
+	public static DeviceServiceException notFoundByAnonymizedId(UUID deviceAnonymizedId)
+	{
+		return new DeviceServiceException(HttpStatus.NOT_FOUND, "error.device.not.found.anonymized.id", "<unknown>",
+				deviceAnonymizedId);
 	}
 
 	public static DeviceServiceException notFoundByAnonymizedId(UUID userAnonymizedId, UUID deviceAnonymizedId)

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -40,7 +40,7 @@ import nu.yona.server.util.Require;
 @Service
 public class FirebaseService
 {
-	private final static String FIREBASE_ID_NOT_REGISTERED = "registration-token-not-registered";
+	private static final String FIREBASE_ID_NOT_REGISTERED = "registration-token-not-registered";
 	private static final Logger logger = LoggerFactory.getLogger(FirebaseService.class);
 
 	private final Map<String, MessageData> lastMessageByRegistrationToken = new HashMap<>();

--- a/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/MessageService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
@@ -355,9 +355,8 @@ public class MessageService
 
 	private void sendFirebaseNotification(DeviceAnonymizedDto deviceAnonymized, Message message)
 	{
-		LocaleContextHelper.inLocaleContext(
-				() -> firebaseService.sendMessage(deviceAnonymized.getFirebaseInstanceId().get(), message),
-				deviceAnonymized.getLocale());
+		LocaleContextHelper.inLocaleContext(() -> firebaseService.sendMessage(deviceAnonymized.getId(),
+				deviceAnonymized.getFirebaseInstanceId().get(), message), deviceAnonymized.getLocale());
 	}
 
 	@Transactional

--- a/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
+++ b/core/src/main/java/nu/yona/server/rest/PassThroughHeadersHolder.java
@@ -6,6 +6,7 @@ package nu.yona.server.rest;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.http.HttpHeaders;
 
@@ -50,5 +51,10 @@ public class PassThroughHeadersHolder
 	public void clear()
 	{
 		storedHeaders.clear();
+	}
+
+	public void removeAll(Set<String> headerNames)
+	{
+		storedHeaders.keySet().removeAll(headerNames);
 	}
 }

--- a/core/src/test/java/nu/yona/server/messaging/service/MessageServiceTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/service/MessageServiceTest.java
@@ -171,7 +171,7 @@ public class MessageServiceTest extends BaseSpringIntegrationTest
 
 		service.sendMessage(message, UserAnonymizedDto.createInstance(userAnonEntity));
 
-		verify(mockFirebaseService, times(1)).sendMessage(FIREBASE_REGISTRATION_TOKEN, message);
+		verify(mockFirebaseService, times(1)).sendMessage(deviceAnonEntity.getId(), FIREBASE_REGISTRATION_TOKEN, message);
 	}
 
 	@Test
@@ -233,6 +233,6 @@ public class MessageServiceTest extends BaseSpringIntegrationTest
 			service.prepareMessageCollection(user);
 		}
 
-		verify(mockFirebaseService, times(1)).sendMessage(FIREBASE_REGISTRATION_TOKEN, message);
+		verify(mockFirebaseService, times(1)).sendMessage(deviceAnonEntity.getId(), FIREBASE_REGISTRATION_TOKEN, message);
 	}
 }

--- a/core/src/test/java/nu/yona/server/util/AsyncExecutorTest.java
+++ b/core/src/test/java/nu/yona/server/util/AsyncExecutorTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v.2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import nu.yona.server.entities.UserRepositoriesConfiguration;
+import nu.yona.server.rest.PassThroughHeadersHolder;
+
+@Configuration
+@EnableAsync
+@ComponentScan(useDefaultFilters = false, basePackages = { "nu.yona.server.rest", "nu.yona.server.util" }, includeFilters = {
+		@ComponentScan.Filter(pattern = "nu.yona.server.rest.PassThroughHeadersHolder", type = FilterType.REGEX),
+		@ComponentScan.Filter(pattern = "nu.yona.server.util.AsyncExecutor", type = FilterType.REGEX) })
+class AsyncExecutorTestConfiguration extends UserRepositoriesConfiguration
+{
+}
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { AsyncExecutorTestConfiguration.class })
+class AsyncExecutorTest
+{
+	@Autowired
+	private AsyncExecutor service;
+
+	@Autowired
+	private PassThroughHeadersHolder headersHolder;
+
+	@Test
+	void getThreadData_successful_dataIsPresent() throws InterruptedException
+	{
+		DataCarrier expectedData = initializeThread();
+		CountDownLatch doneSignal = new CountDownLatch(1);
+		DataCarrier actionHandlerData = new DataCarrier();
+		DataCarrier completionHandlerData = new DataCarrier();
+
+		service.execAsync(service.getThreadData(), () -> actionHandler(actionHandlerData, Optional.empty()),
+				(t) -> completionHandler(doneSignal, completionHandlerData, t));
+		doneSignal.await();
+
+		assertReturnedData(completionHandlerData, expectedData);
+		assertReturnedData(actionHandlerData, expectedData);
+	}
+
+	@Test
+	void getThreadData_failed_dataIsPresentThrowableIsAvailable() throws InterruptedException
+	{
+		DataCarrier expectedData = initializeThread();
+		expectedData.exception = Optional.of(new NullPointerException("This fails badly"));
+		CountDownLatch doneSignal = new CountDownLatch(1);
+		DataCarrier actionHandlerData = new DataCarrier();
+		DataCarrier completionHandlerData = new DataCarrier();
+
+		service.execAsync(service.getThreadData(), () -> actionHandler(actionHandlerData, expectedData.exception),
+				(t) -> completionHandler(doneSignal, completionHandlerData, t));
+		doneSignal.await();
+
+		assertReturnedData(completionHandlerData, expectedData);
+		expectedData.exception = Optional.empty();
+		assertReturnedData(actionHandlerData, expectedData);
+	}
+
+	private DataCarrier initializeThread()
+	{
+		DataCarrier dataTransfer = new DataCarrier();
+		dataTransfer.mdc = Map.of("MDC key1", UUID.randomUUID().toString(), "MDC key2", UUID.randomUUID().toString());
+		MDC.clear();
+		dataTransfer.mdc.entrySet().stream().forEach(e -> MDC.put(e.getKey(), e.getValue()));
+
+		dataTransfer.headers = Map.of("header1", UUID.randomUUID().toString(), "header2", UUID.randomUUID().toString());
+		headersHolder.importFrom(dataTransfer.headers);
+
+		return dataTransfer;
+	}
+
+	private void actionHandler(DataCarrier returnDataHolder, Optional<Throwable> exception)
+	{
+		returnDataHolder.mdc = MDC.getCopyOfContextMap();
+		returnDataHolder.headers = headersHolder.export();
+		returnDataHolder.threadName = Thread.currentThread().getName();
+		exception.ifPresent(e -> {
+			throw (RuntimeException) e;
+		});
+	}
+
+	private void completionHandler(CountDownLatch doneSignal, DataCarrier returnDataHolder, Optional<Throwable> exception)
+	{
+		returnDataHolder.mdc = MDC.getCopyOfContextMap();
+		returnDataHolder.headers = headersHolder.export();
+		returnDataHolder.threadName = Thread.currentThread().getName();
+		returnDataHolder.exception = exception;
+		doneSignal.countDown();
+	}
+
+	private void assertReturnedData(DataCarrier returnedData, DataCarrier expectedData)
+	{
+		assertThat(returnedData.mdc, is(expectedData.mdc));
+		assertThat(returnedData.headers, is(expectedData.headers));
+		assertNotEquals(Thread.currentThread().getName(), returnedData.threadName);
+		assertEquals(expectedData.exception, returnedData.exception);
+	}
+
+	private static class DataCarrier
+	{
+		Map<String, String> headers;
+		Map<String, String> mdc;
+		Optional<Throwable> exception = Optional.empty();
+		String threadName;
+	}
+}

--- a/core/src/test/java/nu/yona/server/util/AsyncExecutorTest.java
+++ b/core/src/test/java/nu/yona/server/util/AsyncExecutorTest.java
@@ -59,8 +59,8 @@ class AsyncExecutorTest
 				(t) -> completionHandler(doneSignal, completionHandlerData, t));
 		doneSignal.await();
 
-		assertReturnedData(completionHandlerData, expectedData);
-		assertReturnedData(actionHandlerData, expectedData);
+		assertActionHandlerData(actionHandlerData, expectedData);
+		assertCompletionHandlerData(completionHandlerData, expectedData);
 	}
 
 	@Test
@@ -76,9 +76,8 @@ class AsyncExecutorTest
 				(t) -> completionHandler(doneSignal, completionHandlerData, t));
 		doneSignal.await();
 
-		assertReturnedData(completionHandlerData, expectedData);
-		expectedData.exception = Optional.empty();
-		assertReturnedData(actionHandlerData, expectedData);
+		assertActionHandlerData(actionHandlerData, expectedData);
+		assertCompletionHandlerData(completionHandlerData, expectedData);
 	}
 
 	private DataCarrier initializeThread()
@@ -113,11 +112,16 @@ class AsyncExecutorTest
 		doneSignal.countDown();
 	}
 
-	private void assertReturnedData(DataCarrier returnedData, DataCarrier expectedData)
+	private void assertActionHandlerData(DataCarrier returnedData, DataCarrier expectedData)
 	{
 		assertThat(returnedData.mdc, is(expectedData.mdc));
 		assertThat(returnedData.headers, is(expectedData.headers));
 		assertNotEquals(Thread.currentThread().getName(), returnedData.threadName);
+	}
+
+	private void assertCompletionHandlerData(DataCarrier returnedData, DataCarrier expectedData)
+	{
+		assertActionHandlerData(returnedData, expectedData);
 		assertEquals(expectedData.exception, returnedData.exception);
 	}
 

--- a/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
@@ -75,7 +75,18 @@ abstract class Service
 
 	def getLastFirebaseMessage(def firebaseInstanceId)
 	{
-		getResource("$LAST_EMAIL_FIREBASE_MESSAGE/$firebaseInstanceId")
+		// Firebase message is sent asynchronously, so wait till it is done, at most 5 seconds
+		def response
+		for (def i = 0; i < 10; i++)
+		{
+			response = getResource("$LAST_EMAIL_FIREBASE_MESSAGE/$firebaseInstanceId")
+			if (response.status != 404)
+			{
+				return response
+			}
+			sleep(500)
+		}
+		return response
 	}
 
 	def clearLastFirebaseMessage(def firebaseInstanceId)


### PR DESCRIPTION
If the Firebase instance ID is not registered anymore, the Firbase web service returns a 404. In that case, we clear the Firebase instance ID on the DeviceAnonymized entity, so we stop trying to push notifications to that device.

Along with this:
* Added a method to find a DeviceAnonymized without having the UserAnonymized ID available. That ID would otherwise be used for logging, but that isn't worth carrying the UserAnonymized around.
* Used the Spring-way of asynchronous execution. This way, the thread is automatically initialized for Spring behavior.
* Fixed an issue in the Groovy Firebase tests that caused intermittent failures because the asynchronous execution wasn't completed before the Firebase message was fetched by the test
* Created a unit test for AsyncExecutor
* Made the AsyncExecutor clear the MDC and header holder upon completion of the task