### PR TITLE
YD-678 Improve Firebase implementation

### DIFF
--- a/core/src/main/java/nu/yona/server/CoreConfiguration.java
+++ b/core/src/main/java/nu/yona/server/CoreConfiguration.java
@@ -26,6 +26,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+
 import nu.yona.server.entities.RepositoryProvider;
 import nu.yona.server.properties.YonaProperties;
 import nu.yona.server.rest.JsonRootLinkRelationProvider;
@@ -80,6 +82,13 @@ public class CoreConfiguration
 		contextSource.setPassword(yonaProperties.getLdap().getAccessUserPassword());
 		contextSource.afterPropertiesSet();
 		return new LdapTemplate(contextSource);
+	}
+
+	@Bean
+	@ConditionalOnProperty("yona.firebase.enabled")
+	public FirebaseMessaging firebaseMessaging()
+	{
+		return FirebaseMessaging.getInstance();
 	}
 
 	@Bean

--- a/core/src/main/java/nu/yona/server/device/service/DeviceService.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceService.java
@@ -14,8 +14,6 @@ import java.util.stream.IntStream;
 
 import javax.transaction.Transactional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Service;
@@ -54,8 +52,6 @@ public class DeviceService
 	// User-friendly minimum version, used for error message
 	private static final String ANDROID_MIN_APP_VERSION = "1.2";
 	private static final String IOS_MIN_APP_VERSION = ANDROID_MIN_APP_VERSION;
-
-	private static final Logger logger = LoggerFactory.getLogger(DeviceService.class);
 
 	@Autowired(required = false)
 	private UserService userService;
@@ -237,8 +233,6 @@ public class DeviceService
 		}
 		deviceAnonymized.setFirebaseInstanceId(newFirebaseInstanceId);
 		deviceAnonymizedRepository.save(deviceAnonymized);
-		logger.info("Changed Firebase instance ID from {} to {}", oldFirebaseInstanceId.orElse("<not set>"),
-				newFirebaseInstanceId);
 	}
 
 	public UserDeviceDto createDefaultUserDeviceDto()

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -57,6 +57,9 @@ public class FirebaseService
 	@Autowired
 	private DeviceService deviceService;
 
+	@Autowired(required = false)
+	private FirebaseMessaging firebaseMessaging;
+
 	@PostConstruct
 	private void init()
 	{
@@ -92,8 +95,8 @@ public class FirebaseService
 
 		// Sending takes quite a bit of time, so do it asynchronously
 		ThreadData threadData = asyncExecutor.getThreadData();
-		asyncExecutor.execAsync(threadData, () -> sendMessage(registrationToken, firebaseMessage),
-				t -> handleCompletion(t, deviceAnonymizedId, registrationToken));
+		asyncExecutor.execAsync(threadData, () -> sendMessage(registrationToken, deviceAnonymizedId, firebaseMessage),
+				t -> handleCompletion(t, registrationToken));
 	}
 
 	private long getMessageId(nu.yona.server.messaging.entities.Message message)
@@ -112,14 +115,14 @@ public class FirebaseService
 		return Optional.ofNullable(lastMessageByRegistrationToken.remove(registrationToken));
 	}
 
-	private void sendMessage(String registrationToken, Message firebaseMessage)
+	private void sendMessage(String registrationToken, UUID deviceAnonymizedId, Message firebaseMessage)
 	{
 		try
 		{
 			if (yonaProperties.getFirebase().isEnabled())
 			{
 				logger.info("Sending Firebase message");
-				FirebaseMessaging.getInstance().send(firebaseMessage);
+				firebaseMessaging.send(firebaseMessage);
 			}
 			else
 			{
@@ -131,30 +134,19 @@ public class FirebaseService
 		}
 		catch (FirebaseMessagingException e)
 		{
+			if (FIREBASE_ID_NOT_REGISTERED.equals(e.getErrorCode()))
+			{
+				handleNotRegisteredDevice(deviceAnonymizedId);
+				return;
+			}
 			throw FirebaseServiceException.couldNotSendMessage(e);
 		}
 	}
 
-	private void handleCompletion(Optional<Throwable> throwable, UUID deviceAnonymizedId, String token)
+	private void handleCompletion(Optional<Throwable> throwable, String token)
 	{
-		throwable.ifPresentOrElse(t -> handleFailedSend(token, deviceAnonymizedId, t), this::logSuccessfulSend);
-	}
-
-	private void handleFailedSend(String token, UUID deviceAnonymizedId, Throwable throwable)
-	{
-		if (throwable.getCause() instanceof FirebaseMessagingException)
-		{
-			String errorCode = ((FirebaseMessagingException) throwable.getCause()).getErrorCode();
-			logger.error("Firebase error code: {}", errorCode);
-		}
-		if (throwable.getCause() instanceof FirebaseMessagingException
-				&& FIREBASE_ID_NOT_REGISTERED.equals(((FirebaseMessagingException) throwable.getCause()).getErrorCode()))
-		{
-			handleNotRegisteredDevice(deviceAnonymizedId);
-			return;
-		}
-		logger.error(Constants.ALERT_MARKER, "Fatal error: Exception while sending Firebase message to '" + token + "'",
-				throwable);
+		throwable.ifPresent(t -> logger.error(Constants.ALERT_MARKER,
+				"Fatal error: Exception while sending Firebase message to '" + token + "'", throwable));
 	}
 
 	private void handleNotRegisteredDevice(UUID deviceAnonymizedId)
@@ -162,14 +154,6 @@ public class FirebaseService
 		deviceService.clearFirebaseInstanceId(deviceAnonymizedId);
 		logger.info("Firebase instance ID for device anonymized {} cleared, as it was not longer registered with Firebase",
 				deviceAnonymizedId);
-	}
-
-	private void logSuccessfulSend()
-	{
-		if (yonaProperties.getFirebase().isEnabled())
-		{
-			logger.info("Firebase message sent successfully");
-		}
 	}
 
 	public static class MessageData

--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -127,9 +127,7 @@ public class FirebaseService
 			else
 			{
 				logger.info("Firebase message not sent because Firebase is disabled");
-				// Store for testability
-				lastMessageByRegistrationToken.put(registrationToken,
-						MessageData.createInstance(MDC.getCopyOfContextMap(), firebaseMessage));
+				storeForTestability(registrationToken, firebaseMessage);
 			}
 		}
 		catch (FirebaseMessagingException e)
@@ -141,6 +139,12 @@ public class FirebaseService
 			}
 			throw FirebaseServiceException.couldNotSendMessage(e);
 		}
+	}
+
+	private void storeForTestability(String registrationToken, Message firebaseMessage)
+	{
+		lastMessageByRegistrationToken.put(registrationToken,
+				MessageData.createInstance(MDC.getCopyOfContextMap(), firebaseMessage));
 	}
 
 	private void handleCompletion(Optional<Throwable> throwable, String token)

--- a/core/src/main/java/nu/yona/server/rest/TestController.java
+++ b/core/src/main/java/nu/yona/server/rest/TestController.java
@@ -97,12 +97,7 @@ public class TestController extends ControllerBase
 	{
 		Require.that(yonaProperties.isTestServer(),
 				() -> InvalidDataException.onlyAllowedOnTestServers("Endpoint /firebase/messages/last/ is not available"));
-		Optional<MessageData> lastMessage = firebaseService.getLastMessage(registrationToken);
-		if (lastMessage.isEmpty())
-		{
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
-		return createOkResponse(FirebaseMessageDto.createInstance(lastMessage.get()), createFirebaseMessageRepresentationModelAssembler());
+		return createResponse(firebaseService.getLastMessage(registrationToken));
 	}
 
 	/**
@@ -117,12 +112,14 @@ public class TestController extends ControllerBase
 	{
 		Require.that(yonaProperties.isTestServer(),
 				() -> InvalidDataException.onlyAllowedOnTestServers("Endpoint /firebase/messages/last/ is not available"));
-		Optional<MessageData> lastMessage = firebaseService.clearLastMessage(registrationToken);
-		if (lastMessage.isEmpty())
-		{
-			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-		}
-		return createOkResponse(FirebaseMessageDto.createInstance(lastMessage.get()), createFirebaseMessageRepresentationModelAssembler());
+		return createResponse(firebaseService.clearLastMessage(registrationToken));
+	}
+
+	private ResponseEntity<EntityModel<FirebaseMessageDto>> createResponse(Optional<MessageData> lastMessage)
+	{
+		return lastMessage.map(
+				m -> createOkResponse(FirebaseMessageDto.createInstance(m), createFirebaseMessageRepresentationModelAssembler()))
+				.orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
 	}
 
 	private FirebaseMessageRepresentationModelAssembler createFirebaseMessageRepresentationModelAssembler()

--- a/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
+ * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.messaging.service;
 
@@ -24,10 +24,8 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
@@ -39,12 +37,8 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 
 import nu.yona.server.Translator;
-import nu.yona.server.device.entities.DeviceAnonymizedRepository;
-import nu.yona.server.device.entities.UserDeviceRepository;
 import nu.yona.server.device.service.DeviceService;
-import nu.yona.server.entities.DeviceAnonymizedRepositoryMock;
 import nu.yona.server.entities.EntityWithId;
-import nu.yona.server.entities.UserDeviceRepositoryMock;
 import nu.yona.server.entities.UserRepositoriesConfiguration;
 import nu.yona.server.exceptions.YonaException;
 import nu.yona.server.messaging.entities.SystemMessage;
@@ -55,22 +49,11 @@ import nu.yona.server.util.AsyncExecutor;
 
 @Configuration
 @ComponentScan(useDefaultFilters = false, basePackages = { "nu.yona.server.messaging.service",
-		"nu.yona.server.subscriptions.service", "nu.yona.server.properties", "nu.yona.server" }, includeFilters = {
+		"nu.yona.server.properties" }, includeFilters = {
 				@ComponentScan.Filter(pattern = "nu.yona.server.messaging.service.FirebaseService", type = FilterType.REGEX),
 				@ComponentScan.Filter(pattern = "nu.yona.server.properties.YonaProperties", type = FilterType.REGEX) })
 class FirebaseServiceTestConfiguration extends UserRepositoriesConfiguration
 {
-	@Bean
-	UserDeviceRepository getMockDeviceRepository()
-	{
-		return Mockito.spy(new UserDeviceRepositoryMock());
-	}
-
-	@Bean
-	DeviceAnonymizedRepository getMockDeviceAnonymizedRepository()
-	{
-		return Mockito.spy(new DeviceAnonymizedRepositoryMock());
-	}
 }
 
 @ExtendWith(SpringExtension.class)

--- a/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
@@ -60,7 +60,7 @@ class FirebaseServiceTestConfiguration extends UserRepositoriesConfiguration
 @ContextConfiguration(classes = { FirebaseServiceTestConfiguration.class })
 public class FirebaseServiceTest extends BaseSpringIntegrationTest
 {
-	private static final Constructor<FirebaseMessagingException> firebaseMessagingConstructor = JUnitUtil
+	private static final Constructor<FirebaseMessagingException> firebaseMessagingExceptionConstructor = JUnitUtil
 			.getAccessibleConstructor(FirebaseMessagingException.class, String.class, String.class, Throwable.class);
 	private static final Field messageIdField = JUnitUtil.getAccessibleField(EntityWithId.class, "id");
 
@@ -104,8 +104,7 @@ public class FirebaseServiceTest extends BaseSpringIntegrationTest
 	{
 		UUID deviceAnonymizedId = UUID.randomUUID();
 		String registrationToken = "token-" + UUID.randomUUID();
-		SystemMessage message = SystemMessage.createInstance("Hi there!");
-		setId(message, 5); // Make it look like a saved message
+		SystemMessage message = createMessage();
 
 		service.sendMessage(deviceAnonymizedId, registrationToken, message);
 
@@ -118,8 +117,7 @@ public class FirebaseServiceTest extends BaseSpringIntegrationTest
 	{
 		UUID deviceAnonymizedId = UUID.randomUUID();
 		String registrationToken = "token-" + UUID.randomUUID();
-		SystemMessage message = SystemMessage.createInstance("Hi there!");
-		setId(message, 5); // Make it look like a saved message
+		SystemMessage message = createMessage();
 		when(mockFirebaseMessaging.send(any()))
 				.thenThrow(createFirebaseMessagingException("registration-token-not-registered", "Sorry, failed"));
 
@@ -133,8 +131,7 @@ public class FirebaseServiceTest extends BaseSpringIntegrationTest
 	{
 		UUID deviceAnonymizedId = UUID.randomUUID();
 		String registrationToken = "token-" + UUID.randomUUID();
-		SystemMessage message = SystemMessage.createInstance("Hi there!");
-		setId(message, 5); // Make it look like a saved message
+		SystemMessage message = createMessage();
 		when(mockFirebaseMessaging.send(any()))
 				.thenThrow(createFirebaseMessagingException("some-unknown-error", "Sorry, failed"));
 
@@ -143,11 +140,18 @@ public class FirebaseServiceTest extends BaseSpringIntegrationTest
 		verify(mockDeviceService, never()).clearFirebaseInstanceId(any());
 	}
 
+	private SystemMessage createMessage()
+	{
+		SystemMessage message = SystemMessage.createInstance("Hi there!");
+		setId(message, 5); // Make it look like a saved message
+		return message;
+	}
+
 	private FirebaseMessagingException createFirebaseMessagingException(String errorCode, String message)
 	{
 		try
 		{
-			return firebaseMessagingConstructor.newInstance(errorCode, message, null);
+			return firebaseMessagingExceptionConstructor.newInstance(errorCode, message, null);
 		}
 		catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 				| SecurityException e)

--- a/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
+++ b/core/src/test/java/nu/yona/server/messaging/service/FirebaseServiceTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *******************************************************************************/
+package nu.yona.server.messaging.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.repository.Repository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+
+import nu.yona.server.Translator;
+import nu.yona.server.device.entities.DeviceAnonymizedRepository;
+import nu.yona.server.device.entities.UserDeviceRepository;
+import nu.yona.server.device.service.DeviceService;
+import nu.yona.server.entities.DeviceAnonymizedRepositoryMock;
+import nu.yona.server.entities.EntityWithId;
+import nu.yona.server.entities.UserDeviceRepositoryMock;
+import nu.yona.server.entities.UserRepositoriesConfiguration;
+import nu.yona.server.exceptions.YonaException;
+import nu.yona.server.messaging.entities.SystemMessage;
+import nu.yona.server.properties.YonaProperties;
+import nu.yona.server.test.util.BaseSpringIntegrationTest;
+import nu.yona.server.test.util.JUnitUtil;
+import nu.yona.server.util.AsyncExecutor;
+
+@Configuration
+@ComponentScan(useDefaultFilters = false, basePackages = { "nu.yona.server.messaging.service",
+		"nu.yona.server.subscriptions.service", "nu.yona.server.properties", "nu.yona.server" }, includeFilters = {
+				@ComponentScan.Filter(pattern = "nu.yona.server.messaging.service.FirebaseService", type = FilterType.REGEX),
+				@ComponentScan.Filter(pattern = "nu.yona.server.properties.YonaProperties", type = FilterType.REGEX) })
+class FirebaseServiceTestConfiguration extends UserRepositoriesConfiguration
+{
+	@Bean
+	UserDeviceRepository getMockDeviceRepository()
+	{
+		return Mockito.spy(new UserDeviceRepositoryMock());
+	}
+
+	@Bean
+	DeviceAnonymizedRepository getMockDeviceAnonymizedRepository()
+	{
+		return Mockito.spy(new DeviceAnonymizedRepositoryMock());
+	}
+}
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { FirebaseServiceTestConfiguration.class })
+public class FirebaseServiceTest extends BaseSpringIntegrationTest
+{
+	private static final Constructor<FirebaseMessagingException> firebaseMessagingConstructor = JUnitUtil
+			.getAccessibleConstructor(FirebaseMessagingException.class, String.class, String.class, Throwable.class);
+	private static final Field messageIdField = JUnitUtil.getAccessibleField(EntityWithId.class, "id");
+
+	@MockBean
+	private Translator mockTranslator;
+
+	@MockBean
+	private AsyncExecutor mockAsyncExecutor;
+
+	@MockBean
+	private DeviceService mockDeviceService;
+
+	@MockBean
+	private FirebaseMessaging mockFirebaseMessaging;
+
+	@Autowired
+	private YonaProperties yonaProperties;
+
+	@Autowired
+	private FirebaseService service;
+
+	@BeforeEach
+	public void setUp()
+	{
+		doAnswer(invocation -> {
+			exec(invocation.getArgument(1), invocation.getArgument(2));
+			return null;
+		}).when(mockAsyncExecutor).execAsync(any(), any(), any());
+
+		yonaProperties.getFirebase().setEnabled(true);
+	}
+
+	@Override
+	protected Map<Class<?>, Repository<?, ?>> getRepositories()
+	{
+		return new HashMap<>();
+	}
+
+	@Test
+	public void sendMessage_success_sendsFirebaseMessage() throws FirebaseMessagingException
+	{
+		UUID deviceAnonymizedId = UUID.randomUUID();
+		String registrationToken = "token-" + UUID.randomUUID();
+		SystemMessage message = SystemMessage.createInstance("Hi there!");
+		setId(message, 5); // Make it look like a saved message
+
+		service.sendMessage(deviceAnonymizedId, registrationToken, message);
+
+		verify(mockFirebaseMessaging, times(1)).send(any());
+		verify(mockDeviceService, never()).clearFirebaseInstanceId(any());
+	}
+
+	@Test
+	public void sendMessage_unregisteredError_clearsFirebaseInstanceId() throws FirebaseMessagingException
+	{
+		UUID deviceAnonymizedId = UUID.randomUUID();
+		String registrationToken = "token-" + UUID.randomUUID();
+		SystemMessage message = SystemMessage.createInstance("Hi there!");
+		setId(message, 5); // Make it look like a saved message
+		when(mockFirebaseMessaging.send(any()))
+				.thenThrow(createFirebaseMessagingException("registration-token-not-registered", "Sorry, failed"));
+
+		service.sendMessage(deviceAnonymizedId, registrationToken, message);
+
+		verify(mockDeviceService, times(1)).clearFirebaseInstanceId(deviceAnonymizedId);
+	}
+
+	@Test
+	public void sendMessage_unknownError_fails() throws FirebaseMessagingException
+	{
+		UUID deviceAnonymizedId = UUID.randomUUID();
+		String registrationToken = "token-" + UUID.randomUUID();
+		SystemMessage message = SystemMessage.createInstance("Hi there!");
+		setId(message, 5); // Make it look like a saved message
+		when(mockFirebaseMessaging.send(any()))
+				.thenThrow(createFirebaseMessagingException("some-unknown-error", "Sorry, failed"));
+
+		assertThrows(FirebaseServiceException.class, () -> service.sendMessage(deviceAnonymizedId, registrationToken, message));
+
+		verify(mockDeviceService, never()).clearFirebaseInstanceId(any());
+	}
+
+	private FirebaseMessagingException createFirebaseMessagingException(String errorCode, String message)
+	{
+		try
+		{
+			return firebaseMessagingConstructor.newInstance(errorCode, message, null);
+		}
+		catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
+				| SecurityException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private void setId(SystemMessage message, int i)
+	{
+		try
+		{
+			messageIdField.set(message, i);
+		}
+		catch (IllegalArgumentException | IllegalAccessException e)
+		{
+			throw YonaException.unexpected(e);
+		}
+	}
+
+	private void exec(Runnable action, Consumer<Optional<Throwable>> completionHandler)
+	{
+		try
+		{
+			action.run();
+			completionHandler.accept(Optional.empty());
+		}
+		catch (Throwable e)
+		{
+			completionHandler.accept(Optional.of(e));
+			throw e;
+		}
+	}
+}

--- a/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
+++ b/core/src/test/java/nu/yona/server/test/util/JUnitUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.test.util;
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -133,6 +134,20 @@ public class JUnitUtil
 				.orElseThrow(() -> new IllegalStateException("Cannot find field '" + fieldName + "'"));
 		field.setAccessible(true);
 		return field;
+	}
+
+	public static <T> Constructor<T> getAccessibleConstructor(Class<T> clazz, Class<?>... parameterTypes)
+	{
+		try
+		{
+			Constructor<T> constructor = clazz.getDeclaredConstructor(parameterTypes);
+			constructor.setAccessible(true);
+			return constructor;
+		}
+		catch (NoSuchMethodException | SecurityException e)
+		{
+			throw new IllegalStateException("Cannot find constructor", e);
+		}
 	}
 
 	public static LocalDateTime getRoundedCreationDate(User user)


### PR DESCRIPTION
* Handle unregistered devices as part of the exception handling rather than in the completion handler. This gives cleaner failure scenarios.
* Remove excess log statement that reported successful send
* Created a unit test that verifies the FirebaseMessaging failure behavior

Along with this:
* Updated TestController to use the much simpler entity model approach introduced with Spring HATEOAS 1.0