### PR TITLE
YD-681 Use new Spring forward header setting

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -39,7 +39,7 @@ spring.jackson.serialization.indent-output=true
 spring.jackson.mapper.default-view-inclusion=true
 
 # Enable interpretation of headers like X-Forwarded-For and X-Forwarded-Proto
-server.use-forward-headers=true
+server.forward-headers-strategy=native
 
 # User photo upload limit
 spring.servlet.multipart.max-file-size=128KB


### PR DESCRIPTION
The old setting (server.use-forward-headers=true) was deprecated. We now use server.forward-headers-strategy=native. The old setting was deprecated to allow different strategies.