### PR TITLE
YD-705 include exception in Firebase fatal alert

### DIFF
--- a/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
+++ b/core/src/main/java/nu/yona/server/messaging/service/FirebaseService.java
@@ -129,8 +129,7 @@ public class FirebaseService
 	private static void handleCompletion(Optional<Throwable> throwable, String token)
 	{
 		throwable.ifPresent(t -> logger
-				.error(Constants.ALERT_MARKER, "Fatal error: Exception while sending Firebase message to '" + token + "'",
-						throwable));
+				.error(Constants.ALERT_MARKER, "Fatal error: Exception while sending Firebase message to '" + token + "'", t));
 	}
 
 	private void handleNotRegisteredDevice(UUID deviceAnonymizedId)


### PR DESCRIPTION
The code accidentally passed the Optional to the error log method rather than its value.