### PR TITLE
Move Java dependency declarations to separate file and format for Dependabot

### DIFF
--- a/adminservice/build.gradle
+++ b/adminservice/build.gradle
@@ -27,14 +27,14 @@ configurations {
 
 dependencies {
 	implementation  project(":core")
-	runtimeClasspath "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
+	runtimeClasspath project.deps.mariadbClient
 	providedRuntime "org.springframework.boot:spring-boot-starter-tomcat"
 
 	testImplementation project(path: ":core", configuration: "testUtils")
 
 	intTestImplementation "org.codehaus.groovy:groovy-all:3.0.8"
 	intTestImplementation "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
-	intTestImplementation "org.spockframework:spock-core:$project.ext.version_spock_core"
+	intTestImplementation project.deps.spockCore
 }
 
 test {

--- a/analysisservice/build.gradle
+++ b/analysisservice/build.gradle
@@ -26,7 +26,7 @@ configurations {
 
 dependencies {
 	implementation project(":core")
-	runtimeClasspath "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
+	runtimeClasspath project.deps.mariadbClient
 	runtimeClasspath "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 	runtimeClasspath "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
 	providedRuntime "org.springframework.boot:spring-boot-starter-tomcat"
@@ -37,11 +37,11 @@ dependencies {
 
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.mockito:mockito-junit-jupiter"
-	testImplementation "org.jmockit:jmockit:$project.ext.version_jmockit"
+	testImplementation project.deps.jmockit
 
 	intTestImplementation "org.codehaus.groovy:groovy-all:3.0.8"
 	intTestImplementation "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
-	intTestImplementation "org.spockframework:spock-core:$project.ext.version_spock_core"
+	intTestImplementation project.deps.spockCore
 }
 
 test {

--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation project(":core")
 	implementation "org.bouncycastle:bcprov-jdk15on:1.68"
 	implementation "org.bouncycastle:bcpkix-jdk15on:1.68"
-	runtimeClasspath "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
+	runtimeClasspath project.deps.mariadbClient
 	runtimeClasspath "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 	runtimeClasspath "com.fasterxml.jackson.datatype:jackson-datatype-jdk8"
 	providedRuntimeClasspath "org.springframework.boot:spring-boot-starter-tomcat"
@@ -39,7 +39,7 @@ dependencies {
 
 	intTestImplementation "org.codehaus.groovy:groovy-all:3.0.8"
 	intTestImplementation "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
-	intTestImplementation "org.spockframework:spock-core:$project.ext.version_spock_core"
+	intTestImplementation project.deps.spockCore
 }
 
 test {

--- a/batchservice/build.gradle
+++ b/batchservice/build.gradle
@@ -24,9 +24,9 @@ configurations {
 
 dependencies {
 	implementation project(":core")
-	runtimeClasspath "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
-	implementation "org.springframework.batch:spring-batch-core:$project.ext.version_batch_core"
+	implementation project.deps.springBatchCore
 	implementation "org.quartz-scheduler:quartz:2.3.2"
+	runtimeClasspath project.deps.mariadbClient
 	providedRuntime "org.springframework.boot:spring-boot-starter-tomcat"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ plugins {
 
 description = "Yona server"
 
+apply from: "dependencies.gradle"
+
 allprojects {
 	group = "yonadev"
 }
@@ -38,14 +40,6 @@ subprojects {
 	project.ext {
 		build_number = System.getenv().BUILD_NUMBER ?: 0
 		docker_tag = "build-${build_number}"
-
-		version_batch_core = "3.0.7.RELEASE"
-		version_mariadb_client = "1.5.5"
-		version_jmockit = "1.49"
-		version_junit_jupiter = "5.7.2"
-		version_hamcrest_jdk8_time = "0.7.1"
-		version_equalsverifier = "3.6.1"
-		version_spock_core = "2.0-groovy-3.0"
 
 		yona_adminservice_scheme = project.properties["yona_adminservice_scheme"] ?: "http"
 		yona_adminservice_host = project.properties["yona_adminservice_host"] ?: "localhost"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,24 +46,24 @@ dependencies {
 	api "javax.mail:mail:1.4.7"
 	api "org.thymeleaf:thymeleaf-spring5:3.0.12.RELEASE"
 	implementation "org.springframework.ldap:spring-ldap-core:2.3.4.RELEASE"
-	implementation "org.springframework.security:spring-security-config:5.5.0"
-	implementation "org.springframework.security:spring-security-web:5.5.0"
+	implementation project.deps.springSecurityWeb
+	implementation project.deps.springSecurityConfig
 	api "com.google.guava:guava:23.0"
 	implementation "com.googlecode.libphonenumber:libphonenumber:8.12.24"
 	implementation "com.google.firebase:firebase-admin:7.3.0"
 
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.mockito:mockito-junit-jupiter"
-	testImplementation "org.jmockit:jmockit:$project.ext.version_jmockit"
-	testImplementation "org.junit.jupiter:junit-jupiter:$project.ext.version_junit_jupiter"
-	testImplementation "com.spencerwi:hamcrest-jdk8-time:$project.ext.version_hamcrest_jdk8_time"
-	testImplementation "nl.jqno.equalsverifier:equalsverifier:$project.ext.version_equalsverifier"
+	testImplementation project.deps.jmockit
+	testImplementation project.deps.junitJupiter
+	testImplementation project.deps.hamcrestJdk8Time
+	testImplementation project.deps.equalsverifier
 
 	testUtilsImplementation "org.codehaus.groovy:groovy-all:3.0.8"
 	testUtilsImplementation "org.codehaus.groovy.modules.http-builder:http-builder:0.7.1"
 
 	// mandatory dependencies for using Spock
-	testUtilsImplementation "org.spockframework:spock-core:$project.ext.version_spock_core"
+	testUtilsImplementation project.deps.spockCore
 }
 
 test {

--- a/dbinit/build.gradle
+++ b/dbinit/build.gradle
@@ -18,9 +18,9 @@ release {
 
 dependencies {
 	implementation project(":core")
-	runtimeClasspath "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
-	implementation "org.springframework.batch:spring-batch-core:$project.ext.version_batch_core"
+	implementation project.deps.springBatchCore
 	implementation "org.liquibase:liquibase-core:4.3.5"
+	runtimeClasspath project.deps.mariadbClient
 }
 
 docker {

--- a/dbinit/liquibase.gradle
+++ b/dbinit/liquibase.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
 	liquibase "org.liquibase.ext:liquibase-hibernate5:4.3.0.1"
-	liquibase "org.mariadb.jdbc:mariadb-java-client:$project.ext.version_mariadb_client"
+	liquibase project.deps.mariadbClient
 }
 
 //loading properties file.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,39 @@
+/** Parses a version from a dependency declaration string */
+static String versionOf(String dependencySpec) {
+  return dependencySpec.split(':').last()
+}
+
+final Map<String, String> libraries = [
+	// Dependabot will parse these dependencies.
+	// Keep all of these as uninterpolated string literals so that Dependabot can parse the versions and create PRs for
+	// upgrades.
+	//
+	// DO NOT interpolate version variables here because Dependabot is not smart enough to understand those. Dependabot's
+	// version parsing is simply regex matching and never actually evaluates a gradle script.
+	springBatchCore 		: "org.springframework.batch:spring-batch-core:3.0.7.RELEASE",
+	springSecurityWeb		: "org.springframework.security:spring-security-web:5.5.0",
+	mariadbClient			: "org.mariadb.jdbc:mariadb-java-client:1.5.5",
+	jmockit					: "org.jmockit:jmockit:1.49",
+	junitJupiter			: "org.junit.jupiter:junit-jupiter:5.7.2",
+	hamcrestJdk8Time		: "com.spencerwi:hamcrest-jdk8-time:0.7.1",
+	equalsverifier			: "nl.jqno.equalsverifier:equalsverifier:3.6.1",
+	spockCore				: "org.spockframework:spock-core:2.0-groovy-3.0",
+
+]
+
+// Export versions that are needed outside of this file (and elsewhere within)
+final Map<String, String> v = [
+  springSecurityWeb            : versionOf(libraries.springSecurityWeb)
+]
+
+// While Dependabot won't be able to parse these deps, these will get upgraded for free anyway since they share versions
+// with dependencies declared above that are parseable by Dependabot. This is just a workaround to be DRY while still
+// benefiting from Dependabot's automatic PR upgrades.
+final Map<String, String> related = [
+	springSecurityConfig	: "org.springframework.security:spring-security-config:${v.springSecurityWeb}",
+]
+
+ext {
+  deps = libraries + related
+  versions = v
+}


### PR DESCRIPTION
According to dependabot/feedback#345 we'd need to store this info in a file that contains the plain dependency strings in order for Dependabot to parse our dependencies. Otherwise, we aren't going to reap the benefits of Dependabot for our Java libraries.