### PR TITLE
YD-709 Upgrade to Java 1.0.12

### DIFF
--- a/adminservice/src/main/docker/Dockerfile
+++ b/adminservice/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.7-jre-slim
+FROM openjdk:11.0.12-jre-slim
 
 WORKDIR /opt/app
 

--- a/analysisservice/src/main/docker/Dockerfile
+++ b/analysisservice/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.7-jre-slim
+FROM openjdk:11.0.12-jre-slim
 
 WORKDIR /opt/app
 

--- a/appservice/src/main/docker/Dockerfile
+++ b/appservice/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.7-jre-slim
+FROM openjdk:11.0.12-jre-slim
 
 WORKDIR /opt/app
 

--- a/batchservice/src/main/docker/Dockerfile
+++ b/batchservice/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.7-jre-slim
+FROM openjdk:11.0.12-jre-slim
 
 WORKDIR /opt/app
 

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -60,7 +60,7 @@ spring.mail.properties.mail.smtp.writetimeout=180000
 spring.mail.properties.mail.smtps.connectiontimeout=180000
 spring.mail.properties.mail.smtps.timeout=180000
 spring.mail.properties.mail.smtps.writetimeout=180000
-
+spring.mail.properties.mail.smtp.ssl.protocols=TLSv1.2
 
 # Yona properties
 yona.testServer=false


### PR DESCRIPTION
Use TLS 1.2 for SMTP, as the older TLS versions are no longer enabled.