### PR TITLE
YD-690 Added SMTP connection timeouts

### DIFF
--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -49,6 +49,15 @@ management.endpoints.web.exposure.include=*
 management.endpoint.prometheus.enabled=true
 management.metrics.export.prometheus.enabled=true
 
+# Java Mail connection timeouts
+spring.mail.properties.mail.smtp.connectiontimeout=180000
+spring.mail.properties.mail.smtp.timeout=180000
+spring.mail.properties.mail.smtp.writetimeout=180000
+spring.mail.properties.mail.smtps.connectiontimeout=180000
+spring.mail.properties.mail.smtps.timeout=180000
+spring.mail.properties.mail.smtps.writetimeout=180000
+
+
 # Yona properties
 yona.testServer=false
 yona.defaultLocale=en-US


### PR DESCRIPTION
For both SMTP and SMTPS, all set to three minutes. From infinite to 3 minutes is a significant change. If need be, we reduce the values in a next round.