### PR TITLE
Address compiler warnings on core

### DIFF
--- a/core/src/main/java/nu/yona/server/exceptions/UpstreamException.java
+++ b/core/src/main/java/nu/yona/server/exceptions/UpstreamException.java
@@ -5,7 +5,6 @@
 package nu.yona.server.exceptions;
 
 import java.io.Serializable;
-import java.util.Optional;
 
 import org.springframework.http.HttpStatusCode;
 
@@ -15,24 +14,24 @@ import org.springframework.http.HttpStatusCode;
 public class UpstreamException extends YonaException
 {
 	private static final long serialVersionUID = 3472480838017894334L;
-	private final Optional<String> message;
+	private final String message;
 
 	private UpstreamException(HttpStatusCode statusCode, String messageId, String message)
 	{
 		super(statusCode, messageId);
-		this.message = Optional.of(message);
+		this.message = message;
 	}
 
 	private UpstreamException(HttpStatusCode statusCode, String messageId, Serializable... parameters)
 	{
 		super(statusCode, messageId, parameters);
-		message = Optional.empty();
+		this.message = null;
 	}
 
 	@Override
 	public String getLocalizedMessage()
 	{
-		return message.orElse(super.getLocalizedMessage());
+		return message == null ? super.getLocalizedMessage() : message;
 	}
 
 	public static UpstreamException yonaException(HttpStatusCode statusCode, String messageId, String message)

--- a/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/ActivityCategory.java
@@ -45,8 +45,8 @@ public class ActivityCategory extends EntityWithUuid
 		super(null);
 	}
 
-	public ActivityCategory(UUID id, Map<Locale, String> localizableName, boolean mandatoryNoGo, Set<String> smoothwallCategories,
-			Set<String> applications, Map<Locale, String> localizableDescription)
+	public ActivityCategory(UUID id, Map<Locale, String> localizableName, boolean mandatoryNoGo,
+			Set<String> smoothwallCategories, Set<String> applications, Map<Locale, String> localizableDescription)
 	{
 		super(id);
 		setLocalizableName(localizableName);
@@ -73,7 +73,7 @@ public class ActivityCategory extends EntityWithUuid
 		return new HashMap<>(localizableName);
 	}
 
-	public void setLocalizableName(Map<Locale, String> name)
+	public final void setLocalizableName(Map<Locale, String> name)
 	{
 		this.localizableName = new HashMap<>(name);
 	}
@@ -93,7 +93,7 @@ public class ActivityCategory extends EntityWithUuid
 		return Collections.unmodifiableSet(smoothwallCategories);
 	}
 
-	public void setSmoothwallCategories(Set<String> smoothwallCategories)
+	public final void setSmoothwallCategories(Set<String> smoothwallCategories)
 	{
 		this.smoothwallCategories = new HashSet<>(smoothwallCategories);
 	}
@@ -103,7 +103,7 @@ public class ActivityCategory extends EntityWithUuid
 		return Collections.unmodifiableSet(applications);
 	}
 
-	public void setApplications(Set<String> applications)
+	public final void setApplications(Set<String> applications)
 	{
 		this.applications = new HashSet<>(applications);
 	}
@@ -113,7 +113,7 @@ public class ActivityCategory extends EntityWithUuid
 		return new HashMap<>(localizableDescription);
 	}
 
-	public void setLocalizableDescription(Map<Locale, String> localizableDescription)
+	public final void setLocalizableDescription(Map<Locale, String> localizableDescription)
 	{
 		this.localizableDescription = new HashMap<>(localizableDescription);
 	}

--- a/core/src/main/java/nu/yona/server/goals/entities/Goal.java
+++ b/core/src/main/java/nu/yona/server/goals/entities/Goal.java
@@ -108,7 +108,7 @@ public abstract class Goal extends EntityWithUuid implements IGoal
 		this.userAnonymized = userAnonymized;
 	}
 
-	public ActivityCategory getActivityCategory()
+	public final ActivityCategory getActivityCategory()
 	{
 		return activityCategory;
 	}
@@ -201,7 +201,7 @@ public abstract class Goal extends EntityWithUuid implements IGoal
 
 	public abstract Goal cloneAsHistoryItem(LocalDateTime endTime);
 
-	public boolean isMandatory()
+	public final boolean isMandatory()
 	{
 		return getActivityCategory().isMandatoryNoGo();
 	}

--- a/core/src/main/java/nu/yona/server/goals/service/ActivityCategoryDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/ActivityCategoryDto.java
@@ -43,10 +43,14 @@ public class ActivityCategoryDto implements Serializable
 	private static final long serialVersionUID = 2498926948887006481L;
 
 	private UUID id;
+	@SuppressWarnings("serial")
 	private final Map<Locale, String> localizableName;
 	private final boolean mandatoryNoGo;
+	@SuppressWarnings("serial")
 	private final Set<String> smoothwallCategories;
+	@SuppressWarnings("serial")
 	private final Set<String> applications;
+	@SuppressWarnings("serial")
 	private final Map<Locale, String> localizableDescription;
 
 	@JsonCreator

--- a/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/GoalDto.java
@@ -48,8 +48,8 @@ public abstract class GoalDto extends PolymorphicDto implements IGoal, Serializa
 	private final boolean mandatory;
 	private final LocalDateTime endTime;
 
-	protected GoalDto(UUID id, Optional<LocalDateTime> creationTime, Optional<LocalDateTime> endTime, UUID activityCategoryId,
-			boolean mandatory)
+	protected GoalDto(UUID id, Optional<LocalDateTime> creationTime, Optional<LocalDateTime> endTime,
+			UUID activityCategoryId, boolean mandatory)
 	{
 		this.id = (id == null) ? new UUID(0, 0) : id;
 		this.setActivityCategoryId(activityCategoryId);
@@ -151,7 +151,7 @@ public abstract class GoalDto extends PolymorphicDto implements IGoal, Serializa
 	}
 
 	@JsonIgnore
-	public void setActivityCategoryId(UUID activityCategoryId)
+	public final void setActivityCategoryId(UUID activityCategoryId)
 	{
 		this.activityCategoryId = activityCategoryId;
 	}

--- a/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDto.java
+++ b/core/src/main/java/nu/yona/server/goals/service/TimeZoneGoalDto.java
@@ -32,7 +32,9 @@ public class TimeZoneGoalDto extends GoalDto implements ITimezoneGoal
 	private static final long serialVersionUID = 7479427103494945857L;
 
 	private static final Pattern zonePattern = Pattern.compile("[0-2][0-9]:[0-5][0-9]-[0-2][0-9]:[0-5][0-9]");
+	@SuppressWarnings("serial")
 	private final List<String> zones;
+	@SuppressWarnings("serial")
 	private final List<Integer> spreadCells;
 	private transient byte[] spreadCellBytes;
 

--- a/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
+++ b/core/src/main/java/nu/yona/server/rest/GlobalExceptionMapping.java
@@ -66,7 +66,8 @@ public class GlobalExceptionMapping
 	{
 		logUnhandledException("completed with Yona exception", buildRequestInfo(request), exception);
 
-		ErrorResponseDto responseMessage = ErrorResponseDto.createInstance(exception.getMessageId(), exception.getMessage());
+		ErrorResponseDto responseMessage = ErrorResponseDto.createInstance(exception.getMessageId(),
+				exception.getMessage());
 
 		return new ResponseEntity<>(responseMessage, exception.getStatusCode());
 	}
@@ -112,8 +113,8 @@ public class GlobalExceptionMapping
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
 	@ResponseBody
-	public ErrorResponseDto handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException exception,
-			HttpServletRequest request)
+	public ErrorResponseDto handleHttpRequestMethodNotSupportedException(
+			HttpRequestMethodNotSupportedException exception, HttpServletRequest request)
 	{
 		return logUnhandledExceptionAndCreateErrorDto("attempts an unsupported method", exception, request);
 	}
@@ -140,7 +141,7 @@ public class GlobalExceptionMapping
 	 * @return The response object to return.
 	 */
 	@ExceptionHandler(MaxUploadSizeExceededException.class)
-	@ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+	@ResponseStatus(HttpStatus.CONTENT_TOO_LARGE)
 	@ResponseBody
 	public ErrorResponseDto handleMaxUploadSizeExceededException(MaxUploadSizeExceededException exception,
 			HttpServletRequest request)
@@ -173,7 +174,9 @@ public class GlobalExceptionMapping
 	public static String buildRequestInfo(HttpServletRequest request)
 	{
 		String queryString = request.getQueryString();
-		String url = StringUtils.isBlank(queryString) ? request.getRequestURI() : request.getRequestURI() + "?" + queryString;
+		String url = StringUtils.isBlank(queryString) ?
+				request.getRequestURI() :
+				request.getRequestURI() + "?" + queryString;
 		return MessageFormat.format("{0} on URL {1}", request.getMethod(), url);
 	}
 }

--- a/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
+++ b/core/src/main/java/nu/yona/server/rest/HeadersServerInterceptor.java
@@ -4,8 +4,8 @@
  *******************************************************************************/
 package nu.yona.server.rest;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.http.server.ServletServerHttpRequest;
-import org.springframework.lang.Nullable;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -33,7 +33,8 @@ public class HeadersServerInterceptor implements HandlerInterceptor
 	}
 
 	@Override
-	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable Exception ex)
+	public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+			@Nullable Exception ex)
 	{
 		headersHolder.clear();
 	}

--- a/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDto.java
+++ b/core/src/main/java/nu/yona/server/subscriptions/service/UserAnonymizedDto.java
@@ -33,9 +33,12 @@ public class UserAnonymizedDto implements Serializable
 
 	private final LocalDate lastMonitoredActivityDate;
 	private final ZoneId timeZone;
+	@SuppressWarnings("serial")
 	private final Set<GoalDto> goalsIncludingHistoryItems;
 	private final MessageDestinationDto anonymousMessageDestination;
+	@SuppressWarnings("serial")
 	private final Set<BuddyAnonymizedDto> buddiesAnonymized;
+	@SuppressWarnings("serial")
 	private final Set<DeviceAnonymizedDto> devicesAnonymized;
 
 	public UserAnonymizedDto(UUID id, Optional<LocalDate> lastMonitoredActivityDate, ZoneId timeZone,
@@ -57,8 +60,10 @@ public class UserAnonymizedDto implements Serializable
 				getGoalsIncludingHistoryItems(entity), (entity.getAnonymousDestination() == null) ?
 				null :
 				MessageDestinationDto.createInstance(entity.getAnonymousDestination()),
-				entity.getBuddiesAnonymized().stream().map(BuddyAnonymizedDto::createInstance).collect(Collectors.toSet()),
-				entity.getDevicesAnonymized().stream().map(DeviceAnonymizedDto::createInstance).collect(Collectors.toSet()));
+				entity.getBuddiesAnonymized().stream().map(BuddyAnonymizedDto::createInstance)
+						.collect(Collectors.toSet()),
+				entity.getDevicesAnonymized().stream().map(DeviceAnonymizedDto::createInstance)
+						.collect(Collectors.toSet()));
 	}
 
 	public UUID getId()
@@ -78,8 +83,8 @@ public class UserAnonymizedDto implements Serializable
 
 	public Set<GoalDto> getGoalsForActivityCategory(ActivityCategory activityCategory)
 	{
-		return getGoalsIncludingHistoryItems().stream().filter(g -> g.getActivityCategoryId().equals(activityCategory.getId()))
-				.collect(Collectors.toSet());
+		return getGoalsIncludingHistoryItems().stream()
+				.filter(g -> g.getActivityCategoryId().equals(activityCategory.getId())).collect(Collectors.toSet());
 	}
 
 	public ZoneId getTimeZone()
@@ -99,8 +104,8 @@ public class UserAnonymizedDto implements Serializable
 
 	public Optional<BuddyAnonymizedDto> getBuddyAnonymizedByUserAnonymizedIdIfExisting(UUID fromUserAnonymizedId)
 	{
-		return buddiesAnonymized.stream().filter(ba -> ba.getUserAnonymizedId().equals(Optional.of(fromUserAnonymizedId)))
-				.findFirst();
+		return buddiesAnonymized.stream()
+				.filter(ba -> ba.getUserAnonymizedId().equals(Optional.of(fromUserAnonymizedId))).findFirst();
 	}
 
 	public BuddyAnonymizedDto getBuddyAnonymized(UUID buddyAnonymizedId)

--- a/core/src/main/java/nu/yona/server/util/HibernateHelperService.java
+++ b/core/src/main/java/nu/yona/server/util/HibernateHelperService.java
@@ -30,7 +30,7 @@ public class HibernateHelperService
 	public void clearSessionIfNotLockedYet(Class<?> clazz, Serializable id)
 	{
 		Session session = getSession();
-		Object entity = session.get(clazz, id);
+		Object entity = session.find(clazz, id);
 		if (entity != null && isLockedForUpdate(session, entity))
 		{
 			// Already acquired an update lock


### PR DESCRIPTION
* No Optional as attribute type for serializable classes
* Suppress serialization warnings on attributes of collection types
* Only call final methods from constructors
* Use HttpStatus.CONTENT_TOO_LARGE instead of HttpStatus.PAYLOAD_TOO_LARGE
* Use org.jspecify.annotations.Nullable instead of org.springframework.lang.Nullable
* Use Session.find instead of session.get