### PR TITLE
YD-710 Fix NPE when sending system message

### DIFF
--- a/core/src/main/java/nu/yona/server/device/service/DeviceAnonymizedDto.java
+++ b/core/src/main/java/nu/yona/server/device/service/DeviceAnonymizedDto.java
@@ -17,6 +17,7 @@ import nu.yona.server.device.entities.VpnStatusChangeEvent;
 public class DeviceAnonymizedDto implements Serializable
 {
 	private static final long serialVersionUID = 5735844031070742651L;
+	private static final Locale DEFAULT_LOCALE = Locale.forLanguageTag("nl-NL");
 
 	private final UUID id;
 	private final int deviceIndex;
@@ -100,6 +101,7 @@ public class DeviceAnonymizedDto implements Serializable
 
 	public Locale getLocale()
 	{
-		return locale;
+		// Legacy devices don't have this property initialized. Fix it here, as the cache currently contains such legacy DTO instances
+		return (locale == null) ? DEFAULT_LOCALE : locale;
 	}
 }


### PR DESCRIPTION
The locale is not set on legacy devices, causing this NPE. The DTO now provides a default. This is fixed on DTO-level as the cache currently already contains legacy instances.