### PR TITLE
Remove Gradle release plugin

### DIFF
--- a/adminservice/build.gradle
+++ b/adminservice/build.gradle
@@ -11,14 +11,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 
 def dockerImageName = "${project.group}/${jar.baseName}"
 
-release {
-	failOnCommitNeeded = true
-	tagTemplate = "adminservice-${version}"
-	git {
-		requireBranch = "yd-40-changes-for-building|master"
-	}
-}
-
 configurations {
 	providedRuntime
 	intTestImplementation.extendsFrom testImplementation

--- a/analysisservice/build.gradle
+++ b/analysisservice/build.gradle
@@ -10,14 +10,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 
 def dockerImageName = "${project.group}/${jar.baseName}"
 
-release {
-	failOnCommitNeeded = true
-	tagTemplate = "analysisservice-${version}"
-	git {
-		requireBranch = "yd-40-changes-for-building|master"
-	}
-}
-
 configurations {
 	providedRuntime
 	intTestImplementation.extendsFrom testImplementation

--- a/appservice/build.gradle
+++ b/appservice/build.gradle
@@ -10,14 +10,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 
 def dockerImageName = "${project.group}/${jar.baseName}"
 
-release {
-	failOnCommitNeeded = true
-	tagTemplate = "appservice-${version}"
-	git {
-		requireBranch = "yd-40-changes-for-building|master"
-	}
-}
-
 configurations {
 	providedRuntimeClasspath
 	intTestImplementation.extendsFrom testImplementation

--- a/batchservice/build.gradle
+++ b/batchservice/build.gradle
@@ -10,14 +10,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 
 def dockerImageName = "${project.group}/${jar.baseName}"
 
-release {
-	failOnCommitNeeded = true
-	tagTemplate = "batchservice-${version}"
-	git {
-		requireBranch = "yd-40-changes-for-building|master"
-	}
-}
-
 configurations {
 	providedRuntime
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
 	id "groovy"
 	id "io.spring.dependency-management" version "1.0.11.RELEASE"
 	id "org.springframework.boot" version "2.7.0" apply false
-	id "net.researchgate.release" version "2.8.1"
 	id "com.bmuschko.docker-remote-api" version "7.4.0" apply false
 	id "project-report"
     id "org.sonarqube" version "3.4.0.2513"
@@ -33,7 +32,6 @@ subprojects {
 	apply plugin: "groovy"
 	apply plugin: "io.spring.dependency-management"
 	apply plugin: "org.springframework.boot"
-	apply plugin: "net.researchgate.release"
 	apply plugin: "com.bmuschko.docker-remote-api"
 
 	project.ext {

--- a/dbinit/build.gradle
+++ b/dbinit/build.gradle
@@ -8,14 +8,6 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 
 def dockerImageName = "${project.group}/yona-mariadb-liquibase-update"
 
-release {
-	failOnCommitNeeded = true
-	tagTemplate = "adminservice-${version}"
-	git {
-		requireBranch = "yd-40-changes-for-building|master"
-	}
-}
-
 dependencies {
 	implementation project(":core")
 	implementation project.deps.springBatchCore


### PR DESCRIPTION
Yona is an evergreen cloud product, so we are not doing releases.