### PR TITLE
Rename fields of Response class

### DIFF
--- a/adminservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
+++ b/adminservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -40,9 +40,9 @@ class ActivityCategoriesTest extends Specification
 		String gardeningActivityCategoryJson = createActivityCategoryJson(["nl-NL": "Tuinieren", "en-US": "Gardening"], false, ["gardening"], [], ["nl-NL": "Raadplegen van websites over tuinieren", "en-US": "Reading about gardening"])
 
 		when:
-		def updateResponse = adminService.yonaServer.updateResource(createProgrammingResponse.responseData._links.self.href, chessActivityCategoryJson)
+		def updateResponse = adminService.yonaServer.updateResource(createProgrammingResponse.json._links.self.href, chessActivityCategoryJson)
 		assertResponseStatusOk(updateResponse)
-		def deleteResponse = adminService.yonaServer.deleteResource(createCookingResponse.responseData._links.self.href)
+		def deleteResponse = adminService.yonaServer.deleteResource(createCookingResponse.json._links.self.href)
 		assertResponseStatusNoContent(deleteResponse)
 		def createResponse = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, gardeningActivityCategoryJson)
 		assertResponseStatusOk(createResponse)
@@ -62,15 +62,15 @@ class ActivityCategoriesTest extends Specification
 		cleanup:
 		if (createCookingResponse?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(createCookingResponse.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(createCookingResponse.json._links.self.href)
 		}
 		if (createProgrammingResponse?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(createProgrammingResponse.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(createProgrammingResponse.json._links.self.href)
 		}
 		if (createResponse?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(createResponse.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(createResponse.json._links.self.href)
 		}
 	}
 
@@ -81,10 +81,10 @@ class ActivityCategoriesTest extends Specification
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._links.self.href == adminService.url + AdminService.ACTIVITY_CATEGORIES_PATH
-		response.responseData._embedded?."yona:activityCategories" != null
-		response.responseData._embedded."yona:activityCategories".size() > 0
-		def gamblingCategory = response.responseData._embedded."yona:activityCategories".find {
+		response.json._links.self.href == adminService.url + AdminService.ACTIVITY_CATEGORIES_PATH
+		response.json._embedded?."yona:activityCategories" != null
+		response.json._embedded."yona:activityCategories".size() > 0
+		def gamblingCategory = response.json._embedded."yona:activityCategories".find {
 			it._links.self.href ==~ /.*192d69f4-8d3e-499b-983c-36ca97340ba9.*/
 		}
 		gamblingCategory._links.self.href.startsWith(adminService.url)
@@ -108,35 +108,35 @@ class ActivityCategoriesTest extends Specification
 		String englishDescription = "Programming computers"
 		String dutchDescription = "Programmeren van computers"
 		String programmingActivityCategoryJson = createActivityCategoryJson(["nl-NL": dutchName, "en-US": englishName], isNoGo, smoothwallCategories, apps, ["nl-NL": dutchDescription, "en-US": englishDescription])
-		def numActivityCategoriesBeforeAdd = adminService.getAllActivityCategories().responseData._embedded."yona:activityCategories".size()
+		def numActivityCategoriesBeforeAdd = adminService.getAllActivityCategories().json._embedded."yona:activityCategories".size()
 
 		when:
 		def response = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._links.self.href.startsWith(adminService.url)
-		response.responseData.localizableName["en-US"] == englishName
-		response.responseData.localizableName["nl-NL"] == dutchName
-		response.responseData.mandatoryNoGo == isNoGo
-		response.responseData.smoothwallCategories as Set == smoothwallCategories as Set
-		response.responseData.applications as Set == apps as Set
-		response.responseData.localizableDescription["en-US"] == englishDescription
-		response.responseData.localizableDescription["nl-NL"] == dutchDescription
+		response.json._links.self.href.startsWith(adminService.url)
+		response.json.localizableName["en-US"] == englishName
+		response.json.localizableName["nl-NL"] == dutchName
+		response.json.mandatoryNoGo == isNoGo
+		response.json.smoothwallCategories as Set == smoothwallCategories as Set
+		response.json.applications as Set == apps as Set
+		response.json.localizableDescription["en-US"] == englishDescription
+		response.json.localizableDescription["nl-NL"] == dutchDescription
 
-		def getResponse = adminService.yonaServer.getJson(response.responseData._links.self.href)
+		def getResponse = adminService.yonaServer.getJson(response.json._links.self.href)
 		assertResponseStatusOk(getResponse)
-		getResponse.responseData._links.self.href.startsWith(adminService.url)
-		getResponse.responseData.localizableName["en-US"] == englishName
-		getResponse.responseData.localizableName["nl-NL"] == dutchName
-		getResponse.responseData.mandatoryNoGo == isNoGo
-		getResponse.responseData.smoothwallCategories as Set == smoothwallCategories as Set
-		getResponse.responseData.applications as Set == apps as Set
-		getResponse.responseData.localizableDescription["en-US"] == englishDescription
-		getResponse.responseData.localizableDescription["nl-NL"] == dutchDescription
+		getResponse.json._links.self.href.startsWith(adminService.url)
+		getResponse.json.localizableName["en-US"] == englishName
+		getResponse.json.localizableName["nl-NL"] == dutchName
+		getResponse.json.mandatoryNoGo == isNoGo
+		getResponse.json.smoothwallCategories as Set == smoothwallCategories as Set
+		getResponse.json.applications as Set == apps as Set
+		getResponse.json.localizableDescription["en-US"] == englishDescription
+		getResponse.json.localizableDescription["nl-NL"] == dutchDescription
 
 		def getAllResponse = adminService.getAllActivityCategories()
-		getAllResponse.responseData._embedded."yona:activityCategories".size() == numActivityCategoriesBeforeAdd + 1
+		getAllResponse.json._embedded."yona:activityCategories".size() == numActivityCategoriesBeforeAdd + 1
 		def programmingCategory = findActivityCategoryByName(getAllResponse, englishName)
 		programmingCategory != null
 		programmingCategory.applications as Set == apps as Set
@@ -145,7 +145,7 @@ class ActivityCategoriesTest extends Specification
 		cleanup:
 		if (response?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(response.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(response.json._links.self.href)
 		}
 	}
 
@@ -166,32 +166,32 @@ class ActivityCategoriesTest extends Specification
 		def programmingCategory = findActivityCategoryByName(adminService.getAllActivityCategories(), "Programming")
 
 		when:
-		def response = adminService.yonaServer.updateResource(createResponse.responseData._links.self.href, chessActivityCategoryJson)
+		def response = adminService.yonaServer.updateResource(createResponse.json._links.self.href, chessActivityCategoryJson)
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._links.self.href == createResponse.responseData._links.self.href
-		response.responseData.localizableName["en-US"] == englishName
-		response.responseData.localizableName["nl-NL"] == dutchName
-		response.responseData.mandatoryNoGo == isNoGo
-		response.responseData.smoothwallCategories as Set == smoothwallCategories as Set
-		response.responseData.applications as Set == apps as Set
-		response.responseData.localizableDescription["en-US"] == englishDescription
-		response.responseData.localizableDescription["nl-NL"] == dutchDescription
+		response.json._links.self.href == createResponse.json._links.self.href
+		response.json.localizableName["en-US"] == englishName
+		response.json.localizableName["nl-NL"] == dutchName
+		response.json.mandatoryNoGo == isNoGo
+		response.json.smoothwallCategories as Set == smoothwallCategories as Set
+		response.json.applications as Set == apps as Set
+		response.json.localizableDescription["en-US"] == englishDescription
+		response.json.localizableDescription["nl-NL"] == dutchDescription
 
-		def getResponse = adminService.yonaServer.getJson(createResponse.responseData._links.self.href)
+		def getResponse = adminService.yonaServer.getJson(createResponse.json._links.self.href)
 		assertResponseStatusOk(getResponse)
-		getResponse.responseData._links.self.href == createResponse.responseData._links.self.href
-		getResponse.responseData.localizableName["en-US"] == englishName
-		getResponse.responseData.localizableName["nl-NL"] == dutchName
-		getResponse.responseData.mandatoryNoGo == isNoGo
-		getResponse.responseData.smoothwallCategories as Set == smoothwallCategories as Set
-		getResponse.responseData.applications as Set == apps as Set
-		getResponse.responseData.localizableDescription["en-US"] == englishDescription
-		getResponse.responseData.localizableDescription["nl-NL"] == dutchDescription
+		getResponse.json._links.self.href == createResponse.json._links.self.href
+		getResponse.json.localizableName["en-US"] == englishName
+		getResponse.json.localizableName["nl-NL"] == dutchName
+		getResponse.json.mandatoryNoGo == isNoGo
+		getResponse.json.smoothwallCategories as Set == smoothwallCategories as Set
+		getResponse.json.applications as Set == apps as Set
+		getResponse.json.localizableDescription["en-US"] == englishDescription
+		getResponse.json.localizableDescription["nl-NL"] == dutchDescription
 
 		def getAllResponse = adminService.getAllActivityCategories()
-		def chessCategory = getAllResponse.responseData._embedded."yona:activityCategories".find { it.localizableName["en-US"] == englishName }
+		def chessCategory = getAllResponse.json._embedded."yona:activityCategories".find { it.localizableName["en-US"] == englishName }
 		chessCategory != null
 		chessCategory._links.self.href == programmingCategory._links.self.href
 		chessCategory.applications as Set == apps as Set
@@ -200,7 +200,7 @@ class ActivityCategoriesTest extends Specification
 		cleanup:
 		if (createResponse?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(createResponse.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(createResponse.json._links.self.href)
 		}
 	}
 
@@ -210,16 +210,16 @@ class ActivityCategoriesTest extends Specification
 		String programmingActivityCategoryJson = createActivityCategoryJson(["nl-NL": "Programmeren", "en-US": "Programming"], false, ["programming", "scripting"], ["Eclipse", "Visual Studio"], ["nl-NL": "Programmeren van computers", "en-US": "Programming computers"])
 		def createResponse = adminService.yonaServer.createResource(AdminService.ACTIVITY_CATEGORIES_PATH, programmingActivityCategoryJson)
 		assertResponseStatusOk(createResponse)
-		def numActivityCategoriesBeforeDelete = adminService.getAllActivityCategories().responseData._embedded."yona:activityCategories".size()
+		def numActivityCategoriesBeforeDelete = adminService.getAllActivityCategories().json._embedded."yona:activityCategories".size()
 
 		when:
-		def response = adminService.yonaServer.deleteResource(createResponse.responseData._links.self.href)
+		def response = adminService.yonaServer.deleteResource(createResponse.json._links.self.href)
 
 		then:
 		assertResponseStatusNoContent(response)
 
 		def getAllResponse = adminService.getAllActivityCategories()
-		getAllResponse.responseData._embedded."yona:activityCategories".size() == numActivityCategoriesBeforeDelete - 1
+		getAllResponse.json._embedded."yona:activityCategories".size() == numActivityCategoriesBeforeDelete - 1
 		findActivityCategoryByName(getAllResponse, "Programming") == null
 	}
 
@@ -232,7 +232,7 @@ class ActivityCategoriesTest extends Specification
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.activitycategory.duplicate.name"
+		response.json.code == "error.activitycategory.duplicate.name"
 	}
 
 	def 'Try update to duplicate Dutch name'()
@@ -249,16 +249,16 @@ class ActivityCategoriesTest extends Specification
 		String dutchDescription = "Programmeren van computers"
 		String chessActivityCategoryJson = createActivityCategoryJson(["nl-NL": dutchName, "en-US": englishName], isNoGo, smoothwallCategories, apps, ["nl-NL": dutchDescription, "en-US": englishDescription])
 		when:
-		def response = adminService.yonaServer.updateResource(createResponse.responseData._links.self.href, chessActivityCategoryJson)
+		def response = adminService.yonaServer.updateResource(createResponse.json._links.self.href, chessActivityCategoryJson)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.activitycategory.duplicate.name"
+		response.json.code == "error.activitycategory.duplicate.name"
 
 		cleanup:
 		if (createResponse?.status == 200)
 		{
-			adminService.yonaServer.deleteResource(createResponse.responseData._links.self.href)
+			adminService.yonaServer.deleteResource(createResponse.json._links.self.href)
 		}
 	}
 
@@ -280,12 +280,12 @@ class ActivityCategoriesTest extends Specification
 
 	private static findActivityCategoryByName(getAllResponse, englishName)
 	{
-		getAllResponse.responseData._embedded."yona:activityCategories".find { it.localizableName["en-US"] == englishName }
+		getAllResponse.json._embedded."yona:activityCategories".find { it.localizableName["en-US"] == englishName }
 	}
 
 	private static appServicefindActivityCategoryByName(getAllResponse, englishName)
 	{
-		getAllResponse.responseData._embedded."yona:activityCategories".find { it.name == englishName }
+		getAllResponse.json._embedded."yona:activityCategories".find { it.name == englishName }
 	}
 
 	private void waitForCachePropagation(englishName, englishDescription)

--- a/analysisservice/src/intTest/groovy/nu/yona/server/RelevantSmoothwallCategoriesTest.groovy
+++ b/analysisservice/src/intTest/groovy/nu/yona/server/RelevantSmoothwallCategoriesTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -24,11 +24,11 @@ class RelevantSmoothwallCategoriesTest extends Specification
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.categories.size() > 10
-		response.responseData.categories.contains("Gambling")
-		response.responseData.categories.contains("lotto")
-		response.responseData.categories.contains("news/media")
-		response.responseData.categories.contains("newsgroups/forums")
-		response.responseData.categories.contains("social")
+		response.json.categories.size() > 10
+		response.json.categories.contains("Gambling")
+		response.json.categories.contains("lotto")
+		response.json.categories.contains("news/media")
+		response.json.categories.contains("newsgroups/forums")
+		response.json.categories.contains("social")
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AbstractAppServiceIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -181,27 +181,27 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 		def responseMarkRead = appService.postMessageActionWithPassword(message._links."yona:markRead".href as String, [:], user.password)
 		assertResponseStatusOk(responseMarkRead)
-		assert responseMarkRead.responseData._embedded?."yona:affectedMessages"[0]?.isRead == true
-		assert responseMarkRead.responseData._embedded?."yona:affectedMessages"[0]?._links?.self?.href == messageUrl
-		assert responseMarkRead.responseData._embedded?."yona:affectedMessages"[0]?._links?."yona:markUnread"?.href?.startsWith(messageUrl)
+		assert responseMarkRead.json._embedded?."yona:affectedMessages"[0]?.isRead == true
+		assert responseMarkRead.json._embedded?."yona:affectedMessages"[0]?._links?.self?.href == messageUrl
+		assert responseMarkRead.json._embedded?."yona:affectedMessages"[0]?._links?."yona:markUnread"?.href?.startsWith(messageUrl)
 
 		def responseGetAfterMarkRead = appService.getResourceWithPassword(messageUrl, user.password)
 		assertResponseStatusOk(responseGetAfterMarkRead)
-		assert responseGetAfterMarkRead.responseData.isRead == true
-		assert responseGetAfterMarkRead.responseData._links?.self?.href == messageUrl
-		assert responseGetAfterMarkRead.responseData._links?."yona:markUnread"?.href?.startsWith(messageUrl)
+		assert responseGetAfterMarkRead.json.isRead == true
+		assert responseGetAfterMarkRead.json._links?.self?.href == messageUrl
+		assert responseGetAfterMarkRead.json._links?."yona:markUnread"?.href?.startsWith(messageUrl)
 
-		def responseMarkUnread = appService.postMessageActionWithPassword(responseGetAfterMarkRead.responseData._links?."yona:markUnread"?.href as String, [:], user.password)
+		def responseMarkUnread = appService.postMessageActionWithPassword(responseGetAfterMarkRead.json._links?."yona:markUnread"?.href as String, [:], user.password)
 		assertResponseStatusOk(responseMarkUnread)
-		assert responseMarkUnread.responseData._embedded?."yona:affectedMessages"[0]?.isRead == false
-		assert responseMarkUnread.responseData._embedded?."yona:affectedMessages"[0]?._links?.self?.href == messageUrl
-		assert responseMarkUnread.responseData._embedded?."yona:affectedMessages"[0]?._links?."yona:markRead"?.href?.startsWith(messageUrl)
+		assert responseMarkUnread.json._embedded?."yona:affectedMessages"[0]?.isRead == false
+		assert responseMarkUnread.json._embedded?."yona:affectedMessages"[0]?._links?.self?.href == messageUrl
+		assert responseMarkUnread.json._embedded?."yona:affectedMessages"[0]?._links?."yona:markRead"?.href?.startsWith(messageUrl)
 
 		def responseGetAfterMarkUnread = appService.getResourceWithPassword(messageUrl, user.password)
 		assertResponseStatusOk(responseGetAfterMarkUnread)
-		assert responseGetAfterMarkUnread.responseData.isRead == false
-		assert responseGetAfterMarkUnread.responseData._links?.self?.href == messageUrl
-		assert responseGetAfterMarkUnread.responseData._links?."yona:markRead"?.href?.startsWith(messageUrl)
+		assert responseGetAfterMarkUnread.json.isRead == false
+		assert responseGetAfterMarkUnread.json._links?.self?.href == messageUrl
+		assert responseGetAfterMarkUnread.json._links?."yona:markRead"?.href?.startsWith(messageUrl)
 	}
 
 	def updateLastStatusChangeTime(User user, Buddy buddy, relativeLastStatusChangeTimeString)
@@ -212,13 +212,13 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	def findActiveGoal(def response, def activityCategoryUrl)
 	{
-		response.responseData._embedded."yona:goals".find { it._links."yona:activityCategory".href == activityCategoryUrl && !it.historyItem }
+		response.json._embedded."yona:goals".find { it._links."yona:activityCategory".href == activityCategoryUrl && !it.historyItem }
 	}
 
 	def findGoalsIncludingHistoryItems(def response, def activityCategoryUrl)
 	{
 		assertResponseStatusOk(response)
-		response.responseData._embedded."yona:goals".findAll { it._links."yona:activityCategory".href == activityCategoryUrl }
+		response.json._embedded."yona:goals".findAll { it._links."yona:activityCategory".href == activityCategoryUrl }
 	}
 
 	void setGoalCreationTime(User user, activityCategoryUrl, relativeCreationDateTimeString)
@@ -337,19 +337,19 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	void assertWeekOverviewBasics(response, numberOfReportedGoals, expectedTotalElements, expectedPageSize = 2)
 	{
 		assertResponseStatusOk(response)
-		assert response.responseData.page
-		assert response.responseData.page.size == expectedPageSize
-		assert response.responseData.page.totalElements == expectedTotalElements
-		assert response.responseData._links?.self?.href != null
+		assert response.json.page
+		assert response.json.page.size == expectedPageSize
+		assert response.json.page.totalElements == expectedTotalElements
+		assert response.json._links?.self?.href != null
 
 		if (numberOfReportedGoals != null)
 		{
-			assert response.responseData._embedded?."yona:weekActivityOverviews"?.size() == numberOfReportedGoals.size()
+			assert response.json._embedded?."yona:weekActivityOverviews"?.size() == numberOfReportedGoals.size()
 			numberOfReportedGoals.eachWithIndex { numberOfGoals, weekIndex ->
-				assert response.responseData._embedded."yona:weekActivityOverviews"[weekIndex]?.date =~ /\d{4}-W\d{2}/
-				assert response.responseData._embedded."yona:weekActivityOverviews"[weekIndex].timeZoneId == "Europe/Amsterdam"
-				assert response.responseData._embedded."yona:weekActivityOverviews"[weekIndex].weekActivities?.size() == numberOfGoals
-				assert response.responseData._embedded."yona:weekActivityOverviews"[weekIndex]._links?.self?.href
+				assert response.json._embedded."yona:weekActivityOverviews"[weekIndex]?.date =~ /\d{4}-W\d{2}/
+				assert response.json._embedded."yona:weekActivityOverviews"[weekIndex].timeZoneId == "Europe/Amsterdam"
+				assert response.json._embedded."yona:weekActivityOverviews"[weekIndex].weekActivities?.size() == numberOfGoals
+				assert response.json._embedded."yona:weekActivityOverviews"[weekIndex]._links?.self?.href
 			}
 		}
 	}
@@ -404,7 +404,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	{
 		def responseWeekOverviews = appService.getWeekActivityOverviews(user)
 		assertWeekOverviewBasics(responseWeekOverviews, null, expectedTotalWeeks)
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[weeksBack]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[weeksBack]
 		user.getGoals().each {
 			def goal = it
 			assertWeekDetailForGoal(user, weekOverviewLastWeek, goal, expectedValuesInWeek)
@@ -433,7 +433,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	{
 		def dayOffset = YonaServer.relativeDateStringToDaysOffset(weeksBack, shortDay)
 		Map<String, Object> expectedDataForDayAndGoal = getExpectedDataForDayAndGoal(expectedValues, shortDay, goal)
-		def dayActivityOverview = response.responseData._embedded."yona:dayActivityOverviews"[dayOffset]
+		def dayActivityOverview = response.json._embedded."yona:dayActivityOverviews"[dayOffset]
 		assert dayActivityOverview?.date =~ /\d{4}-\d{2}-\d{2}/
 		assert dayActivityOverview.timeZoneId == "Europe/Amsterdam"
 		assert dayActivityOverview.dayActivities?.size() == expectedValues[shortDay].size()
@@ -464,11 +464,11 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 	void assertDayOverviewBasics(response, expectedSize, expectedTotalElements, expectedPageSize = 3)
 	{
 		assertResponseStatusOk(response)
-		assert response.responseData._embedded?."yona:dayActivityOverviews"?.size() == expectedSize
-		assert response.responseData.page
-		assert response.responseData.page.size == expectedPageSize
-		assert response.responseData.page.totalElements == expectedTotalElements
-		assert response.responseData._links?.self?.href
+		assert response.json._embedded?."yona:dayActivityOverviews"?.size() == expectedSize
+		assert response.json.page
+		assert response.json.page.size == expectedPageSize
+		assert response.json.page.totalElements == expectedTotalElements
+		assert response.json._links?.self?.href
 	}
 
 	void assertWeekDetailForGoal(User user, weekActivityOverview, Goal goal, Map<String, Object> expectedValues)
@@ -486,25 +486,25 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		def weekActivityDetailUrl = weekActivityForGoal?._links?."yona:weekDetails"?.href
 		def response = appService.getResourceWithPassword(weekActivityDetailUrl, user.password)
 		assertResponseStatusOk(response)
-		assert response.responseData.spread?.size() == 96
+		assert response.json.spread?.size() == 96
 		List<Integer> expectedSpread = (0..95).collect { 0 }
 		expectedValues.each { it.value.findAll { it.goal.url == goal.url }.each { it.data.spread.each { expectedSpread[it.key] += it.value } } }
-		assert response.responseData.spread == expectedSpread
-		assert response.responseData.totalActivityDurationMinutes == totalDurationMinutes
-		assert response.responseData.date =~ /\d{4}-W\d{2}/
-		assert response.responseData.timeZoneId == "Europe/Amsterdam"
-		assert response.responseData._links?."yona:goal"
+		assert response.json.spread == expectedSpread
+		assert response.json.totalActivityDurationMinutes == totalDurationMinutes
+		assert response.json.date =~ /\d{4}-W\d{2}/
+		assert response.json.timeZoneId == "Europe/Amsterdam"
+		assert response.json._links?."yona:goal"
 		boolean isForBuddy = weekActivityDetailUrl.startsWith(YonaServer.stripQueryString(user.url) + "/buddies/")
-		assert (response.responseData._links?."yona:buddy" != null) == isForBuddy
+		assert (response.json._links?."yona:buddy" != null) == isForBuddy
 		def activeDays = 0
 		expectedValues.each { activeDays += it.value.findAll { it.goal.activityCategoryUrl == goal.activityCategoryUrl }.size() }
-		assert response.responseData.dayActivities?.size() == activeDays
+		assert response.json.dayActivities?.size() == activeDays
 		expectedValues.each {
 			def day = it.key
 			it.value.findAll { it.goal.activityCategoryUrl == goal.activityCategoryUrl }.each {
 				def expectedDataForGoalOnDay = it.data
-				assert response.responseData.dayActivities[fullDay[day]]
-				def dayActivityForGoal = response.responseData.dayActivities[fullDay[day]]
+				assert response.json.dayActivities[fullDay[day]]
+				def dayActivityForGoal = response.json.dayActivities[fullDay[day]]
 				assert dayActivityForGoal.spread == null // Only in detail
 				def expectedDayDurationMinutes = calculateExpectedDurationFromSpread(expectedDataForGoalOnDay.spread)
 				assert dayActivityForGoal.totalActivityDurationMinutes == expectedDayDurationMinutes
@@ -525,7 +525,7 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		def response = appService.getResourceWithPassword(weekActivityDetailUrl, user.password)
 		assertResponseStatusOk(response)
 
-		return response.responseData
+		return response.json
 	}
 
 	def getDayDetail(User user, dayActivityOverviewResponse, Goal goal, weeksBack, shortDay)
@@ -536,14 +536,14 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 
 	def getDayDetail(User user, dayActivityOverviewResponse, Goal goal, dayOffset)
 	{
-		def dayActivityOverview = dayActivityOverviewResponse.responseData._embedded."yona:dayActivityOverviews"[dayOffset]
+		def dayActivityOverview = dayActivityOverviewResponse.json._embedded."yona:dayActivityOverviews"[dayOffset]
 		def dayActivityForGoal = dayActivityOverview.dayActivities.find { it._links."yona:goal".href == goal.url }
 		assert dayActivityForGoal?._links?."yona:dayDetails"?.href
 		def dayActivityDetailUrl = dayActivityForGoal._links."yona:dayDetails".href
 		def response = appService.getResourceWithPassword(dayActivityDetailUrl, user.password)
 		assertResponseStatusOk(response)
 
-		return response.responseData
+		return response.json
 	}
 
 	void assertDayDetail(User user, dayActivityOverviewResponse, Goal goal, expectedValues, int weeksBack, String shortDay)
@@ -566,22 +566,22 @@ abstract class AbstractAppServiceIntegrationTest extends Specification
 		assertResponseStatusOk(response)
 		if (expectedSize == 0)
 		{
-			assert response.responseData._embedded?."yona:dayActivityOverviews" == null
+			assert response.json._embedded?."yona:dayActivityOverviews" == null
 		}
 		else
 		{
-			assert response.responseData._embedded?."yona:dayActivityOverviews"?.size() == expectedSize
+			assert response.json._embedded?."yona:dayActivityOverviews"?.size() == expectedSize
 		}
-		assert response.responseData.page
-		assert response.responseData.page.size == expectedPageSize
-		assert response.responseData.page.totalElements == expectedTotalElements
-		assert response.responseData._links?.self?.href
+		assert response.json.page
+		assert response.json.page.size == expectedPageSize
+		assert response.json.page.totalElements == expectedTotalElements
+		assert response.json._links?.self?.href
 	}
 
 	void assertDayOverviewWithBuddies(response, User actingUser, activityCategoryUrl, expectedValues, weeksBack, shortDay)
 	{
 		def dayOffset = YonaServer.relativeDateStringToDaysOffset(weeksBack, shortDay)
-		def dayActivityOverview = response.responseData._embedded."yona:dayActivityOverviews"[dayOffset]
+		def dayActivityOverview = response.json._embedded."yona:dayActivityOverviews"[dayOffset]
 		int expectedUsersWithGoalInThisCategory = expectedValues.findAll { it.expectedValues[shortDay].find { it.goal.activityCategoryUrl == activityCategoryUrl } }.size()
 		assert dayActivityOverview.date =~ /\d{4}-\d{2}-\d{2}/
 		assert dayActivityOverview.timeZoneId == "Europe/Amsterdam"

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityAggregationBatchJobTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Stichting Yona Foundation
+ * Copyright (c) 2017, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -57,13 +57,13 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 		int nrGoals = 3
-		response.responseData.writeCountPerStep?.aggregateWeekActivities == nrGoals
-		response.responseData.writeCountPerStep?.aggregateDayActivities == 6 + 6 + 4 + YonaServer.getCurrentDayOfWeek() * nrGoals
+		response.json.writeCountPerStep?.aggregateWeekActivities == nrGoals
+		response.json.writeCountPerStep?.aggregateDayActivities == 6 + 6 + 4 + YonaServer.getCurrentDayOfWeek() * nrGoals
 		assertActivityValues(richard, 1, expectedValuesRichardLastWeek, 2)
 
 		def secondAggregationResponse = batchService.triggerActivityAggregationBatchJob()
 		assertResponseStatusOk(secondAggregationResponse)
-		secondAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 0
+		secondAggregationResponse.json.writeCountPerStep?.aggregateWeekActivities == 0
 		// Do not assert aggregateDayActivities; inactivity for past days of current week is suddenly added on second retrieval of week overview, one per loaded goal.
 
 		cleanup:
@@ -85,8 +85,8 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		reportAppActivity(richard, richard.requestingDevice, "NU.nl", "W-1 Mon 23:00", "W-1 Mon 23:49")
 		def firstAggregationResponse = batchService.triggerActivityAggregationBatchJob()
 		assertResponseStatusOk(firstAggregationResponse)
-		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 1
-		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateDayActivities == 1
+		assert firstAggregationResponse.json.writeCountPerStep?.aggregateWeekActivities == 1
+		assert firstAggregationResponse.json.writeCountPerStep?.aggregateDayActivities == 1
 
 		richard = appService.reloadUser(richard)
 		Goal budgetGoalNewsRichard = richard.findActiveGoal(NEWS_ACT_CAT_URL)
@@ -116,8 +116,8 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		def response = batchService.triggerActivityAggregationBatchJob()
 		assertResponseStatusOk(response)
 		int nrGoals = 2
-		response.responseData.writeCountPerStep?.aggregateWeekActivities == nrGoals
-		response.responseData.writeCountPerStep?.aggregateDayActivities == nrGoals * (6 + YonaServer.getCurrentDayOfWeek()) //days are initialized with inactivity, side effect of retrieving and asserting activity
+		response.json.writeCountPerStep?.aggregateWeekActivities == nrGoals
+		response.json.writeCountPerStep?.aggregateDayActivities == nrGoals * (6 + YonaServer.getCurrentDayOfWeek()) //days are initialized with inactivity, side effect of retrieving and asserting activity
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)
 
 		cleanup:
@@ -139,8 +139,8 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		reportAppActivity(richard, richard.requestingDevice, "NU.nl", "W-1 Mon 23:00", "W-1 Mon 23:05")
 		def firstAggregationResponse = batchService.triggerActivityAggregationBatchJob()
 		assertResponseStatusOk(firstAggregationResponse)
-		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateWeekActivities == 1
-		assert firstAggregationResponse.responseData.writeCountPerStep?.aggregateDayActivities == 1
+		assert firstAggregationResponse.json.writeCountPerStep?.aggregateWeekActivities == 1
+		assert firstAggregationResponse.json.writeCountPerStep?.aggregateDayActivities == 1
 
 		richard = appService.reloadUser(richard)
 		Goal budgetGoalNewsRichard = richard.findActiveGoal(NEWS_ACT_CAT_URL)
@@ -168,8 +168,8 @@ class ActivityAggregationBatchJobTest extends AbstractAppServiceIntegrationTest
 		def response = batchService.triggerActivityAggregationBatchJob()
 		assertResponseStatusOk(response)
 		int nrGoals = 2
-		response.responseData.writeCountPerStep?.aggregateWeekActivities == nrGoals
-		response.responseData.writeCountPerStep?.aggregateDayActivities == nrGoals * (6 + YonaServer.getCurrentDayOfWeek()) //days are initialized with inactivity, side effect of retrieving and asserting activity
+		response.json.writeCountPerStep?.aggregateWeekActivities == nrGoals
+		response.json.writeCountPerStep?.aggregateDayActivities == nrGoals * (6 + YonaServer.getCurrentDayOfWeek()) //days are initialized with inactivity, side effect of retrieving and asserting activity
 		assertActivityValues(richard, 1, expectedValuesSecondAggregation, 2)
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityCategoriesTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -18,9 +18,9 @@ class ActivityCategoriesTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._links.self.href == appService.url + appService.ACTIVITY_CATEGORIES_PATH
-		response.responseData._embedded."yona:activityCategories".size() > 0
-		def gamblingCategory = response.responseData._embedded."yona:activityCategories".find { it._links.self.href == GAMBLING_ACT_CAT_URL }
+		response.json._links.self.href == appService.url + appService.ACTIVITY_CATEGORIES_PATH
+		response.json._embedded."yona:activityCategories".size() > 0
+		def gamblingCategory = response.json._embedded."yona:activityCategories".find { it._links.self.href == GAMBLING_ACT_CAT_URL }
 		gamblingCategory.keySet() == ["_links", "name", "description"] as Set
 		gamblingCategory.name == "Gambling"
 		gamblingCategory.description == "This challenge includes apps and sites like Poker and Blackjack"

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityCommentTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityCommentTest.groovy
@@ -99,7 +99,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(beaResponseDetailsRichardAsBuddy, """{"message": "Hi Richard! Everything alright?"}""", bea.password)
 
 		def expectedDataRichard = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "BDD", message: "Hi Richard! Everything alright?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		def messageBea1AsSeenByRichard = richardMessages[1]
@@ -107,9 +107,9 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		appService.postMessageActionWithPassword(messageBob1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bob! Doing fine!"], richard.password)
 
 		def expectedDataBob = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedDataBob).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedDataBob).json._embedded."yona:messages"
 		def expectedDataBea = [[nickname: "BDD", message: "Hi Richard! Everything alright?"]]
-		List beaMessagesRichard = getActivityDetailMessages(beaResponseDetailsRichardAsBuddy, bea, expectedDataBea).responseData._embedded."yona:messages"
+		List beaMessagesRichard = getActivityDetailMessages(beaResponseDetailsRichardAsBuddy, bea, expectedDataBea).json._embedded."yona:messages"
 
 		then:
 		bobMessagesRichard[0].nickname == "BD (me)"
@@ -149,7 +149,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(beaResponseDetailsRichardAsBuddy, """{"message": "Hi Richard! Everything alright?"}""", bea.password)
 
 		def expectedDataRichard2 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "BDD", message: "Hi Richard! Everything alright?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard2).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard2).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		def messageBea1AsSeenByRichard = richardMessages[1]
@@ -158,13 +158,13 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		appService.postMessageActionWithPassword(messageBea1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bea! I'm alright!"], richard.password)
 
 		def expectedDataBob = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedDataBob).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedDataBob).json._embedded."yona:messages"
 		def expectedDataBea = [[nickname: "BDD", message: "Hi Richard! Everything alright?"], [nickname: "RQ", message: "Hi Bea! I'm alright!"]]
-		getActivityDetailMessages(beaResponseDetailsRichardAsBuddy, bea, expectedDataBea).responseData._embedded."yona:messages"
+		getActivityDetailMessages(beaResponseDetailsRichardAsBuddy, bea, expectedDataBea).json._embedded."yona:messages"
 		appService.postMessageActionWithPassword(bobMessagesRichard[1]._links."yona:reply".href, ["message": "Great buddy!"], bob.password)
 
 		def expectedDataRichard5 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"], [nickname: "BD", message: "Great buddy!"], [nickname: "BDD", message: "Hi Richard! Everything alright?"], [nickname: "RQ", message: "Hi Bea! I'm alright!"]]
-		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard5, 10).responseData._embedded."yona:messages"
+		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedDataRichard5, 10).json._embedded."yona:messages"
 
 		then:
 		richardMessagesRevisited[0].nickname == "BD"
@@ -192,8 +192,8 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseDayOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = appService.getDayDetailsFromOverview(responseDayOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob, 0, getCurrentShortDay(YonaServer.now))
-		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
-		assert responseDetailsBobAsBuddy.responseData._links."yona:messages".href
+		assert responseDetailsBobAsBuddy.json._links."yona:addComment".href
+		assert responseDetailsBobAsBuddy.json._links."yona:messages".href
 
 		when:
 		def message = """{"message": "You're quiet!"}"""
@@ -220,8 +220,8 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseWeekOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = appService.getWeekDetailsFromOverview(responseWeekOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob, 0)
-		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
-		assert responseDetailsBobAsBuddy.responseData._links."yona:messages".href
+		assert responseDetailsBobAsBuddy.json._links."yona:addComment".href
+		assert responseDetailsBobAsBuddy.json._links."yona:messages".href
 
 		when:
 		def message = """{"message": "You're quiet!"}"""
@@ -255,17 +255,17 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(bobResponseDetailsRichardAsBuddy, """{"message": "Hi buddy! How ya doing?"}""", bob.password)
 
 		def expectedData1 = [[nickname: "BD", message: "Hi buddy! How ya doing?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		appService.postMessageActionWithPassword(messageBob1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bob! Doing fine!"], richard.password)
 
 		def expectedData2 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).json._embedded."yona:messages"
 		appService.postMessageActionWithPassword(bobMessagesRichard[1]._links."yona:reply".href, ["message": "Great buddy!"], bob.password)
 
 		def expectedData3 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"], [nickname: "BD", message: "Great buddy!"]]
-		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).responseData._embedded."yona:messages"
+		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).json._embedded."yona:messages"
 
 		assert richardMessagesRevisited[0].nickname == "BD"
 		assert richardMessagesRevisited[1].nickname == "RQ (me)"
@@ -305,17 +305,17 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(bobResponseDetailsRichardAsBuddy, """{"message": "Hi buddy! How ya doing?"}""", bob.password)
 
 		def expectedData1 = [[nickname: "BD", message: "Hi buddy! How ya doing?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		appService.postMessageActionWithPassword(messageBob1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bob! Doing fine!"], richard.password)
 
 		def expectedData2 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).json._embedded."yona:messages"
 		appService.postMessageActionWithPassword(bobMessagesRichard[1]._links."yona:reply".href, ["message": "Great buddy!"], bob.password)
 
 		def expectedData3 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"], [nickname: "BD", message: "Great buddy!"]]
-		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).responseData._embedded."yona:messages"
+		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).json._embedded."yona:messages"
 
 		assert richardMessagesRevisited[0].nickname == "BD"
 		assert richardMessagesRevisited[1].nickname == "RQ (me)"
@@ -355,17 +355,17 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(bobResponseDetailsRichardAsBuddy, """{"message": "Hi buddy! How ya doing?"}""", bob.password)
 
 		def expectedData1 = [[nickname: "BD", message: "Hi buddy! How ya doing?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		appService.postMessageActionWithPassword(messageBob1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bob! Doing fine!"], richard.password)
 
 		def expectedData2 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).json._embedded."yona:messages"
 		appService.postMessageActionWithPassword(bobMessagesRichard[1]._links."yona:reply".href, ["message": "Great buddy!"], bob.password)
 
 		def expectedData3 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"], [nickname: "BD", message: "Great buddy!"]]
-		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).responseData._embedded."yona:messages"
+		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).json._embedded."yona:messages"
 
 		assert richardMessagesRevisited[0].nickname == "BD"
 		assert richardMessagesRevisited[1].nickname == "RQ (me)"
@@ -406,17 +406,17 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		addComment(bobResponseDetailsRichardAsBuddy, """{"message": "Hi buddy! How ya doing?"}""", bob.password)
 
 		def expectedData1 = [[nickname: "BD", message: "Hi buddy! How ya doing?"]]
-		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).responseData._embedded."yona:messages"
+		List richardMessages = getActivityDetailMessages(richardResponseDetails, richard, expectedData1).json._embedded."yona:messages"
 		def messageBob1AsSeenByRichard = richardMessages[0]
 		assert messageBob1AsSeenByRichard.nickname == "BD"
 		appService.postMessageActionWithPassword(messageBob1AsSeenByRichard._links."yona:reply".href, ["message": "Hi Bob! Doing fine!"], richard.password)
 
 		def expectedData2 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"]]
-		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).responseData._embedded."yona:messages"
+		List bobMessagesRichard = getActivityDetailMessages(bobResponseDetailsRichardAsBuddy, bob, expectedData2).json._embedded."yona:messages"
 		appService.postMessageActionWithPassword(bobMessagesRichard[1]._links."yona:reply".href, ["message": "Great buddy!"], bob.password)
 
 		def expectedData3 = [[nickname: "BD", message: "Hi buddy! How ya doing?"], [nickname: "RQ", message: "Hi Bob! Doing fine!"], [nickname: "BD", message: "Great buddy!"]]
-		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).responseData._embedded."yona:messages"
+		List richardMessagesRevisited = getActivityDetailMessages(richardResponseDetails, richard, expectedData3, 10).json._embedded."yona:messages"
 
 		assert richardMessagesRevisited[0].nickname == "BD"
 		assert richardMessagesRevisited[1].nickname == "RQ (me)"
@@ -461,7 +461,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		then:
 		def response = addComment(responseDetailsBobAsBuddy, messageJson, richard.password)
 		assertResponseStatus(response, expectedStatus)
-		expectedStatus == 200 || response.responseData.message == "The string 'message' is too long. It contains $messageLength characters while only 200 are allowed"
+		expectedStatus == 200 || response.json.message == "The string 'message' is too long. It contains $messageLength characters while only 200 are allowed"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -480,7 +480,7 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 
 	static addComment(appService, response, message, password)
 	{
-		appService.yonaServer.createResourceWithPassword(response.responseData._links."yona:addComment".href, message, password)
+		appService.yonaServer.createResourceWithPassword(response.json._links."yona:addComment".href, message, password)
 	}
 
 	void assertCommentingWorks(User richard, User bob, boolean isWeek, Closure userOverviewRetriever, Closure buddyOverviewRetriever, Closure detailsRetriever)
@@ -505,8 +505,8 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusOk(responseOverviewsBobAsBuddyAll)
 
 		def responseDetailsBobAsBuddy = detailsRetriever(responseOverviewsBobAsBuddyAll, richard, budgetGoalNewsBuddyBob)
-		assert responseDetailsBobAsBuddy.responseData._links."yona:addComment".href
-		assert responseDetailsBobAsBuddy.responseData._links."yona:messages".href
+		assert responseDetailsBobAsBuddy.json._links."yona:addComment".href
+		assert responseDetailsBobAsBuddy.json._links."yona:messages".href
 
 		appService.clearLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)
 		appService.clearLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
@@ -514,8 +514,8 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 		def responseAddMessage = addComment(appService, responseDetailsBobAsBuddy, message, richard.password)
 
 		assertResponseStatusOk(responseAddMessage)
-		def addedMessage = responseAddMessage.responseData
-		assertCommentMessageDetails(addedMessage, richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "You're quiet!", addedMessage)
+		def addedMessage = responseAddMessage.json
+		assertCommentMessageDetails(addedMessage, richard, isWeek, richard, responseDetailsBobAsBuddy.json._links.self.href, "You're quiet!", addedMessage)
 
 		assertResponseStatus(appService.clearLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId), 404)
 		// No message sent since last clear
@@ -526,93 +526,93 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 
 		def expectedData1 = [[nickname: richard.nickname, message: "You're quiet!"]]
 		def responseInitialGetCommentMessagesSeenByRichard = getActivityDetailMessages(appService, responseDetailsBobAsBuddy, richard, expectedData1)
-		List initialMessagesSeenByRichard = responseInitialGetCommentMessagesSeenByRichard.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(initialMessagesSeenByRichard[0], richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "You're quiet!", initialMessagesSeenByRichard[0])
+		List initialMessagesSeenByRichard = responseInitialGetCommentMessagesSeenByRichard.json._embedded."yona:messages"
+		assertCommentMessageDetails(initialMessagesSeenByRichard[0], richard, isWeek, richard, responseDetailsBobAsBuddy.json._links.self.href, "You're quiet!", initialMessagesSeenByRichard[0])
 
 		def responseOverviewsBobAll = userOverviewRetriever(bob)
 		assertResponseStatusOk(responseOverviewsBobAll)
 
 		def responseDetailsBob = detailsRetriever(responseOverviewsBobAll, bob, budgetGoalNewsBob)
-		assert responseDetailsBob.responseData._links."yona:addComment" == null
-		assert responseDetailsBob.responseData._links."yona:messages".href
+		assert responseDetailsBob.json._links."yona:addComment" == null
+		assert responseDetailsBob.json._links."yona:messages".href
 
 		def responseInitialGetCommentMessagesSeenByBob = getActivityDetailMessages(appService, responseDetailsBob, bob, expectedData1)
-		List initialMessagesSeenByBob = responseInitialGetCommentMessagesSeenByBob.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(initialMessagesSeenByBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "You're quiet!", initialMessagesSeenByBob[0])
+		List initialMessagesSeenByBob = responseInitialGetCommentMessagesSeenByBob.json._embedded."yona:messages"
+		assertCommentMessageDetails(initialMessagesSeenByBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "You're quiet!", initialMessagesSeenByBob[0])
 
 		replyToMessage(appService, initialMessagesSeenByBob[0], bob, "My battery died :)", isWeek, responseDetailsBob, initialMessagesSeenByBob[0])
 
 		def expectedData2 = [[nickname: richard.nickname, message: "You're quiet!"], [nickname: bob.nickname, message: "My battery died :)"]]
 		def responseSecondGetCommentMessagesSeenByRichard = getActivityDetailMessages(appService, responseDetailsBobAsBuddy, richard, expectedData2)
-		List replyMessagesSeenByRichard = responseSecondGetCommentMessagesSeenByRichard.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(replyMessagesSeenByRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "My battery died :)",
-				replyMessagesSeenByRichard[0], responseSecondGetCommentMessagesSeenByRichard.responseData._embedded."yona:messages"[0])
+		List replyMessagesSeenByRichard = responseSecondGetCommentMessagesSeenByRichard.json._embedded."yona:messages"
+		assertCommentMessageDetails(replyMessagesSeenByRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "My battery died :)",
+				replyMessagesSeenByRichard[0], responseSecondGetCommentMessagesSeenByRichard.json._embedded."yona:messages"[0])
 
 		replyToMessage(appService, replyMessagesSeenByRichard[1], richard, "Too bad!", isWeek, responseDetailsBobAsBuddy, replyMessagesSeenByRichard[0])
 
 		def expectedData3 = [[nickname: richard.nickname, message: "You're quiet!"], [nickname: bob.nickname, message: "My battery died :)"], [nickname: richard.nickname, message: "Too bad!"],]
 		def responseSecondGetCommentMessagesSeenByBob = getActivityDetailMessages(appService, responseDetailsBob, bob, expectedData3)
-		List secondReplyMessagesSeenByBob = responseSecondGetCommentMessagesSeenByBob.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(secondReplyMessagesSeenByBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "Too bad!", secondReplyMessagesSeenByBob[0], secondReplyMessagesSeenByBob[1])
+		List secondReplyMessagesSeenByBob = responseSecondGetCommentMessagesSeenByBob.json._embedded."yona:messages"
+		assertCommentMessageDetails(secondReplyMessagesSeenByBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "Too bad!", secondReplyMessagesSeenByBob[0], secondReplyMessagesSeenByBob[1])
 
 		replyToMessage(appService, secondReplyMessagesSeenByBob[2], bob, "Yes, it is...", isWeek, responseDetailsBob, secondReplyMessagesSeenByBob[0])
 
 		def expectedData4 = [[nickname: richard.nickname, message: "You're quiet!"], [nickname: bob.nickname, message: "My battery died :)"], [nickname: richard.nickname, message: "Too bad!"], [nickname: bob.nickname, message: "Yes, it is..."]]
 		def responseThirdGetCommentMessagesSeenByRichard = getActivityDetailMessages(appService, responseDetailsBobAsBuddy, richard, expectedData4)
-		List replyToReplyMessagesSeenByRichard = responseThirdGetCommentMessagesSeenByRichard.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(replyToReplyMessagesSeenByRichard[3], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "Yes, it is...", replyToReplyMessagesSeenByRichard[0], replyToReplyMessagesSeenByRichard[2])
+		List replyToReplyMessagesSeenByRichard = responseThirdGetCommentMessagesSeenByRichard.json._embedded."yona:messages"
+		assertCommentMessageDetails(replyToReplyMessagesSeenByRichard[3], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "Yes, it is...", replyToReplyMessagesSeenByRichard[0], replyToReplyMessagesSeenByRichard[2])
 
 		replyToMessage(appService, replyToReplyMessagesSeenByRichard[3], richard, "No budget for a new one?", isWeek, responseDetailsBobAsBuddy, replyToReplyMessagesSeenByRichard[0])
 
 		def expectedData5 = [[nickname: richard.nickname, message: "You're quiet!"], [nickname: bob.nickname, message: "My battery died :)"], [nickname: richard.nickname, message: "Too bad!"], [nickname: bob.nickname, message: "Yes, it is..."], [nickname: richard.nickname, message: "No budget for a new one?"]]
 		def responseFinalGetCommentMessagesSeenByRichard = getActivityDetailMessages(appService, responseDetailsBobAsBuddy, richard, expectedData5)
-		List messagesRichard = responseFinalGetCommentMessagesSeenByRichard.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(messagesRichard[0], richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "You're quiet!", messagesRichard[0])
-		assertCommentMessageDetails(messagesRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "My battery died :)", messagesRichard[0], messagesRichard[0])
-		assertCommentMessageDetails(messagesRichard[2], richard, isWeek, richard, responseDetailsBobAsBuddy.responseData._links.self.href, "Too bad!", messagesRichard[0], messagesRichard[1])
-		assertCommentMessageDetails(messagesRichard[3], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "Yes, it is...", messagesRichard[0], messagesRichard[2])
+		List messagesRichard = responseFinalGetCommentMessagesSeenByRichard.json._embedded."yona:messages"
+		assertCommentMessageDetails(messagesRichard[0], richard, isWeek, richard, responseDetailsBobAsBuddy.json._links.self.href, "You're quiet!", messagesRichard[0])
+		assertCommentMessageDetails(messagesRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "My battery died :)", messagesRichard[0], messagesRichard[0])
+		assertCommentMessageDetails(messagesRichard[2], richard, isWeek, richard, responseDetailsBobAsBuddy.json._links.self.href, "Too bad!", messagesRichard[0], messagesRichard[1])
+		assertCommentMessageDetails(messagesRichard[3], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "Yes, it is...", messagesRichard[0], messagesRichard[2])
 		assertNextPage(appService, responseFinalGetCommentMessagesSeenByRichard, richard)
 
 		def responseFinalGetCommentMessagesSeenByBob = getActivityDetailMessages(appService, responseDetailsBob, bob, expectedData5)
-		List messagesBob = responseFinalGetCommentMessagesSeenByBob.responseData._embedded."yona:messages"
-		assertCommentMessageDetails(messagesBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "You're quiet!", messagesBob[0])
-		assertCommentMessageDetails(messagesBob[1], bob, isWeek, bob, responseDetailsBob.responseData._links.self.href, "My battery died :)", messagesBob[0], messagesBob[0])
-		assertCommentMessageDetails(messagesBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "Too bad!", messagesBob[0], messagesBob[1])
-		assertCommentMessageDetails(messagesBob[3], bob, isWeek, bob, responseDetailsBob.responseData._links.self.href, "Yes, it is...", messagesBob[0], messagesBob[2])
+		List messagesBob = responseFinalGetCommentMessagesSeenByBob.json._embedded."yona:messages"
+		assertCommentMessageDetails(messagesBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "You're quiet!", messagesBob[0])
+		assertCommentMessageDetails(messagesBob[1], bob, isWeek, bob, responseDetailsBob.json._links.self.href, "My battery died :)", messagesBob[0], messagesBob[0])
+		assertCommentMessageDetails(messagesBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "Too bad!", messagesBob[0], messagesBob[1])
+		assertCommentMessageDetails(messagesBob[3], bob, isWeek, bob, responseDetailsBob.json._links.self.href, "Yes, it is...", messagesBob[0], messagesBob[2])
 		assertNextPage(appService, responseFinalGetCommentMessagesSeenByBob, bob)
 
 		def allMessagesRichardResponse = appService.getMessages(richard)
-		assert allMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }?.size() == 2
-		def activityCommentMessagesRichard = allMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }
-		assertCommentMessageDetails(activityCommentMessagesRichard[0], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "Yes, it is...", messagesRichard[0], messagesRichard[2])
-		assertCommentMessageDetails(activityCommentMessagesRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.responseData._links.self.href, "My battery died :)", messagesRichard[0], messagesRichard[0])
+		assert allMessagesRichardResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }?.size() == 2
+		def activityCommentMessagesRichard = allMessagesRichardResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }
+		assertCommentMessageDetails(activityCommentMessagesRichard[0], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "Yes, it is...", messagesRichard[0], messagesRichard[2])
+		assertCommentMessageDetails(activityCommentMessagesRichard[1], richard, isWeek, richard.buddies[0], responseDetailsBobAsBuddy.json._links.self.href, "My battery died :)", messagesRichard[0], messagesRichard[0])
 
 		def allMessagesBobResponse = appService.getMessages(bob)
-		assert allMessagesBobResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }?.size() == 3
-		def activityCommentMessagesBob = allMessagesBobResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }
-		assertCommentMessageDetails(activityCommentMessagesBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "No budget for a new one?", activityCommentMessagesBob[2], messagesBob[3])
-		assertCommentMessageDetails(activityCommentMessagesBob[1], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "Too bad!", activityCommentMessagesBob[2], messagesBob[1])
-		assertCommentMessageDetails(activityCommentMessagesBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.responseData._links.self.href, "You're quiet!", activityCommentMessagesBob[2])
+		assert allMessagesBobResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }?.size() == 3
+		def activityCommentMessagesBob = allMessagesBobResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "ActivityCommentMessage" }
+		assertCommentMessageDetails(activityCommentMessagesBob[0], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "No budget for a new one?", activityCommentMessagesBob[2], messagesBob[3])
+		assertCommentMessageDetails(activityCommentMessagesBob[1], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "Too bad!", activityCommentMessagesBob[2], messagesBob[1])
+		assertCommentMessageDetails(activityCommentMessagesBob[2], bob, isWeek, bob.buddies[0], responseDetailsBob.json._links.self.href, "You're quiet!", activityCommentMessagesBob[2])
 	}
 
 	private static void replyToMessage(AppService appService, messageToReply, User senderUser, messageToSend, boolean isWeek, responseGetActivityDetails, threadHeadMessage)
 	{
 		def responseReplyFromBob = appService.postMessageActionWithPassword(messageToReply._links."yona:reply".href, ["message": messageToSend], senderUser.password)
 		assertResponseStatusOk(responseReplyFromBob)
-		assert responseReplyFromBob.responseData.properties["status"] == "done"
-		assert responseReplyFromBob.responseData._embedded?."yona:affectedMessages"?.size() == 1
-		def replyMessage = responseReplyFromBob.responseData._embedded."yona:affectedMessages"[0]
-		assertCommentMessageDetails(replyMessage, senderUser, isWeek, senderUser, responseGetActivityDetails.responseData._links.self.href, messageToSend, threadHeadMessage, messageToReply)
+		assert responseReplyFromBob.json.properties["status"] == "done"
+		assert responseReplyFromBob.json._embedded?."yona:affectedMessages"?.size() == 1
+		def replyMessage = responseReplyFromBob.json._embedded."yona:affectedMessages"[0]
+		assertCommentMessageDetails(replyMessage, senderUser, isWeek, senderUser, responseGetActivityDetails.json._links.self.href, messageToSend, threadHeadMessage, messageToReply)
 	}
 
 	private static getActivityDetailMessages(AppService appService, responseGetActivityDetails, User user, List expectedData, int pageSize = 4)
 	{
 		int expectedNumMessages = expectedData.size
 		int expectedNumMessagesInPage = Math.min(expectedNumMessages, pageSize)
-		def response = appService.yonaServer.getJsonWithPassword(responseGetActivityDetails.responseData._links."yona:messages".href, user.password, ["size": pageSize])
+		def response = appService.yonaServer.getJsonWithPassword(responseGetActivityDetails.json._links."yona:messages".href, user.password, ["size": pageSize])
 
 		assertResponseStatusOk(response)
-		def messages = response.responseData?._embedded?."yona:messages"
+		def messages = response.json?._embedded?."yona:messages"
 		if (expectedNumMessagesInPage == 0)
 		{
 			assert messages == null
@@ -625,15 +625,15 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 			assert message.nickname == expectedData[i].nickname + ((expectedData[i].nickname == user.nickname) ? " (me)" : "")
 			assert message.message == expectedData[i].message
 		}
-		assert response.responseData.page.size == pageSize
-		assert response.responseData.page.totalElements == expectedNumMessages
-		assert response.responseData.page.totalPages == Math.ceil(expectedNumMessages / pageSize)
-		assert response.responseData.page.number == 0
+		assert response.json.page.size == pageSize
+		assert response.json.page.totalElements == expectedNumMessages
+		assert response.json.page.totalPages == Math.ceil(expectedNumMessages / pageSize)
+		assert response.json.page.number == 0
 
-		assert response.responseData._links?.prev?.href == null
+		assert response.json._links?.prev?.href == null
 		if (expectedNumMessages > pageSize)
 		{
-			assert response.responseData._links?.next?.href
+			assert response.json._links?.next?.href
 		}
 
 		return response
@@ -642,17 +642,17 @@ class ActivityCommentTest extends AbstractAppServiceIntegrationTest
 	private static void assertNextPage(AppService appService, responseGetActivityDetails, User user)
 	{
 		int defaultPageSize = 4
-		def response = appService.yonaServer.getJsonWithPassword(responseGetActivityDetails.responseData._links.next.href, user.password)
+		def response = appService.yonaServer.getJsonWithPassword(responseGetActivityDetails.json._links.next.href, user.password)
 
 		assertResponseStatusOk(response)
-		assert response.responseData?._embedded?."yona:messages"?.size() == 1
-		assert response.responseData.page.size == defaultPageSize
-		assert response.responseData.page.totalElements == 5
-		assert response.responseData.page.totalPages == 2
-		assert response.responseData.page.number == 1
+		assert response.json?._embedded?."yona:messages"?.size() == 1
+		assert response.json.page.size == defaultPageSize
+		assert response.json.page.totalElements == 5
+		assert response.json.page.totalPages == 2
+		assert response.json.page.number == 1
 
-		assert response.responseData._links?.prev?.href
-		assert response.responseData._links?.next?.href == null
+		assert response.json._links?.prev?.href
+		assert response.json._links?.next?.href == null
 	}
 
 	private static void assertCommentMessageDetails(message, User user, boolean isWeek, sender, expectedDetailsUrl, expectedText, threadHeadMessage, repliedMessage = null)

--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -51,7 +51,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(responseDayOverviewWithBuddies, 404)
-		responseDayOverviewWithBuddies.responseData.code == "error.buddy.list.empty"
+		responseDayOverviewWithBuddies.json.code == "error.buddy.list.empty"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -71,19 +71,19 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewBasics(responseDayOverviews, 1, 1)
 		assertWeekOverviewBasics(responseWeekOverviews, [2], 1)
 
-		def weekActivityOverviewForGoal = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == goal.url }
+		def weekActivityOverviewForGoal = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == goal.url }
 		weekActivityOverviewForGoal?._links?."yona:weekDetails"?.href
 		weekActivityOverviewForGoal?._links?."next"?.href == null
 		weekActivityOverviewForGoal?._links?."prev"?.href == null
 		def weekActivityDetailUrl = weekActivityOverviewForGoal?._links?."yona:weekDetails"?.href
 		def responseWeekDetails = appService.getResourceWithPassword(weekActivityDetailUrl, richard.password)
 		assertResponseStatusOk(responseWeekDetails)
-		def weekActivityDetails = responseWeekDetails.responseData
+		def weekActivityDetails = responseWeekDetails.json
 		weekActivityDetails._links."yona:goal".href == weekActivityOverviewForGoal._links."yona:goal".href
 		weekActivityDetails?._links?."next"?.href == null
 		weekActivityDetails?._links?."prev"?.href == null
 
-		def dayActivityOverview = responseDayOverviews.responseData._embedded."yona:dayActivityOverviews"[0]
+		def dayActivityOverview = responseDayOverviews.json._embedded."yona:dayActivityOverviews"[0]
 		def dayActivityOverviewForGoal = dayActivityOverview.dayActivities.find { it._links."yona:goal".href == goal.url }
 		dayActivityOverviewForGoal?._links?."yona:dayDetails"?.href
 		dayActivityOverviewForGoal?._links?."next"?.href == null
@@ -91,7 +91,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def dayActivityDetailUrl = dayActivityOverviewForGoal?._links?."yona:dayDetails"?.href
 		def responseDayDetail = appService.getResourceWithPassword(dayActivityDetailUrl, richard.password)
 		assertResponseStatusOk(responseDayDetail)
-		def dayActivityDetails = responseDayDetail.responseData
+		def dayActivityDetails = responseDayDetail.json
 		dayActivityDetails._links."yona:goal".href == dayActivityOverviewForGoal._links."yona:goal".href
 		dayActivityDetails?._links?."next"?.href == null
 		dayActivityDetails?._links?."prev"?.href == null
@@ -133,11 +133,11 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviewsPage3, [2, 1], expectedTotalWeeks)
 		assertWeekOverviewBasics(responseWeekOverviewsPage4, [1], expectedTotalWeeks)
 
-		def week5ForGoal = responseWeekOverviewsPage3.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def week4ForGoal = responseWeekOverviewsPage2.responseData._embedded."yona:weekActivityOverviews"[1].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def week3ForGoal = responseWeekOverviewsPage2.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def week2ForGoal = responseWeekOverviewsPage1.responseData._embedded."yona:weekActivityOverviews"[1].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def week1ForGoal = responseWeekOverviewsPage1.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def week5ForGoal = responseWeekOverviewsPage3.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def week4ForGoal = responseWeekOverviewsPage2.json._embedded."yona:weekActivityOverviews"[1].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def week3ForGoal = responseWeekOverviewsPage2.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def week2ForGoal = responseWeekOverviewsPage1.json._embedded."yona:weekActivityOverviews"[1].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def week1ForGoal = responseWeekOverviewsPage1.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
 		assertWeekDetailPrevNextLinks(richard, week5ForGoal, null, week4ForGoal)
 		assertWeekDetailPrevNextLinks(richard, week4ForGoal, week5ForGoal, week3ForGoal)
 		assertWeekDetailPrevNextLinks(richard, week1ForGoal, week2ForGoal, null)
@@ -145,11 +145,11 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewBasics(responseDayOverviewsPage1, 3, expectedTotalDays)
 		assertDayOverviewBasics(responseDayOverviewsPage2, 3, expectedTotalDays)
 
-		def day1ForGoal = responseDayOverviewsPage1.responseData._embedded."yona:dayActivityOverviews"[0].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def day2ForGoal = responseDayOverviewsPage1.responseData._embedded."yona:dayActivityOverviews"[1].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def day3ForGoal = responseDayOverviewsPage1.responseData._embedded."yona:dayActivityOverviews"[2].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def secondToLastDayForGoal = responseDayOverviewsAllOnOnePage.responseData._embedded."yona:dayActivityOverviews"[expectedDaysNews - 2].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
-		def lastDayForGoal = responseDayOverviewsAllOnOnePage.responseData._embedded."yona:dayActivityOverviews"[expectedDaysNews - 1].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def day1ForGoal = responseDayOverviewsPage1.json._embedded."yona:dayActivityOverviews"[0].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def day2ForGoal = responseDayOverviewsPage1.json._embedded."yona:dayActivityOverviews"[1].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def day3ForGoal = responseDayOverviewsPage1.json._embedded."yona:dayActivityOverviews"[2].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def secondToLastDayForGoal = responseDayOverviewsAllOnOnePage.json._embedded."yona:dayActivityOverviews"[expectedDaysNews - 2].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
+		def lastDayForGoal = responseDayOverviewsAllOnOnePage.json._embedded."yona:dayActivityOverviews"[expectedDaysNews - 1].dayActivities.find { it._links."yona:goal".href == budgetGoalNews.url }
 		assertDayDetailPrevNextLinks(richard, lastDayForGoal, null, secondToLastDayForGoal)
 		assertDayDetailPrevNextLinks(richard, day2ForGoal, day3ForGoal, day1ForGoal)
 		assertDayDetailPrevNextLinks(richard, day1ForGoal, day2ForGoal, null)
@@ -223,7 +223,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 3], expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalNewsRichard, 6)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Mon")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Tue")
@@ -284,7 +284,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Sat")
 
-		def buddyWeekOverviewLastWeek = responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def buddyWeekOverviewLastWeek = responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(buddyWeekOverviewLastWeek, budgetGoalSocialBob, 3)
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewLastWeek, budgetGoalSocialBob, expectedValuesBobLastWeek, "Thu")
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewLastWeek, budgetGoalSocialBob, expectedValuesBobLastWeek, "Fri")
@@ -307,30 +307,30 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def weekOverviewLink = weekOverviewLastWeek._links.self.href
 		def weekOverviewResponse = appService.getResourceWithPassword(weekOverviewLink, richard.password)
 		assertResponseStatusOk(weekOverviewResponse)
-		assert weekOverviewResponse.responseData.date == weekOverviewLastWeek.date
+		assert weekOverviewResponse.json.date == weekOverviewLastWeek.date
 
 		def dayOverviewOffset = YonaServer.relativeDateStringToDaysOffset(1, "Thu")
-		def dayOverviewLink = responseDayOverviewsAll.responseData._embedded."yona:dayActivityOverviews"[dayOverviewOffset]._links.self.href
+		def dayOverviewLink = responseDayOverviewsAll.json._embedded."yona:dayActivityOverviews"[dayOverviewOffset]._links.self.href
 		def dayOverviewResponse = appService.getResourceWithPassword(dayOverviewLink, richard.password)
 		assertResponseStatusOk(dayOverviewResponse)
-		assert dayOverviewResponse.responseData.date == responseDayOverviewsAll.responseData._embedded."yona:dayActivityOverviews"[dayOverviewOffset].date
+		assert dayOverviewResponse.json.date == responseDayOverviewsAll.json._embedded."yona:dayActivityOverviews"[dayOverviewOffset].date
 
 		def dayOverviewWithBuddiesOffset = YonaServer.relativeDateStringToDaysOffset(1, "Fri")
-		def dayOverviewWithBuddiesLink = responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset]._links.self.href
+		def dayOverviewWithBuddiesLink = responseDayOverviewsWithBuddies.json._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset]._links.self.href
 		def dayOverviewWithBuddiesResponse = appService.getResourceWithPassword(dayOverviewWithBuddiesLink, richard.password)
 		assertResponseStatusOk(dayOverviewWithBuddiesResponse)
-		assert dayOverviewWithBuddiesResponse.responseData.date == responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset].date
+		assert dayOverviewWithBuddiesResponse.json.date == responseDayOverviewsWithBuddies.json._embedded."yona:dayActivityOverviews"[dayOverviewWithBuddiesOffset].date
 
 		def buddyWeekOverviewLink = buddyWeekOverviewLastWeek._links.self.href
 		def responseBuddyWeekOverview = appService.getResourceWithPassword(buddyWeekOverviewLink, richard.password)
 		assertResponseStatusOk(responseBuddyWeekOverview)
-		assert responseBuddyWeekOverview.responseData.date == buddyWeekOverviewLastWeek.date
+		assert responseBuddyWeekOverview.json.date == buddyWeekOverviewLastWeek.date
 
 		def buddyDayOverviewOffset = YonaServer.relativeDateStringToDaysOffset(1, "Sat")
-		def buddyDayOverviewLink = responseBuddyDayOverviews.responseData._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset]._links.self.href
+		def buddyDayOverviewLink = responseBuddyDayOverviews.json._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset]._links.self.href
 		def responseBuddyDayOverview = appService.getResourceWithPassword(buddyDayOverviewLink, richard.password)
 		assertResponseStatusOk(responseBuddyDayOverview)
-		assert responseBuddyDayOverview.responseData.date == responseBuddyDayOverviews.responseData._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset].date
+		assert responseBuddyDayOverview.json.date == responseBuddyDayOverviews.json._embedded."yona:dayActivityOverviews"[buddyDayOverviewOffset].date
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -386,9 +386,9 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		dayDetailBobSocialToday._links.prev != null
 		dayDetailBobSocialToday._links.next == null
 
-		def weekDetailRichardGamblingFirstWeek = getWeekDetail(richard, responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2], noGoGoalGamblingRichard)
-		def weekDetailRichardGamblingSecondWeek = getWeekDetail(richard, responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1], noGoGoalGamblingRichard)
-		def weekDetailRichardGamblingThisWeek = getWeekDetail(richard, responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0], noGoGoalGamblingRichard)
+		def weekDetailRichardGamblingFirstWeek = getWeekDetail(richard, responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[2], noGoGoalGamblingRichard)
+		def weekDetailRichardGamblingSecondWeek = getWeekDetail(richard, responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1], noGoGoalGamblingRichard)
+		def weekDetailRichardGamblingThisWeek = getWeekDetail(richard, responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0], noGoGoalGamblingRichard)
 		weekDetailRichardGamblingFirstWeek._links.prev == null
 		weekDetailRichardGamblingFirstWeek._links.next != null
 		weekDetailRichardGamblingSecondWeek._links.prev != null
@@ -396,9 +396,9 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		weekDetailRichardGamblingThisWeek._links.prev != null
 		weekDetailRichardGamblingThisWeek._links.next == null
 
-		def weekDetailBobSocialFirstWeek = getWeekDetail(richard, responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2], budgetGoalSocialBob)
-		def weekDetailBobSocialSecondWeek = getWeekDetail(richard, responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1], budgetGoalSocialBob)
-		def weekDetailBobSocialThisWeek = getWeekDetail(richard, responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0], budgetGoalSocialBob)
+		def weekDetailBobSocialFirstWeek = getWeekDetail(richard, responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[2], budgetGoalSocialBob)
+		def weekDetailBobSocialSecondWeek = getWeekDetail(richard, responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[1], budgetGoalSocialBob)
+		def weekDetailBobSocialThisWeek = getWeekDetail(richard, responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[0], budgetGoalSocialBob)
 		weekDetailBobSocialFirstWeek._links.prev == null
 		weekDetailBobSocialFirstWeek._links.next != null
 		weekDetailBobSocialSecondWeek._links.prev != null
@@ -440,7 +440,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 2], expectedTotalWeeks, expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, timeZoneGoalMultimediaRichard, 2)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalMultimediaRichard, expectedValuesRichardLastWeek, "Fri")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalMultimediaRichard, expectedValuesRichardLastWeek, "Sat")
@@ -465,7 +465,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def initialResponseWeekOverviews = appService.getWeekActivityOverviews(richard)
 		def initialResponseDayOverviews = appService.getDayActivityOverviews(richard)
 		assertResponseStatusOk(initialResponseWeekOverviews)
-		def initialCurrentWeekOverview = initialResponseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0]
+		def initialCurrentWeekOverview = initialResponseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0]
 		assertDayInWeekOverviewForGoal(initialCurrentWeekOverview, budgetGoalNews, initialExpectedValues, currentShortDay)
 		assertWeekDetailForGoal(richard, initialCurrentWeekOverview, budgetGoalNews, initialExpectedValues)
 		assertDayOverviewForBudgetGoal(initialResponseDayOverviews, budgetGoalNews, initialExpectedValues, 0, currentShortDay)
@@ -477,7 +477,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		def expectedValuesAfterActivity = [(currentShortDay): [[goal: budgetGoalNews, data: [goalAccomplished: false, minutesBeyondGoal: 1, spread: [(getCurrentSpreadCell(now)): 1]]], [goal: budgetGoalGambling, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [:]]]]]
 		def responseWeekOverviewsAfterActivity = appService.getWeekActivityOverviews(richard)
-		def currentWeekOverviewAfterActivity = responseWeekOverviewsAfterActivity.responseData._embedded."yona:weekActivityOverviews"[0]
+		def currentWeekOverviewAfterActivity = responseWeekOverviewsAfterActivity.json._embedded."yona:weekActivityOverviews"[0]
 		assertDayInWeekOverviewForGoal(currentWeekOverviewAfterActivity, budgetGoalNews, expectedValuesAfterActivity, currentShortDay)
 		assertWeekDetailForGoal(richard, currentWeekOverviewAfterActivity, budgetGoalNews, expectedValuesAfterActivity)
 
@@ -506,7 +506,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def initialResponseWeekOverviews = appService.getWeekActivityOverviews(richard)
 		def initialResponseDayOverviews = appService.getDayActivityOverviews(richard, ["size": 14])
 		assertResponseStatusOk(initialResponseWeekOverviews)
-		def initialCurrentWeekOverviewLastWeek = initialResponseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def initialCurrentWeekOverviewLastWeek = initialResponseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertDayInWeekOverviewForGoal(initialCurrentWeekOverviewLastWeek, budgetGoalNews, initialExpectedValuesRichardLastWeek, "Wed")
 		assertWeekDetailForGoal(richard, initialCurrentWeekOverviewLastWeek, budgetGoalNews, initialExpectedValuesRichardLastWeek)
 		assertDayOverviewForBudgetGoal(initialResponseDayOverviews, budgetGoalNews, initialExpectedValuesRichardLastWeek, 1, "Wed")
@@ -523,7 +523,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 														  "Fri": [[goal: noGoGoalGambling, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [:]]], [goal: budgetGoalNews, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [:]]]],
 														  "Sat": [[goal: noGoGoalGambling, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [:]]], [goal: budgetGoalNews, data: [goalAccomplished: true, minutesBeyondGoal: 0, spread: [:]]]],]
 		def responseWeekOverviewsAfterActivity = appService.getWeekActivityOverviews(richard)
-		def currentWeekOverviewAfterActivity = responseWeekOverviewsAfterActivity.responseData._embedded."yona:weekActivityOverviews"[1]
+		def currentWeekOverviewAfterActivity = responseWeekOverviewsAfterActivity.json._embedded."yona:weekActivityOverviews"[1]
 		assertDayInWeekOverviewForGoal(currentWeekOverviewAfterActivity, budgetGoalNews, expectedValuesRichardLastWeekAfterActivity, "Tue")
 		assertDayInWeekOverviewForGoal(currentWeekOverviewAfterActivity, budgetGoalNews, expectedValuesRichardLastWeekAfterActivity, "Wed")
 		assertDayInWeekOverviewForGoal(currentWeekOverviewAfterActivity, budgetGoalNews, expectedValuesRichardLastWeekAfterActivity, "Thu")
@@ -574,7 +574,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseDayOverviewsAllBeforeDelete = appService.getDayActivityOverviews(richard, ["size": 14])
 
 		assertWeekOverviewBasics(responseWeekOverviewsBeforeDelete, expectedGoalsPerWeekBeforeDelete, expectedTotalWeeksBeforeDelete)
-		def weekOverviewLastWeekBeforeDelete = responseWeekOverviewsBeforeDelete.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeekBeforeDelete = responseWeekOverviewsBeforeDelete.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeekBeforeDelete, budgetGoalNews, 6)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeekBeforeDelete, budgetGoalNews, expectedValuesRichardLastWeekBeforeDelete, "Mon")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeekBeforeDelete, budgetGoalNews, expectedValuesRichardLastWeekBeforeDelete, "Tue")
@@ -620,7 +620,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseWeekOverviewsAfterDelete = appService.getWeekActivityOverviews(richard)
 		assertWeekOverviewBasics(responseWeekOverviewsAfterDelete, expectedGoalsPerWeekAfterDelete, expectedTotalWeeksAfterDelete)
 
-		def weekOverviewLastWeekAfterDelete = responseWeekOverviewsAfterDelete.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeekAfterDelete = responseWeekOverviewsAfterDelete.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeekAfterDelete, timeZoneGoalSocial, 4)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeekAfterDelete, timeZoneGoalSocial, expectedValuesRichardLastWeekAfterDelete, "Wed")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeekAfterDelete, timeZoneGoalSocial, expectedValuesRichardLastWeekAfterDelete, "Thu")
@@ -639,7 +639,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseWeekOverviewsNewActivity = appService.getWeekActivityOverviews(richard)
 		assertWeekOverviewBasics(responseWeekOverviewsNewActivity, expectedGoalsPerWeekAfterDelete, expectedTotalWeeksAfterDelete)
 
-		def weekOverviewLastWeekAfterNewActivity = responseWeekOverviewsNewActivity.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeekAfterNewActivity = responseWeekOverviewsNewActivity.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeekAfterNewActivity, timeZoneGoalSocial, 4)
 
 		def responseDayOverviewsAllAfterNewActivity = appService.getDayActivityOverviews(richard, ["size": 14])
@@ -742,7 +742,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 2, 2], expectedTotalWeeks, expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewWeekBeforeLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2]
+		def weekOverviewWeekBeforeLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[2]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewWeekBeforeLastWeek, budgetGoalMultimediaBeforeUpdate, 5)
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalMultimediaBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Tue")
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalMultimediaBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Wed")
@@ -750,7 +750,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalMultimediaBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Fri")
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalMultimediaBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Sat")
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalMultimediaAfterUpdate, 7)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalMultimediaBeforeUpdate, expectedValuesRichardLastWeek, "Sun")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalMultimediaAfterUpdate, expectedValuesRichardLastWeek, "Mon")
@@ -900,7 +900,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 3, 2], expectedTotalWeeks, expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewWeekBeforeLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2]
+		def weekOverviewWeekBeforeLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[2]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewWeekBeforeLastWeek, budgetGoalNewsRichardBeforeUpdate, 6)
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Mon")
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Tue")
@@ -909,7 +909,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Fri")
 		assertDayInWeekOverviewForGoal(weekOverviewWeekBeforeLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardWeekBeforeLastWeek, "Sat")
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalNewsRichardAfterUpdate, 7)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardLastWeek, "Sun")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichardBeforeUpdate, expectedValuesRichardLastWeek, "Mon")
@@ -980,7 +980,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Sat")
 
-		def weekOverviewBuddyWeekBeforeLastWeek = responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2]
+		def weekOverviewBuddyWeekBeforeLastWeek = responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[2]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, 3)
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobWeekBeforeLastWeek, "Thu")
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobWeekBeforeLastWeek, "Fri")
@@ -1023,7 +1023,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Sat")
 
-		def weekOverviewBuddyLastWeek = responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewBuddyLastWeek = responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewBuddyLastWeek, budgetGoalSocialBobAfterUpdate, 7)
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobLastWeek, "Sun")
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobLastWeek, "Mon")
@@ -1172,7 +1172,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [2, 2, 1], expectedTotalWeeksRichard, expectedTotalWeeksRichard)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, timeZoneGoalSocialRichardAfterUpdate, 3)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalSocialRichardBeforeUpdate, expectedValuesRichardLastWeek, "Thu")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, timeZoneGoalSocialRichardAfterUpdate, expectedValuesRichardLastWeek, "Fri")
@@ -1197,7 +1197,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Sat")
 
-		def weekOverviewBuddyWeekBeforeLastWeek = responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[2]
+		def weekOverviewBuddyWeekBeforeLastWeek = responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[2]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, 3)
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobWeekBeforeLastWeek, "Thu")
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyWeekBeforeLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobWeekBeforeLastWeek, "Fri")
@@ -1232,7 +1232,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, MULTIMEDIA_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Sat")
 
-		def weekOverviewBuddyLastWeek = responseBuddyWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewBuddyLastWeek = responseBuddyWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewBuddyLastWeek, budgetGoalSocialBobAfterUpdate, 7)
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobLastWeek, "Sun")
 		assertDayInWeekOverviewForGoal(weekOverviewBuddyLastWeek, budgetGoalSocialBobBeforeUpdate, expectedValuesBobLastWeek, "Mon")
@@ -1289,7 +1289,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		richard.buddies[0].dailyActivityReportsUrl == null
 		richard.buddies[0].weeklyActivityReportsUrl == null
 		assertResponseStatusOk(responseDayOverviewsWithBuddies)
-		responseDayOverviewsWithBuddies.responseData?._embedded == null // Richard doesn't know Bob's goals yet
+		responseDayOverviewsWithBuddies.json?._embedded == null // Richard doesn't know Bob's goals yet
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -1315,11 +1315,11 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(responseDayOverviewsWithBuddies)
-		responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[0].dayActivities.find { it._links."yona:activityCategory"?.href == GAMBLING_ACT_CAT_URL }.dayActivitiesForUsers.size() == 2
+		responseDayOverviewsWithBuddies.json._embedded."yona:dayActivityOverviews"[0].dayActivities.find { it._links."yona:activityCategory"?.href == GAMBLING_ACT_CAT_URL }.dayActivitiesForUsers.size() == 2
 		def responseWeekOverviews = appService.getWeekActivityOverviews(bob, bob.buddies[0])
 		assertResponseStatusOk(responseWeekOverviews)
-		responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalGamblingRichard.url }
-		def weekActivityForGoal = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalGamblingRichard.url }
+		responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalGamblingRichard.url }
+		def weekActivityForGoal = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0].weekActivities.find { it._links."yona:goal".href == budgetGoalGamblingRichard.url }
 		def dayActivityInWeekForGoal = weekActivityForGoal.dayActivities[YonaServer.now.dayOfWeek.toString()]
 		dayActivityInWeekForGoal.totalActivityDurationMinutes == 0
 
@@ -1357,13 +1357,13 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._embedded."yona:activities".size == 2
-		response.responseData._embedded."yona:activities"[0].startTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActStartTime))
-		response.responseData._embedded."yona:activities"[0].endTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActEndTime))
-		response.responseData._embedded."yona:activities"[0].app == app
-		response.responseData._embedded."yona:activities"[1].startTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(netActStartTime))
-		response.responseData._embedded."yona:activities"[1].endTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(netActStartTime).plusMinutes(1))
-		response.responseData._embedded."yona:activities"[1].app == ""
+		response.json._embedded."yona:activities".size == 2
+		response.json._embedded."yona:activities"[0].startTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActStartTime))
+		response.json._embedded."yona:activities"[0].endTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(appActEndTime))
+		response.json._embedded."yona:activities"[0].app == app
+		response.json._embedded."yona:activities"[1].startTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(netActStartTime))
+		response.json._embedded."yona:activities"[1].endTime == YonaServer.toIsoDateTimeString(YonaServer.relativeDateTimeStringToZonedDateTime(netActStartTime).plusMinutes(1))
+		response.json._embedded."yona:activities"[1].app == ""
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -1388,7 +1388,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.invalid.date"
+		assert response.json.code == "error.invalid.date"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -1466,7 +1466,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, NEWS_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, NEWS_ACT_CAT_URL, expectedValuesWithBuddiesWeekBeforeLastWeek, 2, "Sat")
 
-		def thu2 = responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[YonaServer.relativeDateStringToDaysOffset(2, "Thu")]
+		def thu2 = responseDayOverviewsWithBuddies.json._embedded."yona:dayActivityOverviews"[YonaServer.relativeDateStringToDaysOffset(2, "Thu")]
 		thu2.dayActivities.find { it._links."yona:activityCategory".href == SOCIAL_ACT_CAT_URL } == null // Richard has social but none of his buddies has it, so it's not included
 		thu2.dayActivities.find { it._links."yona:activityCategory".href == MULTIMEDIA_ACT_CAT_URL } != null // Buddy has multimedia, so it's included, though Richard doesn't have it
 		thu2.dayActivities.find { it._links."yona:activityCategory".href == MULTIMEDIA_ACT_CAT_URL }.dayActivitiesForUsers.size() == 1 // Only Bob
@@ -1483,7 +1483,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, NEWS_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Fri")
 		assertDayOverviewWithBuddies(responseDayOverviewsWithBuddies, richard, NEWS_ACT_CAT_URL, expectedValuesWithBuddiesLastWeek, 1, "Sat")
 
-		def mon1 = responseDayOverviewsWithBuddies.responseData._embedded."yona:dayActivityOverviews"[YonaServer.relativeDateStringToDaysOffset(1, "Mon")]
+		def mon1 = responseDayOverviewsWithBuddies.json._embedded."yona:dayActivityOverviews"[YonaServer.relativeDateStringToDaysOffset(1, "Mon")]
 		mon1.dayActivities.find { it._links."yona:activityCategory".href == SOCIAL_ACT_CAT_URL } == null // Nobody has social, so it's not included
 		mon1.dayActivities.find { it._links."yona:activityCategory".href == MULTIMEDIA_ACT_CAT_URL } != null // Buddy has multimedia, so it's included
 		mon1.dayActivities.find { it._links."yona:activityCategory".href == MULTIMEDIA_ACT_CAT_URL }.dayActivitiesForUsers.size() == 1 // Only Bob
@@ -1515,7 +1515,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(responseDayOverviewsWithBuddies)
-		responseDayOverviewsWithBuddies.responseData?._embedded == null // Richard doesn't know Bob's goals anymore
+		responseDayOverviewsWithBuddies.json?._embedded == null // Richard doesn't know Bob's goals anymore
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -1609,7 +1609,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 3], expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalNewsRichard, 6)
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, timeZoneGoalSocialRichard, 6)
@@ -1628,10 +1628,10 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayDetail(richardDefault, responseDayOverviewsAll, timeZoneGoalSocialRichard, expectedValuesRichardLastWeek, 1, "Mon")
 
 		def responseRawDataNews = getRawActivityData(richardDefault, "W-1 Mon 00:00", budgetGoalNewsRichard)
-		assertRawActivityData(responseRawDataNews.responseData._embedded."yona:activities", expectedRawValuesNewsMon)
+		assertRawActivityData(responseRawDataNews.json._embedded."yona:activities", expectedRawValuesNewsMon)
 
 		def responseRawDataSocial = getRawActivityData(richardDefault, "W-1 Mon 00:00", timeZoneGoalSocialRichard)
-		assertRawActivityData(responseRawDataSocial.responseData._embedded."yona:activities", expectedRawValuesSocialMon)
+		assertRawActivityData(responseRawDataSocial.json._embedded."yona:activities", expectedRawValuesSocialMon)
 
 		richardDefault.requestingDevice.lastMonitoredActivityDate == YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Mon 00:00").toLocalDate()
 		richardIphone.requestingDevice.lastMonitoredActivityDate == YonaServer.relativeDateTimeStringToZonedDateTime("W-1 Tue 00:00").toLocalDate()
@@ -1676,7 +1676,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseWeekOverviews, [3, 2], expectedTotalWeeks)
 		assertWeekDateForCurrentWeek(responseWeekOverviews)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalSocialRichard, 6)
 
@@ -1782,10 +1782,10 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertWeekOverviewBasics(responseBuddyWeekOverviewsBea, [2, 2, 2], 3, 100)
 
 		// W-3
-		responseBuddyWeekOverviewsBea.responseData._embedded."yona:weekActivityOverviews".size() == 3 // No data for W-3
+		responseBuddyWeekOverviewsBea.json._embedded."yona:weekActivityOverviews".size() == 3 // No data for W-3
 
 		// W-2
-		def buddyWeekOverviewWeekM2Bea = responseBuddyWeekOverviewsBea.responseData._embedded."yona:weekActivityOverviews"[2]
+		def buddyWeekOverviewWeekM2Bea = responseBuddyWeekOverviewsBea.json._embedded."yona:weekActivityOverviews"[2]
 		assertNumberOfReportedDaysForGoalInWeekOverview(buddyWeekOverviewWeekM2Bea, budgetGoalSocialBea, 4)
 		assertNumberOfReportedDaysForGoalInWeekOverview(buddyWeekOverviewWeekM2Bea, noGoGoalGamblingBea, 4)
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM2Bea, budgetGoalSocialBea, expectedValuesBeaWeekM2, "Wed")
@@ -1797,10 +1797,10 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM2Bea, noGoGoalGamblingBea, expectedValuesBeaWeekM2, "Fri")
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM2Bea, noGoGoalGamblingBea, expectedValuesBeaWeekM2, "Sat")
 
-		responseBuddyWeekOverviewsBob.responseData._embedded."yona:weekActivityOverviews".size() == 2 // No data for W-2
+		responseBuddyWeekOverviewsBob.json._embedded."yona:weekActivityOverviews".size() == 2 // No data for W-2
 
 		// W-1
-		def buddyWeekOverviewWeekM1Bea = responseBuddyWeekOverviewsBea.responseData._embedded."yona:weekActivityOverviews"[1]
+		def buddyWeekOverviewWeekM1Bea = responseBuddyWeekOverviewsBea.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(buddyWeekOverviewWeekM1Bea, budgetGoalSocialBea, 7)
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bea, budgetGoalSocialBea, expectedValuesBeaWeekM1, "Sun")
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bea, budgetGoalSocialBea, expectedValuesBeaWeekM1, "Mon")
@@ -1817,7 +1817,7 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bea, noGoGoalGamblingBea, expectedValuesBeaWeekM1, "Fri")
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bea, noGoGoalGamblingBea, expectedValuesBeaWeekM1, "Sat")
 
-		def buddyWeekOverviewWeekM1Bob = responseBuddyWeekOverviewsBob.responseData._embedded."yona:weekActivityOverviews"[1]
+		def buddyWeekOverviewWeekM1Bob = responseBuddyWeekOverviewsBob.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(buddyWeekOverviewWeekM1Bob, budgetGoalNewsBob, 3)
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bob, budgetGoalNewsBob, expectedValuesBobWeekM1, "Thu")
 		assertDayInWeekOverviewForGoal(buddyWeekOverviewWeekM1Bob, budgetGoalNewsBob, expectedValuesBobWeekM1, "Fri")
@@ -1831,8 +1831,8 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		def responseBuddyDayOverviewsBob = appService.getDayActivityOverviews(richard, buddyBob, ["size": 100])
 
 		then:
-		responseBuddyDayOverviewsBea.responseData._embedded."yona:dayActivityOverviews".size() == expectedTotalDaysBea
-		responseBuddyDayOverviewsBob.responseData._embedded."yona:dayActivityOverviews".size() == expectedTotalDaysBob
+		responseBuddyDayOverviewsBea.json._embedded."yona:dayActivityOverviews".size() == expectedTotalDaysBea
+		responseBuddyDayOverviewsBob.json._embedded."yona:dayActivityOverviews".size() == expectedTotalDaysBob
 
 		// W-2
 		assertDayDetail(richard, responseBuddyDayOverviewsBea, budgetGoalSocialBea, expectedValuesBeaWeekM2, 2, "Wed")
@@ -2079,20 +2079,20 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 				.toFormatter(YonaServer.EN_US_LOCALE)
 
 		String currentWeek = weekFormatter.format(YonaServer.now)
-		assert responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[0].date == currentWeek || isSunday
+		assert responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[0].date == currentWeek || isSunday
 	}
 
 	private void assertWeekDetailPrevNextLinks(User user, weekActivityForGoal, expectedPrevWeekForGoal, expectedNextWeekForGoal)
 	{
 		def weekDetails = appService.getWeekDetailsForWeekFromOverviewItem(user, weekActivityForGoal)
-		assert weekDetails?.responseData?._links?."prev"?.href == expectedPrevWeekForGoal?._links?."yona:weekDetails"?.href
-		assert weekDetails?.responseData?._links?."next"?.href == expectedNextWeekForGoal?._links?."yona:weekDetails"?.href
+		assert weekDetails?.json?._links?."prev"?.href == expectedPrevWeekForGoal?._links?."yona:weekDetails"?.href
+		assert weekDetails?.json?._links?."next"?.href == expectedNextWeekForGoal?._links?."yona:weekDetails"?.href
 	}
 
 	private void assertDayDetailPrevNextLinks(User user, dayActivityForGoal, expectedPrevDayForGoal, expectedNextDayForGoal)
 	{
 		def dayDetails = appService.getDayDetailsForDayFromOverviewItem(user, dayActivityForGoal)
-		assert dayDetails?.responseData?._links?."prev"?.href == expectedPrevDayForGoal?._links?."yona:dayDetails"?.href
-		assert dayDetails?.responseData?._links?."next"?.href == expectedNextDayForGoal?._links?."yona:dayDetails"?.href
+		assert dayDetails?.json?._links?."prev"?.href == expectedPrevDayForGoal?._links?."yona:dayDetails"?.href
+		assert dayDetails?.json?._links?."next"?.href == expectedNextDayForGoal?._links?."yona:dayDetails"?.href
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/AppActivityTest.groovy
@@ -40,7 +40,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -65,7 +65,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
-		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesRichard = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesRichard.size() == 1
 		goalConflictMessagesRichard[0].nickname == "RQ (me)"
 		assertEquals(goalConflictMessagesRichard[0].creationTime as String, goalConflictTime)
@@ -73,7 +73,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesBob = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesBob.size() == 1
 		goalConflictMessagesBob[0].nickname == richard.nickname
 		assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
@@ -110,7 +110,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
-		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesRichard = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesRichard.size() == 1
 		goalConflictMessagesRichard[0].nickname == "RQ (me)"
 		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
@@ -118,7 +118,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesBob = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesBob.size() == 1
 		goalConflictMessagesBob[0].nickname == richard.nickname
 		assertEquals(goalConflictMessagesBob[0].creationTime, goalConflictTime)
@@ -152,12 +152,12 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesRichard = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesRichard.size() == 1
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesBob = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesBob.size() == 1
 
 		cleanup:
@@ -187,7 +187,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
 		ZonedDateTime goalConflictTime = YonaServer.now
-		def goalConflictMessagesRichard = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesRichard = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesRichard.size() == 1
 		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
 		assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
@@ -195,7 +195,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def goalConflictMessagesBob = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesBob = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessagesBob.size() == 1
 		assertEquals(goalConflictMessagesRichard[0].creationTime, goalConflictTime)
 		assertEquals(goalConflictMessagesRichard[0].activityStartTime, startTime)
@@ -224,7 +224,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" } == null
+		getMessagesRichardResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" } == null
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -245,7 +245,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.analysis.invalid.app.activity.data.end.before.start"
+		response.json.code == "error.analysis.invalid.app.activity.data.end.before.start"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -267,7 +267,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.analysis.invalid.app.activity.data.ends.in.future"
+		response.json.code == "error.analysis.invalid.app.activity.data.ends.in.future"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -289,7 +289,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.analysis.invalid.app.activity.data.starts.in.future"
+		response.json.code == "error.analysis.invalid.app.activity.data.starts.in.future"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -309,7 +309,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(responseNoActivities, 400)
-		responseNoActivities.responseData.message ==~ /(?s).*Missing required creator property 'activities'.*/
+		responseNoActivities.json.message ==~ /(?s).*Missing required creator property 'activities'.*/
 
 		when:
 		def requestJsonNoDeviceDateTime = """{
@@ -319,7 +319,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(responseNoDeviceDateTime, 400)
-		responseNoDeviceDateTime.responseData.message ==~ /(?s).*Missing required creator property 'deviceDateTime'.*/
+		responseNoDeviceDateTime.json.message ==~ /(?s).*Missing required creator property 'deviceDateTime'.*/
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -347,7 +347,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size()
+		getMessagesRichardResponse.json._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size()
 		// Don't poke into the messages. The app activity spans many days and we only support activities spanning at most two days
 
 		cleanup:
@@ -374,7 +374,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		def response = appService.getDayDetails(richard, GAMBLING_ACT_CAT_URL, appActStartTime)
 		assertResponseStatusOk(response)
-		assert response.responseData.totalActivityDurationMinutes == Duration.between(appActStartTime, appActEndTime).toMinutes()
+		assert response.json.totalActivityDurationMinutes == Duration.between(appActStartTime, appActEndTime).toMinutes()
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -405,7 +405,7 @@ class AppActivityTest extends AbstractAppServiceIntegrationTest
 		then:
 		def response = appService.getDayDetails(richard, GAMBLING_ACT_CAT_URL, appActOneStartTime)
 		assertResponseStatusOk(response)
-		assert response.responseData.totalActivityDurationMinutes == Duration.between(appActOneStartTime, appActTwoEndTime).toMinutes() + netActDuration
+		assert response.json.totalActivityDurationMinutes == Duration.between(appActOneStartTime, appActTwoEndTime).toMinutes() + netActDuration
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BasicBuddyTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -48,7 +48,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.buddy.only.twoway.buddies.allowed"
+		response.json.code == "error.buddy.only.twoway.buddies.allowed"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -69,10 +69,10 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 201)
-		response.responseData._embedded."yona:user".firstName == bobby.firstName
-		response.responseData._embedded."yona:user".lastName == bobby.lastName
-		response.responseData._links."yona:user" == null
-		response.responseData._links.self.href.startsWith(YonaServer.stripQueryString(richard.url))
+		response.json._embedded."yona:user".firstName == bobby.firstName
+		response.json._embedded."yona:user".lastName == bobby.lastName
+		response.json._links."yona:user" == null
+		response.json._links.self.href.startsWith(YonaServer.stripQueryString(richard.url))
 
 		User richardWithBuddy = appService.reloadUser(richard)
 		richardWithBuddy.buddies != null
@@ -107,8 +107,8 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._embedded."yona:messages".size() == 1
-		def buddyConnectRequestMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
+		response.json._embedded."yona:messages".size() == 1
+		def buddyConnectRequestMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
 		buddyConnectRequestMessages.size() == 1
 		buddyConnectRequestMessages[0].nickname == richard.nickname
 		assertEquals(buddyConnectRequestMessages[0].creationTime as String, YonaServer.now)
@@ -144,11 +144,11 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.properties.status == "done"
-		response.responseData._embedded."yona:affectedMessages".size() == 1
-		response.responseData._embedded."yona:affectedMessages"[0]._links.self.href == connectRequestMessage.selfUrl
-		response.responseData._embedded."yona:affectedMessages"[0].status == "ACCEPTED"
-		response.responseData._embedded."yona:affectedMessages"[0]._links.keySet() == ["self", "edit", "yona:markRead"] as Set
+		response.json.properties.status == "done"
+		response.json._embedded."yona:affectedMessages".size() == 1
+		response.json._embedded."yona:affectedMessages"[0]._links.self.href == connectRequestMessage.selfUrl
+		response.json._embedded."yona:affectedMessages"[0].status == "ACCEPTED"
+		response.json._embedded."yona:affectedMessages"[0]._links.keySet() == ["self", "edit", "yona:markRead"] as Set
 
 		List<Buddy> buddies = appService.getBuddies(bob)
 		buddies.size() == 1
@@ -168,8 +168,8 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		def getMessagesResponse = appService.getMessages(bob)
 
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
-		def buddyConnectRequestMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
+		getMessagesResponse.json._embedded."yona:messages".size() == 1
+		def buddyConnectRequestMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
 		buddyConnectRequestMessages.size() == 1
 		buddyConnectRequestMessages[0].nickname == richard.nickname
 		assertEquals(buddyConnectRequestMessages[0].creationTime as String, YonaServer.now)
@@ -204,7 +204,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		def buddyConnectResponseMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		buddyConnectResponseMessages[0]._links."yona:user".href.startsWith(YonaServer.stripQueryString(bob.url))
 		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
@@ -256,7 +256,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getBuddyUserGoalsResponse = appService.yonaServer.getJson(richard.buddies[0].user.goalsUrl, [:], ["Yona-Password": richard.password])
 		assertResponseStatusOk(getBuddyUserGoalsResponse)
-		getBuddyUserGoalsResponse.responseData._embedded."yona:goals".size() == 2
+		getBuddyUserGoalsResponse.json._embedded."yona:goals".size() == 2
 
 		buddiesRichard[0].user.goals.size() == 2
 		buddiesRichard[0].user.devices.size() == 1
@@ -299,7 +299,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
 		assertEquals(richardGoalConflictMessages[0].creationTime as String, now)
@@ -313,7 +313,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == richard.nickname
 		assertEquals(bobGoalConflictMessages[0].creationTime as String, now)
@@ -346,13 +346,13 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == bob.nickname
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == "BD (me)"
 
@@ -375,11 +375,11 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -406,7 +406,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == bob.nickname
 		richardGoalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
@@ -416,13 +416,13 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		dayActivityDetailUrlRichard
 		def dayActivityDetailRichard = appService.getResourceWithPassword(dayActivityDetailUrlRichard, richard.password)
 		assertResponseStatusOk(dayActivityDetailRichard)
-		dayActivityDetailRichard.responseData.date == YonaServer.toIsoDateString(goalConflictTime)
-		dayActivityDetailRichard.responseData._links."yona:goal".href == goalBuddyBob.url
-		dayActivityDetailRichard.responseData.totalMinutesBeyondGoal == 1
+		dayActivityDetailRichard.json.date == YonaServer.toIsoDateString(goalConflictTime)
+		dayActivityDetailRichard.json._links."yona:goal".href == goalBuddyBob.url
+		dayActivityDetailRichard.json.totalMinutesBeyondGoal == 1
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == "BD (me)"
 		bobGoalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
@@ -432,9 +432,9 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		dayActivityDetailUrlBob
 		def dayActivityDetailBob = appService.getResourceWithPassword(dayActivityDetailUrlBob, bob.password)
 		assertResponseStatusOk(dayActivityDetailBob)
-		dayActivityDetailBob.responseData.date == YonaServer.toIsoDateString(goalConflictTime)
-		dayActivityDetailBob.responseData._links."yona:goal".href == goalBob.url
-		dayActivityDetailBob.responseData.totalMinutesBeyondGoal == 1
+		dayActivityDetailBob.json.date == YonaServer.toIsoDateString(goalConflictTime)
+		dayActivityDetailBob.json._links."yona:goal".href == goalBob.url
+		dayActivityDetailBob.json.totalMinutesBeyondGoal == 1
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -461,7 +461,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].url == url
 
@@ -469,7 +469,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].url == null
 
@@ -493,7 +493,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].url == url.substring(0, 2048)
 
@@ -501,7 +501,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].url == null
 
@@ -540,16 +540,16 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessages" }.size() == 0
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessages" }.size() == 0
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
 		richardGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessages" }.size() == 0
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessages" }.size() == 0
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == "BD (me)"
 		bobGoalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
@@ -576,7 +576,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		def buddyDisconnectMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		def buddyDisconnectMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 		buddyDisconnectMessages[0].reason == "USER_REMOVED_BUDDY"
 		buddyDisconnectMessages[0].nickname == "${richard.nickname}"
@@ -619,7 +619,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 
-		def buddyDisconnectMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		def buddyDisconnectMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 		buddyDisconnectMessages[0].reason == "USER_REMOVED_BUDDY"
 		buddyDisconnectMessages[0].nickname == "${bob.nickname}"
@@ -679,7 +679,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		appService.getBuddies(richard).size() == 0 // Buddy removed for Richard
 
 		// Connect request message is removed, so Bob doesn't have any messages
-		appService.getMessages(bob).responseData.page.totalElements == 0
+		appService.getMessages(bob).json.page.totalElements == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -830,7 +830,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 	private void processBuddyDisconnectMessage(User user)
 	{
-		def disconnectMessage = appService.getMessages(user).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }[0]
+		def disconnectMessage = appService.getMessages(user).json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }[0]
 		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 	}
 
@@ -839,7 +839,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		analysisService.postToAnalysisEngine(user.requestingDevice, ["Gambling"], "http://www.poker.com")
 		def responseGetMessagesBuddy = appService.getMessages(buddy)
 		assertResponseStatusOk(responseGetMessagesBuddy)
-		def goalConflictMessagesBuddy = responseGetMessagesBuddy.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesBuddy = responseGetMessagesBuddy.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		assert goalConflictMessagesBuddy.size() == 1
 		assert goalConflictMessagesBuddy[0].nickname == user.nickname
 		assert goalConflictMessagesBuddy[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
@@ -850,7 +850,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 
 		def responseGetMessagesUser = appService.getMessages(user)
 		assertResponseStatusOk(responseGetMessagesUser)
-		def goalConflictMessagesUser = responseGetMessagesUser.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesUser = responseGetMessagesUser.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		assert goalConflictMessagesUser.size() == 1
 		def responseDeleteMessageUser = appService.deleteResourceWithPassword(goalConflictMessagesUser[0]._links.edit.href, user.password)
 		assertResponseStatusOk(responseDeleteMessageUser)
@@ -861,11 +861,11 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		analysisService.postToAnalysisEngine(user.requestingDevice, ["Gambling"], "http://www.poker.com")
 		def responseGetMessagesBuddy = appService.getMessages(buddy)
 		assertResponseStatusOk(responseGetMessagesBuddy)
-		assert responseGetMessagesBuddy.responseData._embedded?."yona:messages"?.find { it."@type" == "GoalConflictMessage" } == null
+		assert responseGetMessagesBuddy.json._embedded?."yona:messages"?.find { it."@type" == "GoalConflictMessage" } == null
 
 		def responseGetMessagesUser = appService.getMessages(user)
 		assertResponseStatusOk(responseGetMessagesUser)
-		def goalConflictMessagesUser = responseGetMessagesUser.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessagesUser = responseGetMessagesUser.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		assert goalConflictMessagesUser.size() == 1
 		def responseDeleteMessageUser = appService.deleteResourceWithPassword(goalConflictMessagesUser[0]._links.edit.href, user.password)
 		assertResponseStatusOk(responseDeleteMessageUser)
@@ -908,7 +908,7 @@ class BasicBuddyTest extends AbstractAppServiceIntegrationTest
 		void assertSuccess()
 		{
 			assertResponseStatusOk(response)
-			def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+			def buddyConnectResponseMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 			buddyConnectResponseMessages[0]._links."yona:user".href.startsWith(YonaServer.stripQueryString(bob.url))
 			buddyConnectResponseMessages[0]._embedded?."yona:user" == null
 			buddyConnectResponseMessages[0].nickname == bob.nickname

--- a/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/BuddyValidationTest.groovy
@@ -39,7 +39,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.firstname"
+		response.json.code == "error.user.firstname"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -56,7 +56,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.lastname"
+		response.json.code == "error.user.lastname"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -73,7 +73,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.mobile.number"
+		response.json.code == "error.user.mobile.number"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -90,7 +90,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.mobile.number.invalid"
+		response.json.code == "error.user.mobile.number.invalid"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -107,7 +107,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.email.address"
+		response.json.code == "error.user.email.address"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -128,11 +128,11 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response1, 400)
-		response1.responseData.code == "error.user.email.address.invalid"
+		response1.json.code == "error.user.email.address.invalid"
 		assertResponseStatus(response2, 400)
-		response2.responseData.code == "error.user.email.address.invalid"
+		response2.json.code == "error.user.email.address.invalid"
 		assertResponseStatus(response3, 400)
-		response3.responseData.code == "error.user.email.address.invalid"
+		response3.json.code == "error.user.email.address.invalid"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -149,7 +149,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.buddy.cannot.invite.self"
+		response.json.code == "error.buddy.cannot.invite.self"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -168,7 +168,7 @@ class BuddyValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.buddy.cannot.invite.existing.buddy"
+		response.json.code == "error.buddy.cannot.invite.existing.buddy"
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/CreateUserOnBuddyRequestTest.groovy
@@ -34,7 +34,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.mobile.number.not.confirmed"
+		response.json.code == "error.mobile.number.not.confirmed"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -50,11 +50,11 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 201)
-		response.responseData._embedded."yona:user".firstName == "Bobby"
-		response.responseData._embedded."yona:user".lastName == "Dun"
-		response.responseData._embedded."yona:user".appLastOpenedDate == null
-		response.responseData._links."yona:user" == null
-		response.responseData._links.self.href.startsWith(YonaServer.stripQueryString(richard.url))
+		response.json._embedded."yona:user".firstName == "Bobby"
+		response.json._embedded."yona:user".lastName == "Dun"
+		response.json._embedded."yona:user".appLastOpenedDate == null
+		response.json._links."yona:user" == null
+		response.json._links.self.href.startsWith(YonaServer.stripQueryString(richard.url))
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -112,7 +112,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getUserResponse = appService.getUser(inviteUrl, null)
 		assertResponseStatus(getUserResponse, 400)
-		getUserResponse.responseData.code == "error.decrypting.data"
+		getUserResponse.json.code == "error.decrypting.data"
 
 		User bobFromGetAfterUpdate = appService.reloadUser(updatedBob)
 		bobFromGetAfterUpdate.firstName == newFirstName
@@ -125,7 +125,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.yonaServer.getJsonWithPassword(YonaServer.stripQueryString(bobFromGetAfterUpdate.url) + "/messages/", bobFromGetAfterUpdate.password)
 		assertResponseStatus(getMessagesResponse, 400)
-		getMessagesResponse.responseData.code == "error.mobile.number.not.confirmed"
+		getMessagesResponse.json.code == "error.mobile.number.not.confirmed"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -216,11 +216,11 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getUserResponse = appService.getUser(updatedBob.url, updatedBob.password)
 		assertResponseStatusOk(getUserResponse)
-		getUserResponse.responseData._embedded."yona:goals"._embedded."yona:goals"
-		getUserResponse.responseData._embedded."yona:goals"._embedded."yona:goals".size() == 1 //mandatory goal
+		getUserResponse.json._embedded."yona:goals"._embedded."yona:goals"
+		getUserResponse.json._embedded."yona:goals"._embedded."yona:goals".size() == 1 //mandatory goal
 		def getMessagesResponse = appService.getMessages(updatedBob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 1 // The buddy request from Richard
+		getMessagesResponse.json._embedded."yona:messages".size() == 1 // The buddy request from Richard
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -292,7 +292,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		def buddyConnectResponseMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages[0]._links?."yona:user"?.href?.startsWith(YonaServer.stripQueryString(bob.url))
 		buddyConnectResponseMessages[0]._embedded?."yona:user" == null
 		buddyConnectResponseMessages[0].nickname == newNickname
@@ -341,7 +341,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
 		richardGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
@@ -349,7 +349,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(updatedBob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == richard.nickname
 		bobGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
@@ -391,7 +391,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -415,7 +415,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -432,7 +432,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.not.created.on.buddy.request"
+		response.json.code == "error.user.not.created.on.buddy.request"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -453,7 +453,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.created.on.buddy.request"
+		response.json.code == "error.user.created.on.buddy.request"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -475,7 +475,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.not.created.on.buddy.request"
+		response.json.code == "error.user.not.created.on.buddy.request"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -512,10 +512,10 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
+		getMessagesResponse.json._embedded
+		getMessagesResponse.json._embedded."yona:messages".size() == 1
 
-		def buddyConnectResponseMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		def buddyConnectResponseMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
 		buddyConnectResponseMessage.message == "User account was deleted"
 		buddyConnectResponseMessage.nickname == "Bobby Dun"
@@ -557,7 +557,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		def richardGoalConflictMessages = getMessagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def richardGoalConflictMessages = getMessagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		richardGoalConflictMessages.size() == 1
 		richardGoalConflictMessages[0].nickname == "RQ (me)"
 		richardGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
@@ -565,7 +565,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		def bobGoalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def bobGoalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		bobGoalConflictMessages.size() == 1
 		bobGoalConflictMessages[0].nickname == richard.nickname
 		bobGoalConflictMessages[0]._links."yona:activityCategory".href == NEWS_ACT_CAT_URL
@@ -599,8 +599,8 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatus(response, expectedStatus)
 		if (expectedStatus == 400)
 		{
-			response.responseData.code == "error.request.missing.property"
-			response.responseData.message ==~ /^Mandatory property '$propertyToRemove'.*/
+			response.json.code == "error.request.missing.property"
+			response.json.message ==~ /^Mandatory property '$propertyToRemove'.*/
 		}
 
 		cleanup:
@@ -632,7 +632,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.exists"
+		response.json.code == "error.user.exists"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -642,13 +642,13 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	def assertUserCreationFailedBecauseOfDuplicate(response)
 	{
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.exists.created.on.buddy.request"
+		response.json.code == "error.user.exists.created.on.buddy.request"
 	}
 
 	def assertUserOverwriteResponseDetails(def response)
 	{
 		assertResponseStatusCreated(response)
-		assertUser(response.responseData)
+		assertUser(response.json)
 	}
 
 	def sendBuddyRequestForBobby(User user, String mobileNumber)
@@ -672,10 +672,10 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 	{
 		def response = appService.getLastEmail()
 		assertResponseStatusOk(response)
-		assert response.responseData.from == "Richard Quinn <noreply@yona.nu>"
-		assert response.responseData.to == "Bobby Dun <bobdunn325@gmail.com>"
-		assert response.responseData.subject == "Become friend of Richard Quinn on Yona!"
-		assert response.responseData.body ==~ /(?s).*Return to this mail and click <a href="http.*/
+		assert response.json.from == "Richard Quinn <noreply@yona.nu>"
+		assert response.json.to == "Bobby Dun <bobdunn325@gmail.com>"
+		assert response.json.subject == "Become friend of Richard Quinn on Yona!"
+		assert response.json.body ==~ /(?s).*Return to this mail and click <a href="http.*/
 		String inviteUrl = getInviteUrl(response)
 		assert inviteUrl ==~ /.*$ENCODED_TEST_TEMP_PASSWORD.*/
 	}
@@ -689,7 +689,7 @@ class CreateUserOnBuddyRequestTest extends AbstractAppServiceIntegrationTest
 
 	String getInviteUrl(response)
 	{
-		def matcher = response.responseData.body =~ /(?s).*Return to this mail and click <a href="([^"]*)".*/
+		def matcher = response.json.body =~ /(?s).*Return to this mail and click <a href="([^"]*)".*/
 		assert matcher.matches()
 		matcher[0][1]
 	}

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceManagementTest.groovy
@@ -37,22 +37,22 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
 		assertResponseStatusOk(getResponseAfter)
-		getResponseAfter.responseData.yonaPassword == null
-		getResponseAfter.responseData._links.self.href == richard.newDeviceRequestUrl
-		getResponseAfter.responseData._links.edit.href == richard.newDeviceRequestUrl
-		getResponseAfter.responseData._links."yona:user".href
+		getResponseAfter.json.yonaPassword == null
+		getResponseAfter.json._links.self.href == richard.newDeviceRequestUrl
+		getResponseAfter.json._links.edit.href == richard.newDeviceRequestUrl
+		getResponseAfter.json._links."yona:user".href
 		def baseUserUrl = YonaServer.stripQueryString(richard.url)
-		YonaServer.stripQueryString(getResponseAfter.responseData._links."yona:user".href) == baseUserUrl
+		YonaServer.stripQueryString(getResponseAfter.json._links."yona:user".href) == baseUserUrl
 		// The below assert checks the path fragment. If it fails, the Swagger spec needs to be updated too
-		getResponseAfter.responseData._links."yona:registerDevice".href == baseUserUrl + "/devices/"
+		getResponseAfter.json._links."yona:registerDevice".href == baseUserUrl + "/devices/"
 
 		def getWithPasswordResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusOk(getWithPasswordResponseAfter)
-		getWithPasswordResponseAfter.responseData.yonaPassword == richard.password
-		getWithPasswordResponseAfter.responseData._links.self.href == richard.newDeviceRequestUrl
-		getWithPasswordResponseAfter.responseData._links.edit.href == richard.newDeviceRequestUrl
-		getWithPasswordResponseAfter.responseData._links."yona:user".href
-		YonaServer.stripQueryString(getWithPasswordResponseAfter.responseData._links."yona:user".href) == YonaServer.stripQueryString(richard.url)
+		getWithPasswordResponseAfter.json.yonaPassword == richard.password
+		getWithPasswordResponseAfter.json._links.self.href == richard.newDeviceRequestUrl
+		getWithPasswordResponseAfter.json._links.edit.href == richard.newDeviceRequestUrl
+		getWithPasswordResponseAfter.json._links."yona:user".href
+		YonaServer.stripQueryString(getWithPasswordResponseAfter.json._links."yona:user".href) == YonaServer.stripQueryString(richard.url)
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -75,13 +75,13 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
 		assertResponseStatusOk(getResponseAfter)
-		getResponseAfter.responseData.yonaPassword == null
-		getResponseAfter.responseData._links.self.href == richard.newDeviceRequestUrl
-		getResponseAfter.responseData._links.edit.href == richard.newDeviceRequestUrl
-		getResponseAfter.responseData._links."yona:user".href
+		getResponseAfter.json.yonaPassword == null
+		getResponseAfter.json._links.self.href == richard.newDeviceRequestUrl
+		getResponseAfter.json._links.edit.href == richard.newDeviceRequestUrl
+		getResponseAfter.json._links."yona:user".href
 		def baseUserUrl = YonaServer.stripQueryString(richard.url)
-		YonaServer.stripQueryString(getResponseAfter.responseData._links."yona:user".href) == baseUserUrl
-		def registerUrl = getResponseAfter.responseData._links."yona:registerDevice".href
+		YonaServer.stripQueryString(getResponseAfter.json._links."yona:user".href) == baseUserUrl
+		def registerUrl = getResponseAfter.json._links."yona:registerDevice".href
 		// The below assert checks the path fragment. If it fails, the Swagger spec needs to be updated too
 		registerUrl == baseUserUrl + "/devices/"
 
@@ -92,7 +92,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusCreated(registerResponse)
 		assertUserGetResponseDetails(registerResponse, false)
 
-		def devices = registerResponse.responseData._embedded."yona:devices"._embedded."yona:devices"
+		def devices = registerResponse.json._embedded."yona:devices"._embedded."yona:devices"
 		devices.size == 2
 
 		def defaultDevice = (devices[0].name == newDeviceName) ? devices[1] : devices[0]
@@ -107,11 +107,11 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		// User self-link uses the new device as "requestingDeviceId"
 		def idOfNewDevice = extractDeviceId(newDevice._links.self.href)
-		registerResponse.responseData._links.self.href ==~ /.*requestingDeviceId=$idOfNewDevice.*/
+		registerResponse.json._links.self.href ==~ /.*requestingDeviceId=$idOfNewDevice.*/
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def deviceChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
+		def deviceChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
 
 		deviceChangeMessages.size() == 1
 		deviceChangeMessages[0]._links.keySet() == ["self", "edit", "yona:markRead", "yona:buddy", "yona:user"] as Set
@@ -140,7 +140,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(setResponse)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
 		assertResponseStatusOk(getResponseAfter)
-		def registerUrl = getResponseAfter.responseData._links."yona:registerDevice".href
+		def registerUrl = getResponseAfter.json._links."yona:registerDevice".href
 
 		when:
 		def newDeviceName = "My iPhone"
@@ -149,7 +149,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.device.request.invalid.password"
+		response.json.code == "error.device.request.invalid.password"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -168,7 +168,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.no.device.request.present"
+		response.json.code == "error.no.device.request.present"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -186,36 +186,36 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		when:
 		def response
-		response = appService.registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, null, "IOS", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
+		response = appService.registerNewDevice(getResponse.json._links."yona:registerDevice".href, newDeviceRequestPassword, null, "IOS", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.property"
-		response.responseData.message ==~ /^Mandatory property 'name'.*/
+		response.json.code == "error.request.missing.property"
+		response.json.message ==~ /^Mandatory property 'name'.*/
 
 		when:
-		response = appService.registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", null, Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
+		response = appService.registerNewDevice(getResponse.json._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", null, Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.property"
-		response.responseData.message ==~ /^Mandatory property 'operatingSystem'.*/
+		response.json.code == "error.request.missing.property"
+		response.json.message ==~ /^Mandatory property 'operatingSystem'.*/
 
 		when:
-		response = appService.registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", "IOS", null, Device.SUPPORTED_APP_VERSION_CODE)
+		response = appService.registerNewDevice(getResponse.json._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", "IOS", null, Device.SUPPORTED_APP_VERSION_CODE)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.property"
-		response.responseData.message ==~ /^Mandatory property 'appVersion'.*/
+		response.json.code == "error.request.missing.property"
+		response.json.message ==~ /^Mandatory property 'appVersion'.*/
 
 		when:
-		response = appService.registerNewDevice(getResponse.responseData._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", "IOS", Device.SOME_APP_VERSION, null)
+		response = appService.registerNewDevice(getResponse.json._links."yona:registerDevice".href, newDeviceRequestPassword, "TheName", "IOS", Device.SOME_APP_VERSION, null)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.property"
-		response.responseData.message ==~ /^Mandatory property 'appVersionCode'.*/
+		response.json.code == "error.request.missing.property"
+		response.json.message ==~ /^Mandatory property 'appVersionCode'.*/
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -235,7 +235,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, expectedStatus)
-		response.responseData.code == expectedCode
+		response.json.code == expectedCode
 
 		cleanup:
 		appService.deleteUser(user)
@@ -265,12 +265,12 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(responseWrongPassword, 400)
-		responseWrongPassword.responseData.code == "error.decrypting.data"
+		responseWrongPassword.json.code == "error.decrypting.data"
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusOk(getResponseAfter)
-		getResponseAfter.responseData.yonaPassword == richard.password
+		getResponseAfter.json.yonaPassword == richard.password
 		assertResponseStatus(responseWrongMobileNumber, 400)
-		responseWrongMobileNumber.responseData.code == "error.decrypting.data"
+		responseWrongMobileNumber.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -290,7 +290,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusOk(getResponseAfter)
-		getResponseAfter.responseData.yonaPassword == richard.password
+		getResponseAfter.json.yonaPassword == richard.password
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -311,11 +311,11 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber)
 		assertResponseStatus(getResponseAfter, 400)
-		getResponseAfter.responseData.code == "error.no.device.request.present"
+		getResponseAfter.json.code == "error.no.device.request.present"
 
 		def getWithPasswordResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatus(getWithPasswordResponseAfter, 400)
-		getWithPasswordResponseAfter.responseData.code == "error.no.device.request.present"
+		getWithPasswordResponseAfter.json.code == "error.no.device.request.present"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -335,12 +335,12 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(responseWrongPassword, 400)
-		responseWrongPassword.responseData.code == "error.decrypting.data"
+		responseWrongPassword.json.code == "error.decrypting.data"
 		def getResponseAfter = appService.getNewDeviceRequest(richard.mobileNumber, newDeviceRequestPassword)
 		assertResponseStatusOk(getResponseAfter)
-		getResponseAfter.responseData.yonaPassword == richard.password
+		getResponseAfter.json.yonaPassword == richard.password
 		assertResponseStatus(responseWrongMobileNumber, 400)
-		responseWrongMobileNumber.responseData.code == "error.decrypting.data"
+		responseWrongMobileNumber.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -368,7 +368,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def deviceChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
+		def deviceChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
 
 		deviceChangeMessages.size() == 1
 		deviceChangeMessages[0]._links.self != null
@@ -406,7 +406,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def deviceChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
+		def deviceChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
 
 		deviceChangeMessages.size() == 0
 
@@ -443,7 +443,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def deviceChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
+		def deviceChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" }
 
 		deviceChangeMessages.size() == 1
 		deviceChangeMessages[0]._links.self != null
@@ -473,8 +473,8 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.property"
-		response.responseData.message ==~ /^Mandatory property 'name'.*/
+		response.json.code == "error.request.missing.property"
+		response.json.message ==~ /^Mandatory property 'name'.*/
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -491,7 +491,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.invalid.device.name"
+		assert response.json.code == "error.device.invalid.device.name"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -510,7 +510,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.name.already.exists"
+		assert response.json.code == "error.device.name.already.exists"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -558,7 +558,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertWeekOverviewBasics(responseWeekOverviews, [2, 2], expectedTotalWeeks)
 
-		def weekOverviewLastWeek = responseWeekOverviews.responseData._embedded."yona:weekActivityOverviews"[1]
+		def weekOverviewLastWeek = responseWeekOverviews.json._embedded."yona:weekActivityOverviews"[1]
 		assertNumberOfReportedDaysForGoalInWeekOverview(weekOverviewLastWeek, budgetGoalNewsRichard, 6)
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Mon")
 		assertDayInWeekOverviewForGoal(weekOverviewLastWeek, budgetGoalNewsRichard, expectedValuesRichardLastWeek, "Tue")
@@ -591,7 +591,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def deviceChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" && it.message ==~ /^User deleted.*/ }
+		def deviceChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyDeviceChangeMessage" && it.message ==~ /^User deleted.*/ }
 
 		deviceChangeMessages.size() == 1
 		deviceChangeMessages[0]._links.self != null
@@ -619,7 +619,7 @@ class DeviceManagementTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.cannot.delete.last.one"
+		assert response.json.code == "error.device.cannot.delete.last.one"
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/DeviceTest.groovy
@@ -162,7 +162,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		def responseAppleMobileConfig = appService.yonaServer.getData(johnAfterNumberConfirmation.requestingDevice.appleMobileConfig, [:], ["Yona-Password": johnAfterNumberConfirmation.password])
 		assertResponseStatusOk(responseAppleMobileConfig)
 		assert responseAppleMobileConfig.contentType == "application/x-apple-aspen-config"
-		def appleMobileConfig = responseAppleMobileConfig.data
+		def appleMobileConfig = responseAppleMobileConfig.rawData
 		assert appleMobileConfig.contains("<string>${johnAfterNumberConfirmation.requestingDevice.vpnProfile.vpnLoginId}\\n${johnAfterNumberConfirmation.requestingDevice.vpnProfile.vpnPassword}</string>")
 	}
 
@@ -174,7 +174,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		User johnAsCreated = appService.addUser({
 			assertResponseStatus(it, 400)
-			assert it.responseData.code == "error.device.unknown.operating.system"
+			assert it.json.code == "error.device.unknown.operating.system"
 		}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "My Raspberry", "RASPBIAN", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
@@ -190,7 +190,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		User johnAsCreated = appService.addUser({
 			assertResponseStatus(it, 400)
-			assert it.responseData.code == "error.device.unknown.operating.system"
+			assert it.json.code == "error.device.unknown.operating.system"
 		}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "First device", "UNKNOWN", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
@@ -206,7 +206,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		User johnAsCreated = appService.addUser({
 			assertResponseStatus(it, 400)
-			assert it.responseData.code == "error.device.invalid.device.name"
+			assert it.json.code == "error.device.invalid.device.name"
 		}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "012345678901234567891", "IOS", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
@@ -247,7 +247,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 		when:
 		User johnAsCreated = appService.addUser({
 			assertResponseStatus(it, 400)
-			assert it.responseData.code == "error.device.invalid.device.name"
+			assert it.json.code == "error.device.invalid.device.name"
 		}, "John", "Doe", "JD",
 				makeMobileNumber(ts), "some:thing", "IOS", Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE)
 
@@ -280,7 +280,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.cannot.switch.operating.system"
+		assert response.json.code == "error.device.cannot.switch.operating.system"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -297,8 +297,8 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.app.version.not.supported"
-		assert response.responseData.message == "Yona app is out of date and must be updated. Actual version is '$appVersion' but oldest supported version for 'IOS' is '1.2'"
+		assert response.json.code == "error.device.app.version.not.supported"
+		assert response.json.message == "Yona app is out of date and must be updated. Actual version is '$appVersion' but oldest supported version for 'IOS' is '1.2'"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -314,7 +314,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.device.invalid.version.code"
+		assert response.json.code == "error.device.invalid.version.code"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -374,7 +374,7 @@ class DeviceTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, expectedStatus)
-		expectedStatus == 200 || response.responseData.message ==~ /$expectedMessagePattern/
+		expectedStatus == 200 || response.json.message ==~ /$expectedMessagePattern/
 
 
 		cleanup:

--- a/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/EditGoalsTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -35,7 +35,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 404)
-		response.responseData.code == "error.activitycategory.not.found"
+		response.json.code == "error.activitycategory.not.found"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -51,7 +51,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.goal.cannot.add.second.on.activity.category"
+		response.json.code == "error.goal.cannot.add.second.on.activity.category"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -68,7 +68,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData._embedded."yona:goals".size() == 2
+		response.json._embedded."yona:goals".size() == 2
 		def gamblingGoals = filterGoals(response, GAMBLING_ACT_CAT_URL)
 		gamblingGoals.size() == 1
 		gamblingGoals[0]."@type" == "BudgetGoal"
@@ -100,10 +100,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		def responseGoalsAfterAdd = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterAdd)
-		responseGoalsAfterAdd.responseData._embedded."yona:goals".size() == 3
+		responseGoalsAfterAdd.json._embedded."yona:goals".size() == 3
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 1
 		goalChangeMessages[0].change == 'GOAL_ADDED'
 		goalChangeMessages[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -123,7 +123,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goal.historyItem == false
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -147,10 +147,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		def responseGoalsAfterAdd = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterAdd)
-		responseGoalsAfterAdd.responseData._embedded."yona:goals".size() == 3
+		responseGoalsAfterAdd.json._embedded."yona:goals".size() == 3
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 1
 		goalChangeMessages[0].change == 'GOAL_ADDED'
 		goalChangeMessages[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -168,7 +168,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goal.historyItem == false
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -355,11 +355,11 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.maxDurationMinutes == 120
+		response.json.maxDurationMinutes == 120
 
 		def responseGoalsAfterUpdate = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterUpdate)
-		responseGoalsAfterUpdate.responseData._embedded."yona:goals".size() == 4
+		responseGoalsAfterUpdate.json._embedded."yona:goals".size() == 4
 		findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 120
 		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, YonaServer.now)
 
@@ -369,7 +369,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		historyItem.maxDurationMinutes == 60
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 2
 		goalChangeMessages[0].change == 'GOAL_CHANGED'
 		goalChangeMessages[0]._links.keySet() == ["self", "edit", "related", "yona:user", "yona:buddy", "yona:markRead"] as Set
@@ -385,7 +385,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[1]._links?."yona:buddy"?.href == bob.buddies[0].url
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -407,11 +407,11 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.zones.size() == 2
+		response.json.zones.size() == 2
 
 		def responseGoalsAfterUpdate = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterUpdate)
-		responseGoalsAfterUpdate.responseData._embedded."yona:goals".size() == 4
+		responseGoalsAfterUpdate.json._embedded."yona:goals".size() == 4
 		def timeZoneGoalAfterUpdate = findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL)
 		timeZoneGoalAfterUpdate.zones.size() == 2
 		timeZoneGoalAfterUpdate.spreadCells == [44, 45, 46, 47, 80, 81, 82, 83, 84, 85, 86, 87]
@@ -423,7 +423,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		historyItem.spreadCells == [40, 41, 42, 43]
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 2
 		goalChangeMessages[0].change == 'GOAL_CHANGED'
 		goalChangeMessages[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -437,7 +437,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[1].change == 'GOAL_ADDED'
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -462,11 +462,11 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.maxDurationMinutes == 120
+		response.json.maxDurationMinutes == 120
 
 		def responseGoalsAfterUpdate = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterUpdate)
-		responseGoalsAfterUpdate.responseData._embedded."yona:goals".size() == 4
+		responseGoalsAfterUpdate.json._embedded."yona:goals".size() == 4
 		findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 120
 		assertEquals(findActiveGoal(responseGoalsAfterUpdate, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime)
 
@@ -476,7 +476,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		historyItem.maxDurationMinutes == 60
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 2
 		goalChangeMessages[0].change == 'GOAL_CHANGED'
 		goalChangeMessages[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -491,7 +491,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[1]._links?."yona:buddy"?.href == bob.buddies[0].url
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		// Change 2
 		when:
@@ -501,11 +501,11 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response2)
-		response2.responseData.maxDurationMinutes == 180
+		response2.json.maxDurationMinutes == 180
 
 		def responseGoalsAfterUpdate2 = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterUpdate2)
-		responseGoalsAfterUpdate2.responseData._embedded."yona:goals".size() == 5
+		responseGoalsAfterUpdate2.json._embedded."yona:goals".size() == 5
 		findActiveGoal(responseGoalsAfterUpdate2, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 180
 		assertEquals(findActiveGoal(responseGoalsAfterUpdate2, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime2)
 
@@ -515,7 +515,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		historyItem2.maxDurationMinutes == 60
 
 		def bobMessagesResponse2 = appService.getMessages(bob)
-		def goalChangeMessages2 = bobMessagesResponse2.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages2 = bobMessagesResponse2.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages2.size() == 3
 		goalChangeMessages2[0].change == 'GOAL_CHANGED'
 		goalChangeMessages2[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -530,7 +530,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages2[2].change == 'GOAL_ADDED'
 
 		def richardMessagesResponse2 = appService.getMessages(richard)
-		richardMessagesResponse2.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse2.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		// Change 3
 		when:
@@ -540,11 +540,11 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response3)
-		response3.responseData.maxDurationMinutes == 240
+		response3.json.maxDurationMinutes == 240
 
 		def responseGoalsAfterUpdate3 = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterUpdate3)
-		responseGoalsAfterUpdate3.responseData._embedded."yona:goals".size() == 6
+		responseGoalsAfterUpdate3.json._embedded."yona:goals".size() == 6
 		findActiveGoal(responseGoalsAfterUpdate3, SOCIAL_ACT_CAT_URL).maxDurationMinutes == 240
 		assertEquals(findActiveGoal(responseGoalsAfterUpdate3, SOCIAL_ACT_CAT_URL).creationTime, goalUpdateTime3)
 
@@ -554,7 +554,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		historyItem3.maxDurationMinutes == 60
 
 		def bobMessagesResponse3 = appService.getMessages(bob)
-		def goalChangeMessages3 = bobMessagesResponse3.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages3 = bobMessagesResponse3.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages3.size() == 4
 		goalChangeMessages3[0].change == 'GOAL_CHANGED'
 		goalChangeMessages3[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -570,7 +570,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages3[3].change == 'GOAL_ADDED'
 
 		def richardMessagesResponse3 = appService.getMessages(richard)
-		richardMessagesResponse3.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse3.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -589,7 +589,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.goal.cannot.change.type"
+		response.json.code == "error.goal.cannot.change.type"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -607,7 +607,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.goal.cannot.change.activity.category"
+		response.json.code == "error.goal.cannot.change.activity.category"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -623,7 +623,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.goal.budget.invalid.max.duration.cannot.be.negative"
+		response.json.code == "error.goal.budget.invalid.max.duration.cannot.be.negative"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -648,23 +648,23 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(noZoneResponse, 400)
-		noZoneResponse.responseData.code == "error.goal.time.zone.invalid.at.least.one.zone.required"
+		noZoneResponse.json.code == "error.goal.time.zone.invalid.at.least.one.zone.required"
 		assertResponseStatus(invalidFormatResponse, 400)
-		invalidFormatResponse.responseData.code == "error.goal.time.zone.invalid.zone.format"
+		invalidFormatResponse.json.code == "error.goal.time.zone.invalid.zone.format"
 		assertResponseStatus(toNotBeyondFromResponse, 400)
-		toNotBeyondFromResponse.responseData.code == "error.goal.time.zone.to.not.beyond.from"
+		toNotBeyondFromResponse.json.code == "error.goal.time.zone.to.not.beyond.from"
 		assertResponseStatus(invalidFromHourResponse, 400)
-		invalidFromHourResponse.responseData.code == "error.goal.time.zone.not.a.valid.hour"
+		invalidFromHourResponse.json.code == "error.goal.time.zone.not.a.valid.hour"
 		assertResponseStatus(invalidToHourResponse, 400)
-		invalidToHourResponse.responseData.code == "error.goal.time.zone.not.a.valid.hour"
+		invalidToHourResponse.json.code == "error.goal.time.zone.not.a.valid.hour"
 		assertResponseStatus(fromNotQuarterHourResponse, 400)
-		fromNotQuarterHourResponse.responseData.code == "error.goal.time.zone.not.a.quarter.hour"
+		fromNotQuarterHourResponse.json.code == "error.goal.time.zone.not.a.quarter.hour"
 		assertResponseStatus(toNotQuarterHourResponse, 400)
-		toNotQuarterHourResponse.responseData.code == "error.goal.time.zone.not.a.quarter.hour"
+		toNotQuarterHourResponse.json.code == "error.goal.time.zone.not.a.quarter.hour"
 		assertResponseStatus(fromBeyond24Response, 400)
-		fromBeyond24Response.responseData.code == "error.goal.time.zone.beyond.twenty.four"
+		fromBeyond24Response.json.code == "error.goal.time.zone.beyond.twenty.four"
 		assertResponseStatus(toBeyond24Response, 400)
-		toBeyond24Response.responseData.code == "error.goal.time.zone.beyond.twenty.four"
+		toBeyond24Response.json.code == "error.goal.time.zone.beyond.twenty.four"
 		assertResponseStatus(fullDayResponse, 201)
 
 		cleanup:
@@ -684,7 +684,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.goal.update.time.before.original"
+		response.json.code == "error.goal.update.time.before.original"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -706,10 +706,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		def responseGoalsAfterDelete = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterDelete)
-		responseGoalsAfterDelete.responseData._embedded."yona:goals".size() == 2
+		responseGoalsAfterDelete.json._embedded."yona:goals".size() == 2
 
 		def bobMessagesResponse = appService.getMessages(bob)
-		def goalChangeMessages = bobMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = bobMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size() == 2
 		goalChangeMessages[0].change == 'GOAL_DELETED'
 		goalChangeMessages[0]._links.related.href == SOCIAL_ACT_CAT_URL
@@ -723,7 +723,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		goalChangeMessages[1].change == 'GOAL_ADDED'
 
 		def richardMessagesResponse = appService.getMessages(richard)
-		richardMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
+		richardMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -740,10 +740,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(postToAeResponse)
 		def getMessagesRichardBeforeGoalDeleteResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardBeforeGoalDeleteResponse)
-		getMessagesRichardBeforeGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesRichardBeforeGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 		def getMessagesBobBeforeGoalDeleteResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobBeforeGoalDeleteResponse)
-		getMessagesBobBeforeGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesBobBeforeGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 
 		Goal newsGoal = richard.findActiveGoal(NEWS_ACT_CAT_URL)
 
@@ -755,10 +755,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardAfterGoalDeleteResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardAfterGoalDeleteResponse)
-		getMessagesRichardAfterGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
+		getMessagesRichardAfterGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
 		def getMessagesBobAfterGoalDeleteResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobAfterGoalDeleteResponse)
-		getMessagesBobAfterGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
+		getMessagesBobAfterGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -775,10 +775,10 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(postToAeResponse)
 		def getMessagesRichardBeforeGoalDeleteResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardBeforeGoalDeleteResponse)
-		getMessagesRichardBeforeGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesRichardBeforeGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 		def getMessagesBobBeforeGoalDeleteResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobBeforeGoalDeleteResponse)
-		getMessagesBobBeforeGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		getMessagesBobBeforeGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 
 		assertResponseStatusNoContent(appService.removeBuddy(bob, bob.buddies[0], "Richard, as you know our ways parted, so I'll remove you as buddy."))
 
@@ -792,7 +792,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardAfterGoalDeleteResponse = appService.getMessages(richard)
 		assertResponseStatusOk(getMessagesRichardAfterGoalDeleteResponse)
-		getMessagesRichardAfterGoalDeleteResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
+		getMessagesRichardAfterGoalDeleteResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -812,7 +812,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatus(response, 400)
 		def responseGoalsAfterDelete = appService.getGoals(richard)
 		assertResponseStatusOk(responseGoalsAfterDelete)
-		responseGoalsAfterDelete.responseData._embedded."yona:goals".size() == 2
+		responseGoalsAfterDelete.json._embedded."yona:goals".size() == 2
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -820,7 +820,7 @@ class EditGoalsTest extends AbstractAppServiceIntegrationTest
 
 	def filterGoals(def response, def activityCategoryUrl)
 	{
-		response.responseData._embedded."yona:goals".findAll { it._links."yona:activityCategory".href == activityCategoryUrl }
+		response.json._embedded."yona:goals".findAll { it._links."yona:activityCategory".href == activityCategoryUrl }
 	}
 
 	def postFacebookActivityPastHour(User user)

--- a/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/FirebaseTest.groovy
@@ -34,24 +34,24 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		User bob = richardAndBob.bob
 
 		when:
-		def messageUrlRichard = appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }[0]._links.self.href
+		def messageUrlRichard = appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }[0]._links.self.href
 		def responseRichard = appService.getLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(responseRichard)
-		responseRichard.responseData.title == "Message received"
-		responseRichard.responseData.body == "Tap to open message"
-		messageUrlRichard.endsWith(responseRichard.responseData.data.messageId.toString())
+		responseRichard.json.title == "Message received"
+		responseRichard.json.body == "Tap to open message"
+		messageUrlRichard.endsWith(responseRichard.json.data.messageId.toString())
 
 		when:
-		def messageUrlBob = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		def messageUrlBob = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 		def responseBob = appService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(responseBob)
-		responseBob.responseData.title == "Message received"
-		responseBob.responseData.body == "Tap to open message"
-		messageUrlBob.endsWith(responseBob.responseData.data.messageId.toString())
+		responseBob.json.title == "Message received"
+		responseBob.json.body == "Tap to open message"
+		messageUrlBob.endsWith(responseBob.json.data.messageId.toString())
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -72,30 +72,30 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		appService.sendBuddyConnectRequest(richard, bobAndroid, true, [:], headers)
 
 		when:
-		def messageUrlBobAndroid = appService.getMessages(bobAndroid, [:], headers).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		def messageUrlBobAndroid = appService.getMessages(bobAndroid, [:], headers).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 		def responseBobAndroid = appService.getLastFirebaseMessage(bobAndroid.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(responseBobAndroid)
-		responseBobAndroid.responseData.title == "Bericht ontvangen"
-		responseBobAndroid.responseData.body == "Tik om het bericht te openen"
-		messageUrlBobAndroid.endsWith(responseBobAndroid.responseData.data.messageId.toString())
-		responseBobAndroid.responseData.appOs == richardAppOs
-		responseBobAndroid.responseData.appVersionCode == richardAppVersionCode
-		responseBobAndroid.responseData.appVersionName == richardAppVersionName
+		responseBobAndroid.json.title == "Bericht ontvangen"
+		responseBobAndroid.json.body == "Tik om het bericht te openen"
+		messageUrlBobAndroid.endsWith(responseBobAndroid.json.data.messageId.toString())
+		responseBobAndroid.json.appOs == richardAppOs
+		responseBobAndroid.json.appVersionCode == richardAppVersionCode
+		responseBobAndroid.json.appVersionName == richardAppVersionName
 
 		when:
-		def messageUrlBobIos = appService.getMessages(bobIos).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		def messageUrlBobIos = appService.getMessages(bobIos).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 		def responseBobIos = appService.getLastFirebaseMessage(bobIos.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(responseBobIos)
-		responseBobIos.responseData.title == "Message received"
-		responseBobIos.responseData.body == "Tap to open message"
-		messageUrlBobIos.endsWith(responseBobIos.responseData.data.messageId.toString())
-		responseBobIos.responseData.appOs == richardAppOs
-		responseBobIos.responseData.appVersionCode == richardAppVersionCode
-		responseBobIos.responseData.appVersionName == richardAppVersionName
+		responseBobIos.json.title == "Message received"
+		responseBobIos.json.body == "Tap to open message"
+		messageUrlBobIos.endsWith(responseBobIos.json.data.messageId.toString())
+		responseBobIos.json.appOs == richardAppOs
+		responseBobIos.json.appVersionCode == richardAppVersionCode
+		responseBobIos.json.appVersionName == richardAppVersionName
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -114,27 +114,27 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		when:
 		device.postOpenAppEvent(appService, device.operatingSystem) // Defaults to US-English
 		appService.sendBuddyConnectRequest(richard, bob)
-		def messageUrlBob = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		def messageUrlBob = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 		def response = appService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.title == "Message received"
-		response.responseData.body == "Tap to open message"
-		messageUrlBob.endsWith(response.responseData.data.messageId.toString())
+		response.json.title == "Message received"
+		response.json.body == "Tap to open message"
+		messageUrlBob.endsWith(response.json.data.messageId.toString())
 
 		when:
 		appService.postMessageActionWithPassword(messageUrlBob, [:], bob.password)
 		device.postOpenAppEvent(appService, device.operatingSystem, Device.SOME_APP_VERSION, Device.SUPPORTED_APP_VERSION_CODE, "nl-NL")
 		appService.sendBuddyConnectRequest(bea, bob)
-		messageUrlBob = appService.getMessages(bob, ["onlyUnreadMessages": true]).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		messageUrlBob = appService.getMessages(bob, ["onlyUnreadMessages": true]).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 		response = appService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.title == "Bericht ontvangen"
-		response.responseData.body == "Tik om het bericht te openen"
-		messageUrlBob.endsWith(response.responseData.data.messageId.toString())
+		response.json.title == "Bericht ontvangen"
+		response.json.body == "Tik om het bericht te openen"
+		messageUrlBob.endsWith(response.json.data.messageId.toString())
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -153,25 +153,25 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def responseRichard = analysisService.getLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)
-		def messageUrlRichard = appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
+		def messageUrlRichard = appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
 		assertResponseStatusOk(responseRichard)
-		responseRichard.responseData.title == "Message received"
-		responseRichard.responseData.body == "Tap to open message"
-		messageUrlRichard.endsWith(responseRichard.responseData.data.messageId.toString())
-		responseRichard.responseData.appOs == null
-		responseRichard.responseData.appVersionCode == 0
-		responseRichard.responseData.appVersionName == null
+		responseRichard.json.title == "Message received"
+		responseRichard.json.body == "Tap to open message"
+		messageUrlRichard.endsWith(responseRichard.json.data.messageId.toString())
+		responseRichard.json.appOs == null
+		responseRichard.json.appVersionCode == 0
+		responseRichard.json.appVersionName == null
 
 
 		def responseBob = analysisService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
-		def messageUrlBob = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
+		def messageUrlBob = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
 		assertResponseStatusOk(responseBob)
-		responseBob.responseData.title == "Message received"
-		responseBob.responseData.body == "Tap to open message"
-		messageUrlBob.endsWith(responseBob.responseData.data.messageId.toString())
-		responseBob.responseData.appOs == null
-		responseBob.responseData.appVersionCode == 0
-		responseBob.responseData.appVersionName == null
+		responseBob.json.title == "Message received"
+		responseBob.json.body == "Tap to open message"
+		messageUrlBob.endsWith(responseBob.json.data.messageId.toString())
+		responseBob.json.appOs == null
+		responseBob.json.appVersionCode == 0
+		responseBob.json.appVersionName == null
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -202,25 +202,25 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		def responseRichard = analysisService.getLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)
-		def messageUrlRichard = appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
+		def messageUrlRichard = appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
 		assertResponseStatusOk(responseRichard)
-		responseRichard.responseData.title == "Message received"
-		responseRichard.responseData.body == "Tap to open message"
-		messageUrlRichard.endsWith(responseRichard.responseData.data.messageId.toString())
-		responseRichard.responseData.appOs == richardAppOs
-		responseRichard.responseData.appVersionCode == richardAppVersionCode
-		responseRichard.responseData.appVersionName == richardAppVersionName
+		responseRichard.json.title == "Message received"
+		responseRichard.json.body == "Tap to open message"
+		messageUrlRichard.endsWith(responseRichard.json.data.messageId.toString())
+		responseRichard.json.appOs == richardAppOs
+		responseRichard.json.appVersionCode == richardAppVersionCode
+		responseRichard.json.appVersionName == richardAppVersionName
 
 
 		def responseBob = analysisService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
-		def messageUrlBob = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
+		def messageUrlBob = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.self.href
 		assertResponseStatusOk(responseBob)
-		responseBob.responseData.title == "Message received"
-		responseBob.responseData.body == "Tap to open message"
-		messageUrlBob.endsWith(responseBob.responseData.data.messageId.toString())
-		responseBob.responseData.appOs == richardAppOs
-		responseBob.responseData.appVersionCode == richardAppVersionCode
-		responseBob.responseData.appVersionName == richardAppVersionName
+		responseBob.json.title == "Message received"
+		responseBob.json.body == "Tap to open message"
+		messageUrlBob.endsWith(responseBob.json.data.messageId.toString())
+		responseBob.json.appOs == richardAppOs
+		responseBob.json.appVersionCode == richardAppVersionCode
+		responseBob.json.appVersionName == richardAppVersionName
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -241,8 +241,8 @@ class FirebaseTest extends AbstractAppServiceIntegrationTest
 		def response2 = task2.get()
 
 		then:
-		response1.responseData.passThroughHeaders."Yona-App-Version" == appHeader1
-		response2.responseData.passThroughHeaders."Yona-App-Version" == appHeader2
+		response1.json.passThroughHeaders."Yona-App-Version" == appHeader1
+		response2.json.passThroughHeaders."Yona-App-Version" == appHeader2
 	}
 
 	Future getResource(ExecutorService executorService, path, headers = [:])

--- a/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/LocalizationTest.groovy
@@ -23,13 +23,13 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(successResponse)
-		successResponse.responseData.name == "Gambling"
-		successResponse.responseData.description == "This challenge includes apps and sites like Poker and Blackjack"
+		successResponse.json.name == "Gambling"
+		successResponse.json.description == "This challenge includes apps and sites like Poker and Blackjack"
 		successResponse.headers."Content-Language" == ["en-US"]
 		assertResponseStatus(errorResponse, 400)
-		errorResponse.responseData.code == "error.user.mobile.number.invalid"
-		errorResponse.responseData.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
-		errorResponse.responseData.correlationId ==~ /(?i)^$UUID_PATTERN$/
+		errorResponse.json.code == "error.user.mobile.number.invalid"
+		errorResponse.json.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
+		errorResponse.json.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == ["en-US"]
 	}
 
@@ -43,13 +43,13 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(successResponse)
-		successResponse.responseData.name == "Gokken"
-		successResponse.responseData.description == "Deze challenge bevat apps en sites zoals Poker en Blackjack"
+		successResponse.json.name == "Gokken"
+		successResponse.json.description == "Deze challenge bevat apps en sites zoals Poker en Blackjack"
 		successResponse.headers."Content-Language" == ["nl-NL"]
 		assertResponseStatus(errorResponse, 400)
-		errorResponse.responseData.code == "error.user.mobile.number.invalid"
-		errorResponse.responseData.message == "Het mobiele nummer '$wrongNumber' is ongeldig. Het moet beginnen met een +-teken, zonder spaties tussen de tekens"
-		errorResponse.responseData.correlationId ==~ /(?i)^$UUID_PATTERN$/
+		errorResponse.json.code == "error.user.mobile.number.invalid"
+		errorResponse.json.message == "Het mobiele nummer '$wrongNumber' is ongeldig. Het moet beginnen met een +-teken, zonder spaties tussen de tekens"
+		errorResponse.json.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == ["nl-NL"]
 	}
 
@@ -63,13 +63,13 @@ class LocalizationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(successResponse)
-		successResponse.responseData.name == "Gambling"
-		successResponse.responseData.description == "This challenge includes apps and sites like Poker and Blackjack"
+		successResponse.json.name == "Gambling"
+		successResponse.json.description == "This challenge includes apps and sites like Poker and Blackjack"
 		successResponse.headers."Content-Language" == ["en-US"]
 		assertResponseStatus(errorResponse, 400)
-		errorResponse.responseData.code == "error.user.mobile.number.invalid"
-		errorResponse.responseData.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
-		errorResponse.responseData.correlationId ==~ /(?i)^$UUID_PATTERN$/
+		errorResponse.json.code == "error.user.mobile.number.invalid"
+		errorResponse.json.message == "The mobile number '$wrongNumber' is invalid. It must start with a + sign, with no spaces between the digits"
+		errorResponse.json.correlationId ==~ /(?i)^$UUID_PATTERN$/
 		errorResponse.headers."Content-Language" == ["en-US"]
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/MessagingTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/MessagingTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2019 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -34,31 +34,31 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(allMessagesResponse)
-		allMessagesResponse.responseData._links.self.href.startsWith(richard.messagesUrl)
-		allMessagesResponse.responseData._links.self.href.contains("page=0")
-		allMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 1
-		allMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 3
-		allMessagesResponse.responseData._embedded."yona:messages".size() == 4
+		allMessagesResponse.json._links.self.href.startsWith(richard.messagesUrl)
+		allMessagesResponse.json._links.self.href.contains("page=0")
+		allMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 1
+		allMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 3
+		allMessagesResponse.json._embedded."yona:messages".size() == 4
 
 		assertResponseStatusOk(firstPageMessagesResponse)
-		firstPageMessagesResponse.responseData._links.self.href.contains("page=0")
-		firstPageMessagesResponse.responseData._links.self.href.contains("size=2")
-		firstPageMessagesResponse.responseData._links.self.href.contains("sort=creationTime")
-		!firstPageMessagesResponse.responseData._links.prev
-		firstPageMessagesResponse.responseData._links.next
-		firstPageMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 0
-		firstPageMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 2
-		firstPageMessagesResponse.responseData.page.totalElements == 4
+		firstPageMessagesResponse.json._links.self.href.contains("page=0")
+		firstPageMessagesResponse.json._links.self.href.contains("size=2")
+		firstPageMessagesResponse.json._links.self.href.contains("sort=creationTime")
+		!firstPageMessagesResponse.json._links.prev
+		firstPageMessagesResponse.json._links.next
+		firstPageMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 0
+		firstPageMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 2
+		firstPageMessagesResponse.json.page.totalElements == 4
 
 		assertResponseStatusOk(secondPageMessagesResponse)
-		secondPageMessagesResponse.responseData._links.self.href.contains("page=1")
-		secondPageMessagesResponse.responseData._links.self.href.contains("size=2")
-		secondPageMessagesResponse.responseData._links.self.href.contains("sort=creationTime")
-		secondPageMessagesResponse.responseData._links.prev
-		!secondPageMessagesResponse.responseData._links.next
-		secondPageMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 1
-		secondPageMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
-		secondPageMessagesResponse.responseData.page.totalElements == 4
+		secondPageMessagesResponse.json._links.self.href.contains("page=1")
+		secondPageMessagesResponse.json._links.self.href.contains("size=2")
+		secondPageMessagesResponse.json._links.self.href.contains("sort=creationTime")
+		secondPageMessagesResponse.json._links.prev
+		!secondPageMessagesResponse.json._links.next
+		secondPageMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }.size() == 1
+		secondPageMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		secondPageMessagesResponse.json.page.totalElements == 4
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -78,34 +78,34 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 
 		def initialGetMessagesResponse = appService.getMessages(richard)
 		assertResponseStatusOk(initialGetMessagesResponse)
-		assert initialGetMessagesResponse.responseData.page.totalElements == 5
+		assert initialGetMessagesResponse.json.page.totalElements == 5
 
-		markRead(richard, initialGetMessagesResponse.responseData._embedded."yona:messages"[0])
-		markRead(richard, initialGetMessagesResponse.responseData._embedded."yona:messages"[2])
-		markRead(richard, initialGetMessagesResponse.responseData._embedded."yona:messages"[3])
+		markRead(richard, initialGetMessagesResponse.json._embedded."yona:messages"[0])
+		markRead(richard, initialGetMessagesResponse.json._embedded."yona:messages"[2])
+		markRead(richard, initialGetMessagesResponse.json._embedded."yona:messages"[3])
 
 		when:
 		def getUnreadMessagesResponse = appService.getMessages(richard, ["onlyUnreadMessages": true])
 
 		then:
 		assertResponseStatusOk(getUnreadMessagesResponse)
-		getUnreadMessagesResponse.responseData.page.totalElements == 2
+		getUnreadMessagesResponse.json.page.totalElements == 2
 
-		getUnreadMessagesResponse.responseData._embedded."yona:messages"[0]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href
-		getUnreadMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[4]._links.self.href
+		getUnreadMessagesResponse.json._embedded."yona:messages"[0]._links.self.href == initialGetMessagesResponse.json._embedded."yona:messages"[1]._links.self.href
+		getUnreadMessagesResponse.json._embedded."yona:messages"[1]._links.self.href == initialGetMessagesResponse.json._embedded."yona:messages"[4]._links.self.href
 
 		def secondGetMessagesResponse = appService.getMessages(richard, ["onlyUnreadMessages": false])
-		secondGetMessagesResponse.responseData.page.totalElements == 5
+		secondGetMessagesResponse.json.page.totalElements == 5
 
-		markUnread(richard, secondGetMessagesResponse.responseData._embedded."yona:messages"[2])
+		markUnread(richard, secondGetMessagesResponse.json._embedded."yona:messages"[2])
 
 		def secondGetUnreadMessagesResponse = appService.getMessages(richard, ["onlyUnreadMessages": true])
 		assertResponseStatusOk(secondGetUnreadMessagesResponse)
-		secondGetUnreadMessagesResponse.responseData.page.totalElements == 3
+		secondGetUnreadMessagesResponse.json.page.totalElements == 3
 
-		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[0]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href
-		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[1]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[2]._links.self.href
-		secondGetUnreadMessagesResponse.responseData._embedded."yona:messages"[2]._links.self.href == initialGetMessagesResponse.responseData._embedded."yona:messages"[4]._links.self.href
+		secondGetUnreadMessagesResponse.json._embedded."yona:messages"[0]._links.self.href == initialGetMessagesResponse.json._embedded."yona:messages"[1]._links.self.href
+		secondGetUnreadMessagesResponse.json._embedded."yona:messages"[1]._links.self.href == initialGetMessagesResponse.json._embedded."yona:messages"[2]._links.self.href
+		secondGetUnreadMessagesResponse.json._embedded."yona:messages"[2]._links.self.href == initialGetMessagesResponse.json._embedded."yona:messages"[4]._links.self.href
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -119,15 +119,15 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		User bob = addBob()
 		bob.emailAddress = "bob@dunn.net"
 		appService.sendBuddyConnectRequest(richard, bob)
-		def messageUrl = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
+		def messageUrl = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.self.href
 
 		when:
 		def response = appService.deleteResourceWithPassword(messageUrl, bob.password)
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData?.code == "error.cannot.delete.unprocessed.message"
-		def buddyConnectRequestMessages = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
+		response.json?.code == "error.cannot.delete.unprocessed.message"
+		def buddyConnectRequestMessages = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
 		buddyConnectRequestMessages.size() == 1
 		!buddyConnectRequestMessages[0]._links.edit
 
@@ -145,14 +145,14 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		appService.sendBuddyConnectRequest(richard, bob)
 		String acceptUrl = appService.fetchBuddyConnectRequestMessage(bob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message": "Yes, great idea!"], bob.password)
-		def messageDeleteUrl = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.edit.href
+		def messageDeleteUrl = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }[0]._links.edit.href
 
 		when:
 		def response = appService.deleteResourceWithPassword(messageDeleteUrl, bob.password)
 
 		then:
 		assertResponseStatusOk(response)
-		!appService.getMessages(bob).responseData._embedded?."yona:messages"?.size()
+		!appService.getMessages(bob).json._embedded?."yona:messages"?.size()
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -169,14 +169,14 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		String acceptUrl = appService.fetchBuddyConnectRequestMessage(bob).acceptUrl
 		appService.postMessageActionWithPassword(acceptUrl, ["message": "Yes, great idea!"], bob.password)
 		appService.fetchBuddyConnectResponseMessage(richard).processUrl == null // Processing happens automatically these days
-		def messageDeleteUrl = appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }[0]._links.edit.href
+		def messageDeleteUrl = appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }[0]._links.edit.href
 
 		when:
 		def response = appService.deleteResourceWithPassword(messageDeleteUrl, richard.password)
 
 		then:
 		assertResponseStatusOk(response)
-		!appService.getMessages(richard).responseData._embedded?."yona:messages"?.size()
+		!appService.getMessages(richard).json._embedded?."yona:messages"?.size()
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -190,16 +190,16 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		User richard = richardAndBob.richard
 		User bob = richardAndBob.bob
 		analysisService.postToAnalysisEngine(richard.requestingDevice, ["news/media"], "http://www.refdag.nl")
-		def messageDeleteUrl = appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.edit.href
+		def messageDeleteUrl = appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.edit.href
 
 		when:
 		def response = appService.deleteResourceWithPassword(messageDeleteUrl, richard.password)
 
 		then:
 		assertResponseStatusOk(response)
-		appService.getMessages(richard).responseData._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size() == 0
+		appService.getMessages(richard).json._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size() == 0
 
-		appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
+		appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -213,16 +213,16 @@ class MessagingTest extends AbstractAppServiceIntegrationTest
 		User richard = richardAndBob.richard
 		User bob = richardAndBob.bob
 		analysisService.postToAnalysisEngine(richard.requestingDevice, ["news/media"], "http://www.refdag.nl")
-		def messageDeleteUrl = appService.getMessages(bob).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.edit.href
+		def messageDeleteUrl = appService.getMessages(bob).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }[0]._links.edit.href
 
 		when:
 		def response = appService.deleteResourceWithPassword(messageDeleteUrl, bob.password)
 
 		then:
 		assertResponseStatusOk(response)
-		appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
+		appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }.size() == 1
 
-		appService.getMessages(bob).responseData._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size() == 0
+		appService.getMessages(bob).json._embedded?."yona:messages"?.findAll { it."@type" == "GoalConflictMessage" }?.size() == 0
 
 		cleanup:
 		appService.deleteUser(richard)

--- a/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/OverwriteUserTest.groovy
@@ -41,7 +41,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 	private def userExistsAsserter(def response)
 	{
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.user.exists"
+		assert response.json.code == "error.user.exists"
 	}
 
 	def 'Richard gets a confirmation code when requesting to overwrite his account'()
@@ -84,8 +84,8 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded?."yona:messages"?.size() == 1
-		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		getMessagesResponse.json._embedded?."yona:messages"?.size() == 1
+		def buddyDisconnectMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 		def disconnectMessage = buddyDisconnectMessages[0]
 		disconnectMessage.reason == "USER_ACCOUNT_DELETED"
@@ -122,15 +122,15 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".size() == 1
-		def buddyConnectRequestMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
+		getMessagesBobResponse.json._embedded."yona:messages".size() == 1
+		def buddyConnectRequestMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
 		buddyConnectRequestMessages.size() == 1
 		buddyConnectRequestMessages[0].nickname == richard.nickname
 
 		String acceptUrl = buddyConnectRequestMessages[0]._links?."yona:accept"?.href
 		def acceptBuddyRequestResponse = appService.postMessageActionWithPassword(acceptUrl, ["message": "Yes, great idea!"], bob.password)
 		assertResponseStatus(acceptBuddyRequestResponse, 400)
-		acceptBuddyRequestResponse.responseData.code == "error.user.not.found.id"
+		acceptBuddyRequestResponse.json.code == "error.user.not.found.id"
 
 		String rejectUrl = buddyConnectRequestMessages[0]._links?."yona:reject"?.href
 		def rejectBuddyRequestResponse = appService.postMessageActionWithPassword(rejectUrl, ["message": "Too bad!"], bob.password)
@@ -173,12 +173,12 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richardChanged)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded == null
+		getMessagesRichardResponse.json._embedded == null
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".size() == 1
-		def buddyConnectResponseMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		getMessagesBobResponse.json._embedded."yona:messages".size() == 1
+		def buddyConnectResponseMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
 		buddyConnectResponseMessage.message == "User account was deleted"
@@ -223,12 +223,12 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richardChanged)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded == null
+		getMessagesRichardResponse.json._embedded == null
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".size() == 2
-		def buddyConnectResponseMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		getMessagesBobResponse.json._embedded."yona:messages".size() == 2
+		def buddyConnectResponseMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
 		buddyConnectResponseMessage.message == "User account was deleted"
@@ -236,7 +236,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		buddyConnectResponseMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
 		buddyConnectResponseMessage._links?."yona:process" == null // Processing happens automatically these days
 
-		def buddyConnectRequestMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
+		def buddyConnectRequestMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }
 		buddyConnectRequestMessages.size() == 1
 		buddyConnectRequestMessages[0].nickname == richardChanged.nickname
 		assertEquals(buddyConnectRequestMessages[0].creationTime, YonaServer.now)
@@ -282,12 +282,12 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richardChanged)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded == null
+		getMessagesRichardResponse.json._embedded == null
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".size() == 1
-		def buddyConnectResponseMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		getMessagesBobResponse.json._embedded."yona:messages".size() == 1
+		def buddyConnectResponseMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
 		buddyConnectResponseMessage.message == "User account was deleted"
@@ -322,19 +322,19 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesRichardResponse = appService.getMessages(richardChanged)
 		assertResponseStatusOk(getMessagesRichardResponse)
-		getMessagesRichardResponse.responseData._embedded == null
+		getMessagesRichardResponse.json._embedded == null
 
 		def getMessagesBobResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesBobResponse)
-		getMessagesBobResponse.responseData._embedded."yona:messages".size() == 2
+		getMessagesBobResponse.json._embedded."yona:messages".size() == 2
 
-		def goalConflictMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessages.size == 1
 		goalConflictMessages[0].nickname == "BD (me)"
 		goalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		goalConflictMessages[0].url =~ /poker/
 
-		def buddyDisconnectMessages = getMessagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		def buddyDisconnectMessages = getMessagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 		def disconnectMessage = buddyDisconnectMessages[0]
 		disconnectMessage.reason == "USER_ACCOUNT_DELETED"
@@ -367,7 +367,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(richardChanged)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded == null
+		getMessagesResponse.json._embedded == null
 
 		then:
 		assertResponseStatusNoContent(response)
@@ -416,11 +416,11 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		def userAddResponse = appService.addUser(userCreationJson)
 		def overwriteRequestResponse = appService.requestOverwriteUser(userCreationMobileNumber)
 		assertResponseStatusNoContent(overwriteRequestResponse)
-		def userUrl = YonaServer.stripQueryString(userAddResponse.responseData._links.self.href)
+		def userUrl = YonaServer.stripQueryString(userAddResponse.json._links.self.href)
 
 		when:
 		def response1TimeWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12341"])
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.remainingAttempts == 4
 		appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12342"])
 		appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12343"])
 		def response4TimesWrong = appService.addUser(userCreationJson, ["overwriteUserConfirmationCode": "12344"])
@@ -430,21 +430,21 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(userAddResponse, 201)
-		userAddResponse.responseData._links."yona:confirmMobileNumber".href != null
+		userAddResponse.json._links."yona:confirmMobileNumber".href != null
 		assertResponseStatus(response1TimeWrong, 400)
-		response1TimeWrong.responseData.code == "error.user.overwrite.confirmation.code.mismatch"
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.code == "error.user.overwrite.confirmation.code.mismatch"
+		response1TimeWrong.json.remainingAttempts == 4
 		assertResponseStatus(response4TimesWrong, 400)
-		response4TimesWrong.responseData.code == "error.user.overwrite.confirmation.code.mismatch"
-		response4TimesWrong.responseData.remainingAttempts == 1
+		response4TimesWrong.json.code == "error.user.overwrite.confirmation.code.mismatch"
+		response4TimesWrong.json.remainingAttempts == 1
 		assertResponseStatus(response5TimesWrong, 400)
-		response5TimesWrong.responseData.code == "error.user.overwrite.confirmation.code.mismatch"
-		response5TimesWrong.responseData.remainingAttempts == 0
+		response5TimesWrong.json.code == "error.user.overwrite.confirmation.code.mismatch"
+		response5TimesWrong.json.remainingAttempts == 0
 		assertResponseStatus(response6TimesWrong, 400)
-		response6TimesWrong.responseData.code == "error.user.overwrite.confirmation.code.too.many.failed.attempts"
-		response6TimesWrong.responseData.remainingAttempts == null
+		response6TimesWrong.json.code == "error.user.overwrite.confirmation.code.too.many.failed.attempts"
+		response6TimesWrong.json.remainingAttempts == null
 		assertResponseStatus(response7thTimeRight, 400)
-		response7thTimeRight.responseData.code == "error.user.overwrite.confirmation.code.too.many.failed.attempts"
+		response7thTimeRight.json.code == "error.user.overwrite.confirmation.code.too.many.failed.attempts"
 
 		cleanup:
 		if (userUrl)
@@ -471,7 +471,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 		then:
 		def responseGetMessagesBob = appService.getMessages(bob)
 		assertResponseStatusOk(responseGetMessagesBob)
-		assert responseGetMessagesBob.responseData._embedded?."yona:messages"?.find { it."@type" == "GoalConflictMessage" } == null
+		assert responseGetMessagesBob.json._embedded?."yona:messages"?.find { it."@type" == "GoalConflictMessage" } == null
 
 		cleanup:
 		appService.deleteUser(richardAfterOverwrite)
@@ -481,7 +481,7 @@ class OverwriteUserTest extends AbstractAppServiceIntegrationTest
 	private static def assertUserOverwriteResponseDetails(def response)
 	{
 		assertResponseStatusCreated(response)
-		assertUser(response.responseData)
+		assertUser(response.json)
 	}
 
 	def 'Concurrent requests cause no errors'()

--- a/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/PinResetRequestTest.groovy
@@ -50,7 +50,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.delay == "PT10S"
+		response.json.delay == "PT10S"
 		User richardAfterGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedNotGenerated)
 		!richardAfterGet.pinResetRequestUrl
 
@@ -58,7 +58,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		!richardAfterGet.clearPinResetUrl
 		!richardAfterGet.resendPinResetConfirmationCodeUrl
 
-		sleepTillPinResetCodeIsGenerated(richard, response.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, response.json.delay)
 		User richardAfterDelayedGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		richardAfterDelayedGet.verifyPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify"
@@ -75,7 +75,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		User richard = addRichard()
 		def firstResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password, "Accept-Language": "nl-NL"])
 		assertResponseStatusOk(firstResponse)
-		sleepTillPinResetCodeIsGenerated(richard, firstResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, firstResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		assert richard.clearPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/clear"
 		assertResponseStatusNoContent(appService.yonaServer.postJson(richard.clearPinResetUrl, [:], [:], ["Yona-Password": richard.password]))
@@ -87,7 +87,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		response.responseData.delay == "PT10S"
+		response.json.delay == "PT10S"
 		User richardAfterGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedNotGenerated)
 		!richardAfterGet.pinResetRequestUrl
 
@@ -95,7 +95,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		!richardAfterGet.clearPinResetUrl
 		!richardAfterGet.resendPinResetConfirmationCodeUrl
 
-		sleepTillPinResetCodeIsGenerated(richard, response.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, response.json.delay)
 		User richardAfterDelayedGet = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		// The below asserts check the path fragments. If one of these asserts fails, the Swagger spec needs to be updated too
 		richardAfterDelayedGet.verifyPinResetUrl == YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify"
@@ -120,7 +120,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
@@ -143,7 +143,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
@@ -166,14 +166,14 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def responsePost = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.responseData.delay)
+		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.json.delay)
 
 		when:
 		def response = appService.yonaServer.postJson(YonaServer.stripQueryString(richard.url) + "/pinResetRequest/verify", """{"code" : "1234"}""", [:], ["Yona-Password": richard.password])
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
+		response.json.code == "error.pin.reset.request.confirmation.code.mismatch"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -189,7 +189,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.pin.reset.request.confirmation.code.not.set"
+		response.json.code == "error.pin.reset.request.confirmation.code.not.set"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -200,14 +200,14 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def responsePost = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.responseData.delay)
+		sleepTillMidOfPinResetCodeGenerationInterval(richard, responsePost.json.delay)
 
 		when:
 		def response = appService.yonaServer.postJson(YonaServer.stripQueryString(richard.url) + "/pinResetRequest/resend", """{}""", [:], ["Yona-Password": richard.password])
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.pin.reset.request.confirmation.code.not.set"
+		response.json.code == "error.pin.reset.request.confirmation.code.not.set"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -226,7 +226,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
@@ -241,7 +241,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		!richardAfterGet.resendPinResetConfirmationCodeUrl
 		def verifyPinResetAttemptResponse = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password": richard.password])
 		assertResponseStatus(verifyPinResetAttemptResponse, 400)
-		verifyPinResetAttemptResponse.responseData.code == "error.pin.reset.request.confirmation.code.not.set"
+		verifyPinResetAttemptResponse.json.code == "error.pin.reset.request.confirmation.code.not.set"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -252,7 +252,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "1234"}""", [:], ["Yona-Password": richard.password])
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
@@ -277,12 +277,12 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 
 		when:
 		def response1TimeWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12341"}""", [:], ["Yona-Password": richard.password])
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.remainingAttempts == 4
 		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12342"}""", [:], ["Yona-Password": richard.password])
 		appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12343"}""", [:], ["Yona-Password": richard.password])
 		def response4TimesWrong = appService.yonaServer.postJson(richard.verifyPinResetUrl, """{"code" : "12344"}""", [:], ["Yona-Password": richard.password])
@@ -292,19 +292,19 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response1TimeWrong, 400)
-		response1TimeWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.code == "error.pin.reset.request.confirmation.code.mismatch"
+		response1TimeWrong.json.remainingAttempts == 4
 		assertResponseStatus(response4TimesWrong, 400)
-		response4TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
-		response4TimesWrong.responseData.remainingAttempts == 1
+		response4TimesWrong.json.code == "error.pin.reset.request.confirmation.code.mismatch"
+		response4TimesWrong.json.remainingAttempts == 1
 		assertResponseStatus(response5TimesWrong, 400)
-		response5TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.mismatch"
-		response5TimesWrong.responseData.remainingAttempts == 0
+		response5TimesWrong.json.code == "error.pin.reset.request.confirmation.code.mismatch"
+		response5TimesWrong.json.remainingAttempts == 0
 		assertResponseStatus(response6TimesWrong, 400)
-		response6TimesWrong.responseData.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
-		response6TimesWrong.responseData.remainingAttempts == null
+		response6TimesWrong.json.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
+		response6TimesWrong.json.remainingAttempts == null
 		assertResponseStatus(response7thTimeRight, 400)
-		response7thTimeRight.responseData.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
+		response7thTimeRight.json.code == "error.pin.reset.request.confirmation.code.too.many.failed.attempts"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -315,7 +315,7 @@ class PinResetRequestTest extends AbstractAppServiceIntegrationTest
 		given:
 		User richard = addRichard()
 		def resetRequestResponse = appService.yonaServer.postJson(richard.pinResetRequestUrl, [:], [:], ["Yona-Password": richard.password])
-		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.responseData.delay)
+		sleepTillPinResetCodeIsGenerated(richard, resetRequestResponse.json.delay)
 		richard = appService.reloadUser(richard, CommonAssertions.&assertUserGetResponseDetailsPinResetRequestedAndGenerated)
 		def numberOfTimes = 5
 

--- a/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RejectBuddyTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -27,11 +27,11 @@ class RejectBuddyTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(rejectResponse)
-		rejectResponse.responseData._embedded."yona:affectedMessages".size() == 1
-		rejectResponse.responseData._embedded."yona:affectedMessages"[0]._links.self.href == connectRequestMessage.selfUrl
-		rejectResponse.responseData._embedded."yona:affectedMessages"[0].status == "REJECTED"
-		rejectResponse.responseData._embedded."yona:affectedMessages"[0]._links."yona:accept" == null
-		rejectResponse.responseData._embedded."yona:affectedMessages"[0]._links."yona:reject" == null
+		rejectResponse.json._embedded."yona:affectedMessages".size() == 1
+		rejectResponse.json._embedded."yona:affectedMessages"[0]._links.self.href == connectRequestMessage.selfUrl
+		rejectResponse.json._embedded."yona:affectedMessages"[0].status == "REJECTED"
+		rejectResponse.json._embedded."yona:affectedMessages"[0]._links."yona:accept" == null
+		rejectResponse.json._embedded."yona:affectedMessages"[0]._links."yona:reject" == null
 
 		// Verify connect message doesn't have actions anymore
 		def actionUrls = appService.fetchBuddyConnectRequestMessage(bob).rejectUrl

--- a/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/RemoveUserTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -65,10 +65,10 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 2
+		getMessagesResponse.json._embedded
+		getMessagesResponse.json._embedded."yona:messages".size() == 2
 
-		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		def buddyDisconnectMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 		def disconnectMessage = buddyDisconnectMessages[0]
 		disconnectMessage.reason == "USER_ACCOUNT_DELETED"
@@ -77,12 +77,12 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
 		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 
-		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessages.size == 1
 		goalConflictMessages[0].nickname == "BD (me)"
 		goalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		goalConflictMessages[0].url =~ /poker/
-		getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }.size() == 0
+		getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }.size() == 0
 
 		cleanup:
 		appService.deleteUser(bob)
@@ -106,10 +106,10 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 1
+		getMessagesResponse.json._embedded
+		getMessagesResponse.json._embedded."yona:messages".size() == 1
 
-		def buddyConnectResponseMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		def buddyConnectResponseMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		def buddyConnectResponseMessage = buddyConnectResponseMessages[0]
 		buddyConnectResponseMessage.message == "User account was deleted"
@@ -145,7 +145,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		then:
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded == null
+		getMessagesResponse.json._embedded == null
 
 		def buddies = appService.getBuddies(bob)
 		buddies.size() == 0
@@ -177,10 +177,10 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		sleep(500) // TODO this is a temporary measure to see whether this allows Hazelcast to sync the cache to the analysis service
 		//activity comment at activity of Richard
 		def bobResponseDetailsRichard = appService.getDayActivityDetails(bob, bob.buddies[0], budgetGoalNewsBuddyRichard, 1, "Tue")
-		appService.yonaServer.createResourceWithPassword(bobResponseDetailsRichard.responseData._links."yona:addComment".href, """{"message": "Hi Richard, everything OK?"}""", bob.password)
+		appService.yonaServer.createResourceWithPassword(bobResponseDetailsRichard.json._links."yona:addComment".href, """{"message": "Hi Richard, everything OK?"}""", bob.password)
 		//activity comment from Richard
 		def richardResponseDetailsBob = appService.getDayActivityDetails(richard, richard.buddies[0], budgetGoalNewsBuddyBob, 1, "Tue")
-		appService.yonaServer.createResourceWithPassword(richardResponseDetailsBob.responseData._links."yona:addComment".href, """{"message": "Hi Bob, nice activity!"}""", richard.password)
+		appService.yonaServer.createResourceWithPassword(richardResponseDetailsBob.json._links."yona:addComment".href, """{"message": "Hi Bob, nice activity!"}""", richard.password)
 		//buddy info change
 		def updatedRichardJson = richard.convertToJson()
 		updatedRichardJson.nickname = "Richardo"
@@ -196,10 +196,10 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded
-		getMessagesResponse.responseData._embedded."yona:messages".size() == 2 // User removal + own goal conflict
+		getMessagesResponse.json._embedded
+		getMessagesResponse.json._embedded."yona:messages".size() == 2 // User removal + own goal conflict
 
-		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		def buddyDisconnectMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages.size() == 1
 
 		def disconnectMessage = buddyDisconnectMessages[0]
@@ -209,20 +209,20 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		disconnectMessage._links.self.href.startsWith(YonaServer.stripQueryString(bob.messagesUrl))
 		disconnectMessage._links."yona:process" == null // Processing happens automatically these days
 
-		def goalConflictMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
+		def goalConflictMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalConflictMessage" }
 		goalConflictMessages.size == 1
 		goalConflictMessages[0].nickname == "BD (me)"
 		goalConflictMessages[0]._links."yona:activityCategory".href == GAMBLING_ACT_CAT_URL
 		goalConflictMessages[0].url =~ /poker/
-		getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }.size() == 0
+		getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectRequestMessage" }.size() == 0
 
-		def goalChangeMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
+		def goalChangeMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "GoalChangeMessage" }
 		goalChangeMessages.size == 0
 
-		def activityCommentMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "ActivityCommentMessage" }
+		def activityCommentMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "ActivityCommentMessage" }
 		activityCommentMessages.size == 0
 
-		def buddyInfoChangeMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoChangeMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyInfoChangeMessage" }
 		buddyInfoChangeMessages.size == 0
 
 		def buddies = appService.getBuddies(bob)
@@ -242,7 +242,7 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richard, message)
 		def getResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getResponse)
-		assert getResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }[0]._links."yona:process" == null // Processing happens automatically these days
+		assert getResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }[0]._links."yona:process" == null // Processing happens automatically these days
 
 		when:
 		def response = analysisService.postToAnalysisEngine(bob.requestingDevice, ["Gambling"], "http://www.poker.com")
@@ -251,8 +251,8 @@ class RemoveUserTest extends AbstractAppServiceIntegrationTest
 		assertResponseStatusNoContent(response)
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		getMessagesResponse.responseData._embedded
-		def buddyDisconnectMessages = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
+		getMessagesResponse.json._embedded
+		def buddyDisconnectMessages = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "BuddyDisconnectMessage" }
 		buddyDisconnectMessages[0].reason == "USER_ACCOUNT_DELETED"
 		buddyDisconnectMessages[0].message == message
 		buddyDisconnectMessages[0].nickname == richard.nickname

--- a/appservice/src/intTest/groovy/nu/yona/server/SystemMessageTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/SystemMessageTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation
+ * Copyright (c) 2017, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -31,14 +31,14 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(messagesRichardResponse)
 		assertResponseStatusOk(messagesBobResponse)
-		def systemMessagesRichard = messagesRichardResponse.responseData._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
+		def systemMessagesRichard = messagesRichardResponse.json._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
 		systemMessagesRichard.size() == 1
 		systemMessagesRichard[0].message == "Hi there!"
 		systemMessagesRichard[0].nickname == "Yona"
 		systemMessagesRichard[0]._links.keySet() == ["self", "edit", "yona:markRead"] as Set
 		systemMessagesRichard[0]._links?.self?.href?.startsWith(richard.messagesUrl)
 		def messageUrlRichard = systemMessagesRichard[0]._links?.self?.href
-		def systemMessagesBob = messagesBobResponse.responseData._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
+		def systemMessagesBob = messagesBobResponse.json._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
 		systemMessagesBob.size() == 1
 		systemMessagesBob[0].message == "Hi there!"
 		systemMessagesBob[0].nickname == "Yona"
@@ -48,15 +48,15 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 
 		def responseBob = batchService.getLastFirebaseMessage(bob.requestingDevice.firebaseInstanceId)
 		assertResponseStatusOk(responseBob)
-		assert responseBob.responseData.title == "Message received"
-		assert responseBob.responseData.body == "Tap to open message"
-		assert messageUrlBob.endsWith(responseBob.responseData.data.messageId.toString())
+		assert responseBob.json.title == "Message received"
+		assert responseBob.json.body == "Tap to open message"
+		assert messageUrlBob.endsWith(responseBob.json.data.messageId.toString())
 
 		def responseRichard = batchService.getLastFirebaseMessage(richard.requestingDevice.firebaseInstanceId)
 		assertResponseStatusOk(responseRichard)
-		assert responseRichard.responseData.title == "Message received"
-		assert responseRichard.responseData.body == "Tap to open message"
-		assert messageUrlRichard.endsWith(responseRichard.responseData.data.messageId.toString())
+		assert responseRichard.json.title == "Message received"
+		assert responseRichard.json.body == "Tap to open message"
+		assert messageUrlRichard.endsWith(responseRichard.json.data.messageId.toString())
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -74,7 +74,7 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 		sleepTillSystemMessagesAreSent(bob)
 		def getMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(getMessagesResponse)
-		def systemMessagesBob = getMessagesResponse.responseData._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
+		def systemMessagesBob = getMessagesResponse.json._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }
 		assert systemMessagesBob.size() == 1
 		def messageDeleteUrl = systemMessagesBob[0]._links?.edit?.href
 
@@ -83,8 +83,8 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(response)
-		appService.getMessages(richard).responseData._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }.size() == 1
-		appService.getMessages(bob).responseData._embedded == null
+		appService.getMessages(richard).json._embedded."yona:messages".findAll { it."@type" == "SystemMessage" }.size() == 1
+		appService.getMessages(bob).json._embedded == null
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -99,7 +99,7 @@ class SystemMessageTest extends AbstractAppServiceIntegrationTest
 																		  "page"              : 0,
 																		  "size"              : 1])
 			assertResponseStatusOk(getUnreadMessagesResponse)
-			if (getUnreadMessagesResponse.responseData.page.totalElements > 0)
+			if (getUnreadMessagesResponse.json.page.totalElements > 0)
 			{
 				return
 			}

--- a/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UpdateBuddyUserInfoTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -26,7 +26,7 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		User bobAfterUpdate = appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
 		assertResponseStatusOk(richardMessagesAfterUpdate)
-		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
 
 		then:
 		bobAfterUpdate.nickname == "Bobby"
@@ -60,7 +60,7 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		appService.updateUser(CommonAssertions.&assertUserUpdateResponseDetails, new User(updatedBobJson))
 		def richardMessagesAfterUpdate = appService.getMessages(richard)
 		assertResponseStatusOk(richardMessagesAfterUpdate)
-		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = richardMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
 
 		then:
 		buddyInfoUpdateMessages.size() == 1
@@ -101,11 +101,11 @@ class UpdateBuddyUserInfoTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 
-		def buddyInfoUpdateMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyInfoChangeMessage" }
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0].nickname == updatedBobJson.nickname
 
-		def buddyConnectResponseMessages = response.responseData._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
+		def buddyConnectResponseMessages = response.json._embedded."yona:messages".findAll { it."@type" == "BuddyConnectResponseMessage" }
 		buddyConnectResponseMessages.size() == 1
 		buddyConnectResponseMessages[0].nickname == updatedBobJson.nickname
 		buddyConnectResponseMessages[0].status == "ACCEPTED"

--- a/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserPhotoTest.groovy
@@ -35,7 +35,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 		response.contentType == "application/json"
-		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
+		def newUserPhotoUrl = response.json?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
 
 		def richardAfterUpdate = appService.reloadUser(richard)
@@ -57,7 +57,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 		response.contentType == "application/json"
-		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
+		def newUserPhotoUrl = response.json?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
 
 		def downloadResponse = appService.yonaServer.getData(newUserPhotoUrl)
@@ -80,7 +80,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 		response.contentType == "application/json"
-		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
+		def newUserPhotoUrl = response.json?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
 
 		def downloadResponse = appService.yonaServer.getData(newUserPhotoUrl)
@@ -102,7 +102,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 413)
-		response.responseData.code == null // As the app should take care for uploading a resized photo, this is not a user error, so it does not need to have a code
+		response.json.code == null // As the app should take care for uploading a resized photo, this is not a user error, so it does not need to have a code
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -208,7 +208,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesResponse)
-		def bobMessagesFromRichard = bobMessagesResponse.responseData._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
+		def bobMessagesFromRichard = bobMessagesResponse.json._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
 		bobMessagesFromRichard.each {
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
@@ -232,7 +232,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesResponse)
-		def bobMessagesFromRichard = bobMessagesResponse.responseData._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
+		def bobMessagesFromRichard = bobMessagesResponse.json._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
 		bobMessagesFromRichard.each {
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
@@ -259,7 +259,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesResponse)
-		def bobMessagesFromRichard = bobMessagesResponse.responseData._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
+		def bobMessagesFromRichard = bobMessagesResponse.json._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
 		bobMessagesFromRichard.each {
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
@@ -285,7 +285,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesResponse)
-		def bobMessagesFromRichard = bobMessagesResponse.responseData._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
+		def bobMessagesFromRichard = bobMessagesResponse.json._embedded?."yona:messages"?.findAll { it."nickname" == "RQ" }
 		bobMessagesFromRichard.each {
 			it._links?."yona:userPhoto"?.href == richardPhotoUrl
 		}
@@ -309,7 +309,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
 		buddyInfoUpdateMessages[0]._links."yona:process" == null // Processing happens automatically these days
@@ -344,7 +344,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
 		buddyInfoUpdateMessages[0]._links."yona:process" == null // Processing happens automatically these days
@@ -378,7 +378,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
+		def buddyInfoUpdateMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyInfoChangeMessage" }
 		buddyInfoUpdateMessages.size() == 1
 		buddyInfoUpdateMessages[0]._links.self != null
 		buddyInfoUpdateMessages[0]._links."yona:process" == null // Processing happens automatically these days
@@ -409,7 +409,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		def richardAfterUpdate = appService.reloadUser(richard)
 		richardAfterUpdate.userPhotoUrl == null
@@ -429,7 +429,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		def richardAfterUpdate = appService.reloadUser(richard)
 		richardAfterUpdate.userPhotoUrl == userPhotoUrlBefore
@@ -453,9 +453,9 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(response)
 		response.contentType == "application/json"
-		def newUserPhotoUrl = response.responseData?._links?."yona:userPhoto"?.href
+		def newUserPhotoUrl = response.json?._links?."yona:userPhoto"?.href
 		newUserPhotoUrl != null
-		response.responseData.nickname == newNickname
+		response.json.nickname == newNickname
 
 		def richardAfterUpdate = appService.reloadUser(richard)
 		richardAfterUpdate.userPhotoUrl == newUserPhotoUrl
@@ -470,7 +470,7 @@ class UserPhotoTest extends AbstractAppServiceIntegrationTest
 		def multipartEntity = createMultipartEntity(EXAMPLE_PNG_DATA_BASE64, "image/png", "MyPhoto.png")
 		def response = putPhoto(user, multipartEntity)
 		assertResponseStatusOk(response)
-		response.responseData?._links?."yona:userPhoto"?.href
+		response.json?._links?."yona:userPhoto"?.href
 	}
 
 	private static HttpEntity createMultipartEntity(String base64String, mimeType, filename)

--- a/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserTest.groovy
@@ -43,7 +43,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		def getMessagesResponse = appService.yonaServer.getJsonWithPassword(baseUserUrl + "/messages/", john.password)
 		assertResponseStatus(getMessagesResponse, 400)
-		getMessagesResponse.responseData.code == "error.mobile.number.not.confirmed"
+		getMessagesResponse.json.code == "error.mobile.number.not.confirmed"
 
 		cleanup:
 		appService.deleteUser(john)
@@ -111,19 +111,19 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatus(response1TimeWrong, 400)
 		assertResponseStatus(response1TimeWrong, 400)
-		response1TimeWrong.responseData.code == "error.mobile.number.confirmation.code.mismatch"
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.code == "error.mobile.number.confirmation.code.mismatch"
+		response1TimeWrong.json.remainingAttempts == 4
 		assertResponseStatus(response4TimesWrong, 400)
-		response4TimesWrong.responseData.code == "error.mobile.number.confirmation.code.mismatch"
-		response4TimesWrong.responseData.remainingAttempts == 1
+		response4TimesWrong.json.code == "error.mobile.number.confirmation.code.mismatch"
+		response4TimesWrong.json.remainingAttempts == 1
 		assertResponseStatus(response5TimesWrong, 400)
-		response5TimesWrong.responseData.code == "error.mobile.number.confirmation.code.mismatch"
-		response5TimesWrong.responseData.remainingAttempts == 0
+		response5TimesWrong.json.code == "error.mobile.number.confirmation.code.mismatch"
+		response5TimesWrong.json.remainingAttempts == 0
 		assertResponseStatus(response6TimesWrong, 400)
-		response6TimesWrong.responseData.code == "error.mobile.number.confirmation.code.too.many.failed.attempts"
-		response6TimesWrong.responseData.remainingAttempts == null
+		response6TimesWrong.json.code == "error.mobile.number.confirmation.code.too.many.failed.attempts"
+		response6TimesWrong.json.remainingAttempts == null
 		assertResponseStatus(response7thTimeRight, 400)
-		response7thTimeRight.responseData.code == "error.mobile.number.confirmation.code.too.many.failed.attempts"
+		response7thTimeRight.json.code == "error.mobile.number.confirmation.code.too.many.failed.attempts"
 
 		cleanup:
 		appService.deleteUser(john)
@@ -141,15 +141,15 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response1TimeWrong, 400)
-		response1TimeWrong.responseData.code == "error.mobile.number.confirmation.code.mismatch"
-		response1TimeWrong.responseData.remainingAttempts == 4
+		response1TimeWrong.json.code == "error.mobile.number.confirmation.code.mismatch"
+		response1TimeWrong.json.remainingAttempts == 4
 
 		assertResponseStatusNoContent(responseRequestResend)
 
 		def response1TimeWrongAgain = confirmMobileNumber(john, "12341")
 		assertResponseStatus(response1TimeWrongAgain, 400)
-		response1TimeWrongAgain.responseData.code == "error.mobile.number.confirmation.code.mismatch"
-		response1TimeWrongAgain.responseData.remainingAttempts == 4
+		response1TimeWrongAgain.json.code == "error.mobile.number.confirmation.code.mismatch"
+		response1TimeWrongAgain.json.remainingAttempts == 4
 		def responseRight = confirmMobileNumber(john, "1234")
 		assertResponseStatusOk(responseRight)
 
@@ -184,7 +184,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.decrypting.data"
+		response.json.code == "error.decrypting.data"
 
 		cleanup:
 		appService.deleteUser(johnAsCreated)
@@ -201,7 +201,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.message ==~ /.*'requestingUserId'.* is not present.*/
+		response.json.message ==~ /.*'requestingUserId'.* is not present.*/
 
 		cleanup:
 		appService.deleteUser(johnAsCreated)
@@ -218,7 +218,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.missing.password.header"
+		response.json.code == "error.missing.password.header"
 
 		cleanup:
 		appService.deleteUser(johnAsCreated)
@@ -239,9 +239,9 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(userUpdateResponse)
-		userUpdateResponse.responseData._links?."yona:confirmMobileNumber"?.href == null
-		userUpdateResponse.responseData.nickname == newNickname
-		assertDateTimeFormat(userUpdateResponse.responseData.creationTime)
+		userUpdateResponse.json._links?."yona:confirmMobileNumber"?.href == null
+		userUpdateResponse.json.nickname == newNickname
+		assertDateTimeFormat(userUpdateResponse.json.creationTime)
 
 		cleanup:
 		appService.deleteUser(john)
@@ -262,7 +262,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatusOk(userUpdateResponse)
-		User johnAfterUpdate = new User(userUpdateResponse.responseData)
+		User johnAfterUpdate = new User(userUpdateResponse.json)
 		johnAfterUpdate.mobileNumberConfirmationUrl != null
 		johnAfterUpdate.mobileNumber == newMobileNumber
 
@@ -272,7 +272,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(getMessagesResponse, 400)
-		getMessagesResponse.responseData.code == "error.mobile.number.not.confirmed"
+		getMessagesResponse.json.code == "error.mobile.number.not.confirmed"
 
 		when:
 		def johnAfterNumberConfirmation = appService.confirmMobileNumber(CommonAssertions.&assertUserGetResponseDetails, johnAfterUpdate)
@@ -301,7 +301,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.exists"
+		response.json.code == "error.user.exists"
 
 		cleanup:
 		appService.deleteUser(john)
@@ -322,8 +322,8 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.missing.request.parameter"
-		response.responseData.message ==~ /^Request parameter 'requestingDeviceId' is mandatory in this context.*/
+		response.json.code == "error.request.missing.request.parameter"
+		response.json.message ==~ /^Request parameter 'requestingDeviceId' is mandatory in this context.*/
 
 		cleanup:
 		appService.deleteUser(john)
@@ -347,8 +347,8 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.request.extra.property"
-		response.responseData.message ==~ /^Property 'deviceName' is not supported in this context.*/
+		response.json.code == "error.request.extra.property"
+		response.json.message ==~ /^Property 'deviceName' is not supported in this context.*/
 
 		cleanup:
 		appService.deleteUser(john)
@@ -364,7 +364,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.invalid.uuid"
+		assert response.json.code == "error.invalid.uuid"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -382,7 +382,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.user.not.found.id"
+		assert response.json.code == "error.user.not.found.id"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -399,7 +399,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		assert response.responseData.code == "error.user.not.found.id"
+		assert response.json.code == "error.user.not.found.id"
 
 		cleanup:
 		appService.deleteUser(richard)
@@ -415,7 +415,7 @@ class UserTest extends AbstractAppServiceIntegrationTest
 		then:
 		assertResponseStatusOk(responseAppleAppSiteAssociation)
 		responseAppleAppSiteAssociation.contentType == "application/json"
-		responseAppleAppSiteAssociation.responseData.applinks.details[0].appID ==~ /.*\.yona/
+		responseAppleAppSiteAssociation.json.applinks.details[0].appID ==~ /.*\.yona/
 	}
 
 	def 'Last monitored activity date is not present when there were no activities'()

--- a/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/UserValidationTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -33,7 +33,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.firstname"
+		response.json.code == "error.user.firstname"
 	}
 
 	def 'AddUser - empty last name'()
@@ -45,7 +45,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.lastname"
+		response.json.code == "error.user.lastname"
 	}
 
 	def 'AddUser - empty nickname'()
@@ -57,7 +57,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.nickname"
+		response.json.code == "error.user.nickname"
 	}
 
 	def 'AddUser - empty mobile number'()
@@ -69,7 +69,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.mobile.number"
+		response.json.code == "error.user.mobile.number"
 	}
 
 	def 'AddUser - invalid mobile number format'()
@@ -81,7 +81,7 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.mobile.number.invalid"
+		response.json.code == "error.user.mobile.number.invalid"
 	}
 
 	def 'AddUser - invalid mobile number (fixed line)'()
@@ -93,6 +93,6 @@ class UserValidationTest extends AbstractAppServiceIntegrationTest
 
 		then:
 		assertResponseStatus(response, 400)
-		response.responseData.code == "error.user.mobile.number.not.mobile"
+		response.json.code == "error.user.mobile.number.not.mobile"
 	}
 }

--- a/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/VpnConnectionStatusEventTest.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Stichting Yona Foundation
+ * Copyright (c) 2018, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -38,7 +38,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages"?.findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages"?.findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		vpnConnectionStatusChangeMessages.size() == 1
 		vpnConnectionStatusChangeMessages[0]._links.keySet() == ["self", "edit", "yona:buddy", "yona:user", "yona:markRead"] as Set
@@ -75,7 +75,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		vpnConnectionStatusChangeMessages.size() == 2
 		vpnConnectionStatusChangeMessages[0]._links.self != null
@@ -155,7 +155,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		def expectedDeviceName = (lastToggledDevice == 0) ? richardFirstDevice.name : richardSecondDevice.name
 		def expectedStatus = (lastToggledDevice == 0) ? firstDeviceStatus : secondDeviceStatus
@@ -172,12 +172,12 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 		def getResponseAfter = appService.getNewDeviceRequest(user.mobileNumber)
 		assertResponseStatusOk(getResponseAfter)
 
-		def registerUrl = getResponseAfter.responseData._links."yona:registerDevice".href
+		def registerUrl = getResponseAfter.json._links."yona:registerDevice".href
 
 		def registerResponse = appService.registerNewDevice(registerUrl, newDeviceRequestPassword, newDeviceName, newDeviceOs)
 		assertResponseStatusCreated(registerResponse)
 
-		def devices = registerResponse.responseData._embedded."yona:devices"._embedded."yona:devices"
+		def devices = registerResponse.json._embedded."yona:devices"._embedded."yona:devices"
 
 		assert devices.size == 2
 		def newDeviceJson = (devices[0].name == newDeviceName) ? devices[0] : devices[1]
@@ -195,7 +195,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 		bob = appService.reloadUser(bob)
 		def bobInitialMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobInitialMessagesResponse)
-		def initialVpnConnectionStatusChangeMessages = bobInitialMessagesResponse.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def initialVpnConnectionStatusChangeMessages = bobInitialMessagesResponse.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		when:
 		def response = richard.requestingDevice.postVpnStatus(appService, false)
@@ -212,7 +212,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		vpnConnectionStatusChangeMessages == initialVpnConnectionStatusChangeMessages
 
@@ -232,7 +232,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 		bob = appService.reloadUser(bob)
 		def bobInitialMessagesResponse = appService.getMessages(bob)
 		assertResponseStatusOk(bobInitialMessagesResponse)
-		def initialVpnConnectionStatusChangeMessages = bobInitialMessagesResponse.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def initialVpnConnectionStatusChangeMessages = bobInitialMessagesResponse.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		when:
 		def response = richard.requestingDevice.postVpnStatus(appService, true)
@@ -249,7 +249,7 @@ class VpnConnectionStatusEventTest extends AbstractAppServiceIntegrationTest
 
 		def bobMessagesAfterUpdate = appService.getMessages(bob)
 		assertResponseStatusOk(bobMessagesAfterUpdate)
-		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.responseData._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
+		def vpnConnectionStatusChangeMessages = bobMessagesAfterUpdate.json._embedded?."yona:messages".findAll { it."@type" == "BuddyVpnConnectionStatusChangeMessage" }
 
 		vpnConnectionStatusChangeMessages == initialVpnConnectionStatusChangeMessages
 

--- a/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/CommonAssertions.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Stichting Yona Foundation
+ * Copyright (c) 2017, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -52,50 +52,50 @@ class CommonAssertions
 	static void assertUserCreationResponseDetails(def response)
 	{
 		assertResponseStatusCreated(response)
-		assertUser(response.responseData, false)
+		assertUser(response.json, false)
 	}
 
 	static void assertUserUpdateResponseDetails(def response)
 	{
 		assertResponseStatusOk(response)
-		assertUser(response.responseData, false)
+		assertUser(response.json, false)
 	}
 
 	static void assertUserGetResponseDetailsIgnoreDefaultDevice(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertUser(response.responseData, false, false, false)
+		assertUser(response.json, false, false, false)
 	}
 
 	static void assertUserGetResponseDetails(def response, assertDefaultDevice = true)
 	{
 		assertResponseStatusSuccess(response)
-		assertUser(response.responseData, false, false, assertDefaultDevice)
+		assertUser(response.json, false, false, assertDefaultDevice)
 	}
 
 	static void assertUserGetResponseDetailsPinResetRequestedNotGenerated(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertUser(response.responseData, true)
-		assert response.responseData.keySet() == USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
-		assert response.responseData._links.keySet() == USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED
-		assert response.responseData._embedded.keySet() == USER_EMBEDDED
+		assertUser(response.json, true)
+		assert response.json.keySet() == USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
+		assert response.json._links.keySet() == USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_NOT_GENERATED
+		assert response.json._embedded.keySet() == USER_EMBEDDED
 	}
 
 	static void assertUserGetResponseDetailsPinResetRequestedAndGenerated(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertUser(response.responseData, true)
-		assert response.responseData.keySet() == USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
-		assert response.responseData._links.keySet() == USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED
-		assert response.responseData._embedded.keySet() == USER_EMBEDDED
+		assertUser(response.json, true)
+		assert response.json.keySet() == USER_PROPERTIES_NUM_CONFIRMED_BEFORE_ACTIVITY
+		assert response.json._links.keySet() == USER_LINKS_NUM_CONFIRMED_PIN_RESET_REQUESTED_AND_GENERATED
+		assert response.json._embedded.keySet() == USER_EMBEDDED
 	}
 
 	static void assertUserGetResponseDetailsCreatedOnBuddyRequest(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertUser(response.responseData, true, true)
-		assert response.responseData.keySet() == USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST
+		assertUser(response.json, true, true)
+		assert response.json.keySet() == USER_PROPERTIES_CREATED_ON_BUDDY_REQUEST
 	}
 
 	static void assertUser(user, boolean skipPropertySetAssertion = true, boolean userCreatedOnBuddyRequest = false, assertDefaultDevice = true)
@@ -161,13 +161,13 @@ class CommonAssertions
 	static void assertUserGetResponseDetailsWithBuddyDataEstablishedRelationship(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertBuddyUser(response.responseData, true)
+		assertBuddyUser(response.json, true)
 	}
 
 	static void assertUserGetResponseDetailsWithBuddyDataNotYetEstablishedRelationship(def response)
 	{
 		assertResponseStatusSuccess(response)
-		assertBuddyUser(response.responseData, false)
+		assertBuddyUser(response.json, false)
 	}
 
 	static void assertVpnProfile(def vpnProfile)
@@ -275,19 +275,19 @@ class CommonAssertions
 
 	static void assertResponseStatus(def response, int status)
 	{
-		assert response.status == status, "Invalid status: $response.status (expecting $status). Response: $response.data"
+		assert response.status == status, "Invalid status: $response.status (expecting $status). Response: $response.rawData"
 	}
 
 	static void assertResponseStatusSuccess(def response)
 	{
-		assert response.status >= 200 && response.status < 300, "Invalid status: $response.status (expecting 2xx). Response: $response.data"
+		assert response.status >= 200 && response.status < 300, "Invalid status: $response.status (expecting 2xx). Response: $response.rawData"
 	}
 
 	static assertBuddyUsers(response)
 	{
-		if (response.responseData._embedded?."yona:buddies"?._embedded?."yona:buddies")
+		if (response.json._embedded?."yona:buddies"?._embedded?."yona:buddies")
 		{
-			response.responseData._embedded."yona:buddies"._embedded."yona:buddies".each { assertBuddyUser(it._embedded."yona:user", it.sendingStatus == "ACCEPTED") }
+			response.json._embedded."yona:buddies"._embedded."yona:buddies".each { assertBuddyUser(it._embedded."yona:user", it.sendingStatus == "ACCEPTED") }
 		}
 	}
 

--- a/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
+++ b/core/src/testUtils/groovy/nu/yona/server/test/Service.groovy
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2021 Stichting Yona Foundation
+ * Copyright (c) 2015, 2022 Stichting Yona Foundation
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v.2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at https://mozilla.org/MPL/2.0/.
@@ -76,7 +76,7 @@ abstract class Service
 	{
 		def response = getResource("/hibernateStatistics/", ["reset": "false"])
 		assertResponseStatusOk(response)
-		response.responseData
+		response.json
 	}
 
 	def getLastEmail()


### PR DESCRIPTION
Now that we're not bound to the HTTPBuilder anymore, we can use more self-explaining property names.