### PR TITLE
Upgrade helm charts for new API versions

### DIFF
--- a/k8s/helm/yona/Chart.yaml
+++ b/k8s/helm/yona/Chart.yaml
@@ -1,6 +1,6 @@
 name: yona
 home: https://yona.nu/
-version: 0.0.6
+version: 0.0.7
 appVersion: _ReplaceWithBuildNumber_
 description: The Yona Server backs the Yona mobile app, providing user management, buddy relationship management, web traffic classification and buddy messaging
 sources:
@@ -11,7 +11,3 @@ maintainers:
   - name: Bert Roos
     email: bert@famroos.nu
 icon: http://www.yona.nu/wp-content/themes/yona/assets/img/yona-logo.png
-dependencies:
-  - name: stable/mariadb
-    version: 0.6.3
- 

--- a/k8s/helm/yona/requirements.yaml
+++ b/k8s/helm/yona/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
   - name: mariadb
-    version: 0.6.3
+    version: 7.0.1
     repository:  "https://kubernetes-charts.storage.googleapis.com"
     condition: support_infrastructure.enabled
   - name: ldap
-    version: 0.1.1
+    version: 0.1.2
     repository:  "https://jump.ops.yona.nu/helm-charts"
     condition: support_infrastructure.enabled
   - name: hazelcast

--- a/k8s/helm/yona/templates/03_job-liquibase.yaml
+++ b/k8s/helm/yona/templates/03_job-liquibase.yaml
@@ -66,7 +66,7 @@ spec:
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.db.name }}"
             {{- end }}
             - name: RELEASE
             {{- if .Values.mariadb.seed_release}}

--- a/k8s/helm/yona/templates/03_job-liquibase.yaml
+++ b/k8s/helm/yona/templates/03_job-liquibase.yaml
@@ -25,9 +25,9 @@ spec:
           image: craftypenguins/k8s-init-mysql:latest
           env:
             - name: DBUSER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: DBPASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: DBHOST
               {{- if .Values.mariadb.hostname_override }}
               value: {{ .Values.mariadb.hostname_override | quote }}
@@ -35,7 +35,7 @@ spec:
               value: {{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local
               {{- end }}
             - name: DBNAME
-              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+              value: {{ .Values.mariadb.db.name | quote }}
             - name: TIMEOUT
               value: "10s"
         - name: validateldap
@@ -59,9 +59,9 @@ spec:
           imagePullPolicy: IfNotPresent
           env:       
             - name: USER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: PASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: URL
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}

--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.global.stage | default "develop" }}-admin
@@ -16,6 +16,10 @@ spec:
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: admin
+      stage: {{ .Values.global.stage | default "develop" }}
   template:
     metadata:
       labels:

--- a/k8s/helm/yona/templates/10_deployment_admin.yaml
+++ b/k8s/helm/yona/templates/10_deployment_admin.yaml
@@ -38,9 +38,9 @@ spec:
           image: craftypenguins/k8s-init-mysql:latest
           env:
             - name: DBUSER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: DBPASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: DBHOST
               {{- if .Values.mariadb.hostname_override }}
               value: {{ .Values.mariadb.hostname_override | quote }}
@@ -48,7 +48,7 @@ spec:
               value: {{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local
               {{- end }}
             - name: DBNAME
-              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+              value: {{ .Values.mariadb.db.name | quote }}
             - name: TIMEOUT
               value: "10s"
       containers:
@@ -56,14 +56,14 @@ spec:
           image: '{{ .Values.global.imagebase | default "yonadev" }}/adminservice:build-{{ .Chart.AppVersion }}'
           env:       
             - name: YONA_DB_USER_NAME
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: YONA_DB_PASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: YONA_DB_URL
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.db.name }}"
             {{- end }}
             - name: YONA_BATCH_SERVICE_SERVICE_URL
             {{- if hasKey .Values.batch "url_override" }}

--- a/k8s/helm/yona/templates/10_deployment_analysis.yaml
+++ b/k8s/helm/yona/templates/10_deployment_analysis.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.global.stage | default "develop" }}-analysis
@@ -16,6 +16,10 @@ spec:
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: analysis
+      stage: {{ .Values.global.stage | default "develop" }}
   template:
     metadata:
       labels:

--- a/k8s/helm/yona/templates/10_deployment_analysis.yaml
+++ b/k8s/helm/yona/templates/10_deployment_analysis.yaml
@@ -38,9 +38,9 @@ spec:
           image: craftypenguins/k8s-init-mysql:latest
           env:
             - name: DBUSER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: DBPASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: DBHOST
               {{- if .Values.mariadb.hostname_override }}
               value: {{ .Values.mariadb.hostname_override | quote }}
@@ -48,7 +48,7 @@ spec:
               value: {{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local
               {{- end }}
             - name: DBNAME
-              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+              value: {{ .Values.mariadb.db.name | quote }}
             - name: TIMEOUT
               value: "10s"
       containers:
@@ -57,14 +57,14 @@ spec:
           #imagePullPolicy: Always
           env:
             - name: YONA_DB_USER_NAME
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: YONA_DB_PASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: YONA_DB_URL
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.db.name }}"
             {{- end }}
           ports:
             - containerPort: 8080

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -38,9 +38,9 @@ spec:
           image: craftypenguins/k8s-init-mysql:latest
           env:
             - name: DBUSER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: DBPASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: DBHOST
               {{- if .Values.mariadb.hostname_override }}
               value: {{ .Values.mariadb.hostname_override | quote }}
@@ -48,7 +48,7 @@ spec:
               value: {{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local
               {{- end }}
             - name: DBNAME
-              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+              value: {{ .Values.mariadb.db.name | quote }}
             - name: TIMEOUT
               value: "10s"
       containers:
@@ -56,14 +56,14 @@ spec:
           image: '{{ .Values.global.imagebase | default "yonadev" }}/appservice:build-{{ .Chart.AppVersion }}'
           env:       
             - name: YONA_DB_USER_NAME
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: YONA_DB_PASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: YONA_DB_URL
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.db.name }}"
             {{- end }}
             - name: YONA_ANALYSIS_SERVICE_SERVICE_URL
             {{- if hasKey .Values.analysis "url_override" }}

--- a/k8s/helm/yona/templates/10_deployment_app.yaml
+++ b/k8s/helm/yona/templates/10_deployment_app.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.global.stage | default "develop" }}-app
@@ -16,6 +16,10 @@ spec:
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: app
+      stage: {{ .Values.global.stage | default "develop" }}
   template:
     metadata:
       labels:

--- a/k8s/helm/yona/templates/10_deployment_batch.yaml
+++ b/k8s/helm/yona/templates/10_deployment_batch.yaml
@@ -38,9 +38,9 @@ spec:
           image: craftypenguins/k8s-init-mysql:latest
           env:
             - name: DBUSER
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: DBPASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: DBHOST
               {{- if .Values.mariadb.hostname_override }}
               value: {{ .Values.mariadb.hostname_override | quote }}
@@ -48,7 +48,7 @@ spec:
               value: {{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local
               {{- end }}
             - name: DBNAME
-              value: {{ .Values.mariadb.mariadbDatabase | quote }}
+              value: {{ .Values.mariadb.db.name | quote }}
             - name: TIMEOUT
               value: "10s"
       containers:
@@ -57,14 +57,14 @@ spec:
           #imagePullPolicy: Always
           env:       
             - name: YONA_DB_USER_NAME
-              value: {{ .Values.mariadb.mariadbUser | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.user | default "develop" | quote }}
             - name: YONA_DB_PASSWORD
-              value: {{ .Values.mariadb.mariadbPassword | default "develop" | quote }}
+              value: {{ .Values.mariadb.db.password | default "develop" | quote }}
             - name: YONA_DB_URL
             {{- if .Values.mariadb.url_override}}
               value: {{ .Values.mariadb.url_override | quote }}
             {{- else }}
-              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.mariadbDatabase }}"
+              value: "jdbc:mariadb://{{ .Release.Name }}-mariadb.{{ .Release.Namespace }}.svc.cluster.local/{{ .Values.mariadb.db.name }}"
             {{- end }}
           ports:
             - containerPort: 8080

--- a/k8s/helm/yona/templates/10_deployment_batch.yaml
+++ b/k8s/helm/yona/templates/10_deployment_batch.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.global.stage | default "develop" }}-batch
@@ -16,6 +16,10 @@ spec:
     rollingUpdate:
       maxSurge: 2
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: batch
+      stage: {{ .Values.global.stage | default "develop" }}
   template:
     metadata:
       labels:

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -184,15 +184,21 @@ apple:
   ca_certificate_file: apple/AppleWWDRCA.cer
 
 mariadb:
-  mariadbRootPassword: develop
-  mariadbUser: develop
-  mariadbPassword: develop
-  mariadbDatabase: yona
+  db:
+    user: develop
+    password: develop
+    name: yona
+  rootUser:
+    password: develop
   persistence:
-    storageClass: standard
-    size: 2Gi
+    enabled: false
+  replication:
+    enabled: false
+  volumePermissions:
+    enabled: true
   user: develop
   password: develop
+  mariadbDatabase: yona
   #url_override: "jdbc:mariadb://db.default.svc.cluster.local/yona"
   #hostname_override: yona-mariadb.yona.svc.cluster.local
 

--- a/k8s/helm/yona/values.yaml
+++ b/k8s/helm/yona/values.yaml
@@ -196,9 +196,6 @@ mariadb:
     enabled: false
   volumePermissions:
     enabled: true
-  user: develop
-  password: develop
-  mariadbDatabase: yona
   #url_override: "jdbc:mariadb://db.default.svc.cluster.local/yona"
   #hostname_override: yona-mariadb.yona.svc.cluster.local
 


### PR DESCRIPTION
Use new updated mariadb and openldap charts for local testing (when support_infrastructure: true) and update app deployments to new api version. 