### PR TITLE
Address compilation warnings in batch service

### DIFF
--- a/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
+++ b/batchservice/src/main/java/nu/yona/server/BatchServiceApplication.java
@@ -12,9 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
 
 import nu.yona.server.properties.PropertyInitializer;
 
@@ -29,12 +27,6 @@ public class BatchServiceApplication
 		PropertyInitializer.initializePropertiesFromEnvironment();
 		ConfigurableApplicationContext context = SpringApplication.run(BatchServiceApplication.class, args);
 		ApplicationStatusLogger.addLoggerForContextClosedEvent(context);
-	}
-
-	@Bean
-	public TaskScheduler taskScheduler()
-	{
-		return new ConcurrentTaskScheduler(); // single threaded by default
 	}
 
 	@Bean(name = "noopItemWriter")

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/ActivityAggregationBatchJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/ActivityAggregationBatchJob.java
@@ -91,14 +91,14 @@ public class ActivityAggregationBatchJob
 	private Step aggregateDayActivities()
 	{
 		return new StepBuilder("aggregateDayActivities", jobRepository).<Long, DayActivity>chunk(
-						DAY_ACTIVITY_CHUNK_SIZE, transactionManager).reader(dayActivityReader).processor(dayActivityProcessor())
-				.writer(dayActivityWriter()).build();
+						DAY_ACTIVITY_CHUNK_SIZE).transactionManager(transactionManager).reader(dayActivityReader)
+				.processor(dayActivityProcessor()).writer(dayActivityWriter()).build();
 	}
 
 	private Step aggregateWeekActivities()
 	{
 		return new StepBuilder("aggregateWeekActivities", jobRepository).<Long, WeekActivity>chunk(
-						WEEK_ACTIVITY_CHUNK_SIZE, transactionManager).reader(weekActivityReader)
+						WEEK_ACTIVITY_CHUNK_SIZE).transactionManager(transactionManager).reader(weekActivityReader)
 				.processor(weekActivityProcessor()).writer(weekActivityWriter()).build();
 	}
 

--- a/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/jobs/SendSystemMessageBatchJob.java
@@ -88,8 +88,8 @@ public class SendSystemMessageBatchJob
 
 	private Step sendSystemMessages()
 	{
-		return new StepBuilder("sendSystemMessages", jobRepository).<UUID, Void>chunk(USERS_CHUNK_SIZE,
-						transactionManager).reader(userAnonymizedReader).processor(userAnonymizedProcessor)
+		return new StepBuilder("sendSystemMessages", jobRepository).<UUID, Void>chunk(USERS_CHUNK_SIZE)
+				.transactionManager(transactionManager).reader(userAnonymizedReader).processor(userAnonymizedProcessor)
 				.writer(noopItemWriter).build();
 	}
 

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/CronTriggerDto.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/CronTriggerDto.java
@@ -38,8 +38,8 @@ public class CronTriggerDto
 		this(null, name, description, jobName, cronExpression, timeZone, null);
 	}
 
-	public CronTriggerDto(String group, String name, String description, String jobName, String cronExpression, String timeZone,
-			Date nextFireTime)
+	public CronTriggerDto(String group, String name, String description, String jobName, String cronExpression,
+			String timeZone, Date nextFireTime)
 	{
 		StringUtil.assertPlainTextCharacters(group, "group");
 		StringUtil.assertPlainTextCharacters(name, "name");
@@ -59,7 +59,7 @@ public class CronTriggerDto
 		return group;
 	}
 
-	public void setGroup(String group)
+	public final void setGroup(String group)
 	{
 		this.group = group;
 	}

--- a/batchservice/src/main/java/nu/yona/server/batch/quartz/JobDto.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/quartz/JobDto.java
@@ -50,7 +50,7 @@ public class JobDto
 		return group;
 	}
 
-	public void setGroup(String group)
+	public final void setGroup(String group)
 	{
 		this.group = group;
 	}

--- a/batchservice/src/main/java/nu/yona/server/batch/service/BatchTaskService.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/service/BatchTaskService.java
@@ -36,8 +36,8 @@ import nu.yona.server.util.TimeUtil;
 @Service
 public class BatchTaskService
 {
-	private static final String PIN_RESET_CONFIRMMATION_CODE_JOB_NAME = "PinResetConfirmationCode";
-	private static final String PIN_RESET_CONFIRMMATION_CODE_TRIGGER_NAME = PIN_RESET_CONFIRMMATION_CODE_JOB_NAME;
+	private static final String PIN_RESET_CONFIRMATION_CODE_JOB_NAME = "PinResetConfirmationCode";
+	private static final String PIN_RESET_CONFIRMATION_CODE_TRIGGER_NAME = PIN_RESET_CONFIRMATION_CODE_JOB_NAME;
 
 	private static final Logger logger = LoggerFactory.getLogger(BatchTaskService.class);
 
@@ -73,8 +73,8 @@ public class BatchTaskService
 	{
 		logger.info("Received request to generate PIN reset confirmation code for user with ID {} at {}",
 				request.getUserId(), request.getExecutionTime());
-		schedulingService.schedule(ScheduleGroup.OTHER, PIN_RESET_CONFIRMMATION_CODE_JOB_NAME,
-				PIN_RESET_CONFIRMMATION_CODE_TRIGGER_NAME + " " + request.getUserId(),
+		schedulingService.schedule(ScheduleGroup.OTHER, PIN_RESET_CONFIRMATION_CODE_JOB_NAME,
+				PIN_RESET_CONFIRMATION_CODE_TRIGGER_NAME + " " + request.getUserId(),
 				PinResetConfirmationCodeSenderQuartzJob.buildParameterMap(request.getUserId(),
 						request.getLocaleString()), TimeUtil.toDate(request.getExecutionTime()));
 	}
@@ -109,7 +109,7 @@ public class BatchTaskService
 			return launcher.run(job, jobParameters);
 		}
 		catch (JobExecutionAlreadyRunningException | JobRestartException | JobInstanceAlreadyCompleteException |
-			   InvalidJobParametersException e)
+		       InvalidJobParametersException e)
 		{
 			logger.error("Unexpected exception", e);
 			throw YonaException.unexpected(e);

--- a/batchservice/src/main/java/nu/yona/server/batch/service/BatchTaskService.java
+++ b/batchservice/src/main/java/nu/yona/server/batch/service/BatchTaskService.java
@@ -15,8 +15,8 @@ import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.launch.JobRestartException;
-import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -46,6 +46,9 @@ public class BatchTaskService
 
 	@Autowired
 	private JobRepository jobRepository;
+
+	@Autowired
+	private JobOperator jobOperator;
 
 	@Autowired
 	@Qualifier("activityAggregationJob")
@@ -103,10 +106,7 @@ public class BatchTaskService
 	{
 		try
 		{
-			TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
-			launcher.setJobRepository(jobRepository);
-			launcher.setTaskExecutor(taskExecutor);
-			return launcher.run(job, jobParameters);
+			return jobOperator.run(job, jobParameters);
 		}
 		catch (JobExecutionAlreadyRunningException | JobRestartException | JobInstanceAlreadyCompleteException |
 		       InvalidJobParametersException e)


### PR DESCRIPTION
* Deprecation of stepBuilder.chunk(size, transaction manager)
* Make methods called from DTO constructors final
* Remove unnecessary taskScheduler bean
* Replace deprecated TaskExecutorJobLauncher with standard JobOperator bean

Along with this corrected spelling errors on BatchTaskService constants