### PR TITLE
YD-702 Removed obsolete debug logging

### DIFF
--- a/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
+++ b/appservice/src/intTest/groovy/nu/yona/server/ActivityTest.groovy
@@ -27,7 +27,6 @@ import nu.yona.server.test.Device
 import nu.yona.server.test.Goal
 import nu.yona.server.test.TimeZoneGoal
 import nu.yona.server.test.User
-import spock.lang.IgnoreRest
 
 class ActivityTest extends AbstractAppServiceIntegrationTest
 {
@@ -159,7 +158,6 @@ class ActivityTest extends AbstractAppServiceIntegrationTest
 		appService.deleteUser(richard)
 	}
 
-	@IgnoreRest
 	def 'Retrieve activity report of previous week'()
 	{
 		given:

--- a/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
+++ b/appservice/src/main/java/nu/yona/server/admin/rest/AdminController.java
@@ -48,27 +48,19 @@ public class AdminController extends ControllerBase
 	{
 		try
 		{
-			logger.info("DEBUG: begin AdminController.requestOverwriteUserConfirmationCode for {}", mobileNumber);
-			try
-			{
-				// Use DOS protection to prevent spamming numbers with confirmation code text messages
-				// Do not include the mobile number in the URI. DOS protection should be number-independent
-				URI uri = getRequestOverwriteUserConfirmationCodeLinkBuilder("NotSpecified").toUri();
-				dosProtectionService.executeAttempt(uri, request,
-						yonaProperties.getSecurity().getMaxRequestOverwriteUserConfirmationCodeAttemptsPerTimeWindow(),
-						() -> userService.requestOverwriteUserConfirmationCode(mobileNumber));
-			}
-			catch (UserServiceException e)
-			{
-				// prevent detecting whether a mobile number exists
-				logger.error("Caught UserServiceException. Ignoring it", e);
-			}
-			return createNoContentResponse();
+			// Use DOS protection to prevent spamming numbers with confirmation code text messages
+			// Do not include the mobile number in the URI. DOS protection should be number-independent
+			URI uri = getRequestOverwriteUserConfirmationCodeLinkBuilder("NotSpecified").toUri();
+			dosProtectionService.executeAttempt(uri, request,
+					yonaProperties.getSecurity().getMaxRequestOverwriteUserConfirmationCodeAttemptsPerTimeWindow(),
+					() -> userService.requestOverwriteUserConfirmationCode(mobileNumber));
 		}
-		finally
+		catch (UserServiceException e)
 		{
-			logger.info("DEBUG: end  AdminController.requestOverwriteUserConfirmationCode for {}", mobileNumber);
+			// prevent detecting whether a mobile number exists
+			logger.error("Caught UserServiceException. Ignoring it", e);
 		}
+		return createNoContentResponse();
 	}
 
 	private static WebMvcLinkBuilder getRequestOverwriteUserConfirmationCodeLinkBuilder(String mobileNumber)

--- a/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/entities/User.java
@@ -11,9 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,7 +30,6 @@ import nu.yona.server.util.TimeUtil;
 @Table(name = "USERS")
 public class User extends EntityWithUuid
 {
-	private static final Logger logger = LoggerFactory.getLogger(User.class);
 	private int privateDataMigrationVersion;
 
 	private String firstName;
@@ -353,11 +349,6 @@ public class User extends EntityWithUuid
 	public void setOverwriteUserConfirmationCode(ConfirmationCode overwriteUserConfirmationCode)
 	{
 		Objects.requireNonNull(overwriteUserConfirmationCode);
-		if (this.overwriteUserConfirmationCode != null)
-		{
-			logger.info("DEBUG: mobile number {} replace overwrite confirmation code with ID {} with a new one with ID {}",
-					this.getMobileNumber(), this.overwriteUserConfirmationCode.getId(), overwriteUserConfirmationCode.getId());
-		}
 		this.overwriteUserConfirmationCode = overwriteUserConfirmationCode;
 	}
 

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAddService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAddService.java
@@ -242,11 +242,8 @@ public class UserAddService
 						userProvidedConfirmationCode, r),
 				() -> UserOverwriteConfirmationException.tooManyAttempts(existingUserEntity.getMobileNumber()));
 
-		// notice we can't delete the associated anonymized data
-		// because the anonymized data cannot be retrieved
+		// notice we can't delete the associated anonymized data because the anonymized data cannot be retrieved
 		// (the relation is encrypted, the password is not available)
-		logger.info("DEBUG: mobile number {} delete/overwrite user with confirmation code ID {}", mobileNumber,
-				confirmationCode.get().getId());
 		userRepository.delete(existingUserEntity);
 		userRepository.flush(); // So we can insert another one
 		logger.info("User with mobile number '{}' and ID '{}' removed, to overwrite the account",

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserUpdateService.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserUpdateService.java
@@ -112,27 +112,18 @@ public class UserUpdateService
 
 	private void setOverwriteUserConfirmationCodeIfNotDoneRecently(String mobileNumber, User user)
 	{
-		try
+		if (isOverwriteUserConfirmationCodeStillValid(user.getOverwriteUserConfirmationCode()))
 		{
-			logger.info("DEBUG: begin UserUpdateService.setOverwriteUserConfirmationCodeIfNotDoneRecently for {}", mobileNumber);
-			if (isOverwriteUserConfirmationCodeStillValid(user.getOverwriteUserConfirmationCode()))
-			{
-				logger.info(
-						"User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code, but the current one 'DEBUG {}' is still valid, so no new code is sent",
-						user.getMobileNumber(), user.getId(), user.getOverwriteUserConfirmationCode().get().getId());
-				return;
-			}
-			ConfirmationCode confirmationCode = createConfirmationCode();
-			user.setOverwriteUserConfirmationCode(confirmationCode);
-			sendConfirmationCodeTextMessage(mobileNumber, confirmationCode, SmsTemplate.OVERWRITE_USER_CONFIRMATION);
 			logger.info(
-					"User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code 'DEBUG created {}'",
-					user.getMobileNumber(), user.getId(), confirmationCode.getId());
+					"User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code, but the current one is still valid, so no new code is sent",
+					user.getMobileNumber(), user.getId());
+			return;
 		}
-		finally
-		{
-			logger.info("DEBUG: end UserUpdateService.setOverwriteUserConfirmationCodeIfNotDoneRecently for {}", mobileNumber);
-		}
+		ConfirmationCode confirmationCode = createConfirmationCode();
+		user.setOverwriteUserConfirmationCode(confirmationCode);
+		sendConfirmationCodeTextMessage(mobileNumber, confirmationCode, SmsTemplate.OVERWRITE_USER_CONFIRMATION);
+		logger.info("User with mobile number '{}' and ID '{}' requested an account overwrite confirmation code",
+				user.getMobileNumber(), user.getId());
 	}
 
 	private boolean isOverwriteUserConfirmationCodeStillValid(Optional<ConfirmationCode> overwriteUserConfirmationCode)


### PR DESCRIPTION
These log statements were introduced with e9c5df12a477d51cb2649d1da1068b3670843d7f to chase YD-695. That's resolved now, so the debug log statements were obsolete and are now removed.