### PR TITLE
YD-685 Gracefully handle activity on orphaned user anonymized

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -329,7 +329,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(bob)
 	}
 
-	def 'Goal conflict of Bob immediately after Bob\'s buddy acceptance is reported to Richard and Bob'()
+	def 'Goal conflict of Bob immediately after Richard processed Bob\'s buddy response is reported to Richard and Bob'()
 	{
 		given:
 		User richard = addRichard()
@@ -338,6 +338,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		appService.sendBuddyConnectRequest(richard, bob)
 		def acceptUrl = appService.fetchBuddyConnectRequestMessage(bob).acceptUrl
 		assertResponseStatusOk(appService.postMessageActionWithPassword(acceptUrl, ["message" : "Yes, great idea!"], bob.password))
+		assertResponseStatusOk(appService.getMessages(richard)) // Causes processing of Bob's buddy connect response message
 
 		when:
 		def response = analysisService.postToAnalysisEngine(bob.requestingDevice, ["news/media"], "http://www.refdag.nl")

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymizedRepository.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/BuddyAnonymizedRepository.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License, v.
- * 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2015, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.subscriptions.entities;
 
@@ -10,4 +10,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface BuddyAnonymizedRepository extends CrudRepository<BuddyAnonymized, UUID>
 {
+	boolean existsByOwningUserAnonymizedIdAndUserAnonymizedId(UUID owningUserAnonymized, UUID userAnonymizedId);
 }

--- a/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/BuddyService.java
@@ -481,7 +481,17 @@ public class BuddyService
 	{
 		return user.getBuddiesAnonymized().stream().filter(ba -> ba.getSendingStatus() == Status.ACCEPTED)
 				.map(BuddyAnonymizedDto::getUserAnonymizedId).filter(Optional::isPresent).map(Optional::get)
+				.filter(buddyUserAnonymizedId -> otherBuddyAnonymizedStillExists(user, buddyUserAnonymizedId))
 				.map(buaid -> userAnonymizedService.getUserAnonymized(buaid)).collect(Collectors.toSet());
+	}
+
+	private boolean otherBuddyAnonymizedStillExists(UserAnonymizedDto user, UUID buddyUserAnonymizedId)
+	{
+		// If a user overwrites their account, the user anonymized entity will continue to exist. If a device still uses the old
+		// VPN account after overwriting their user account, the analysis engine might still create goal conflict messages for
+		// buddies, though the buddies do not know the user anymore. To prevent that, we should filter out the buddy anonymized
+		// entities that do not have a corresponding buddy anonymized entity at the receiving end.
+		return buddyAnonymizedRepository.existsByOwningUserAnonymizedIdAndUserAnonymizedId(buddyUserAnonymizedId, user.getId());
 	}
 
 	public Set<MessageDestination> getBuddyDestinations(UserAnonymized user)

--- a/core/src/test/java/nu/yona/server/entities/BuddyAnonymizedRepositoryMock.java
+++ b/core/src/test/java/nu/yona/server/entities/BuddyAnonymizedRepositoryMock.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2017 Stichting Yona Foundation
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ * Copyright (c) 2017, 2020 Stichting Yona Foundation This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *******************************************************************************/
 package nu.yona.server.entities;
+
+import java.util.UUID;
+
+import org.apache.commons.lang.NotImplementedException;
 
 import nu.yona.server.subscriptions.entities.BuddyAnonymized;
 import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
@@ -13,4 +14,9 @@ import nu.yona.server.subscriptions.entities.BuddyAnonymizedRepository;
 public class BuddyAnonymizedRepositoryMock extends MockJpaRepositoryEntityWithUuid<BuddyAnonymized>
 		implements BuddyAnonymizedRepository
 {
+	@Override
+	public boolean existsByOwningUserAnonymizedIdAndUserAnonymizedId(UUID owningUserAnonymized, UUID userAnonymizedId)
+	{
+		throw new NotImplementedException();
+	}
 }


### PR DESCRIPTION
A device might continue to use its VPN after the user overwrote their account. In that case, new goal conflict messages might be created for a user user anonymized that is orphaned and where the buddies already wiped the related messages and buddy entity. Such a new goal conflict message would lead to an inconsistency where the belonging buddy entity cannot be found.

To fix this, BuddyService.getBuddyUsersAnonymized now does not return buddy entities for which the corresponding buddy entity at the other side does not exist.

This has a minor side effect: earlier, if two users became buddies, the goal conflicts of the accepting user would be reported to the requesting user immediately after the accepting user accepted the request. Now this is delayed a little: goal conflicts of the accepting user are now reported to the requesting user after the requesting user processed the buddy connect response message of the accepting user.